### PR TITLE
chore: bump tag

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,4 +11,4 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.12"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.13"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump the proxy container image to ghcr.io/tinfoilsh/confidential-model-router:0.0.13 to pull in the latest patch and keep configs up to date.

<sup>Written for commit eb03103e672fe4e48fc5b50d1494cdcb63931366. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

