### PR TITLE
chore: bump version

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,4 +11,4 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.9"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.12"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the proxy container image to ghcr.io/tinfoilsh/confidential-model-router:0.0.12. This keeps us on the latest router release.

<!-- End of auto-generated description by cubic. -->

