### PR TITLE
feat: add long context nomic

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -19,6 +19,11 @@ models:
     enclaves:
       - nomic-embed-text.model.tinfoil.sh
 
+  nomic-embed-text-long:
+    repo: tinfoilsh/confidential-nomic-embed-text-long
+    enclaves:
+      - nomic-embed-text-long.model.tinfoil.sh
+
   qwen2-5-72b:
     repo: tinfoilsh/confidential-qwen2-5-72b
     enclaves:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add nomic-embed-text-long to the model registry to support long-context text embeddings. Includes repo mapping and enclave endpoint for deployment.

<sup>Written for commit 9152f3bbf541f88f939b843e43189a30f774a2d5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

