### PR TITLE
dev

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,7 @@
 routers:
   inference.tinfoil.sh:
   router.inf6.tinfoil.sh:
-  router.inf7.tinfoil.sh:
+  # router.inf7.tinfoil.sh:
 
 models:
   llama-free:


### PR DESCRIPTION
from dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled router.inf7.tinfoil.sh in config by commenting it out, so traffic no longer routes to inf7 and avoids errors from that node.

<sup>Written for commit 59d445363d715f10a8ed3ad339adbbec00f96d28. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

