### PR TITLE
dev

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 routers:
   inference.tinfoil.sh:
-  router.inf6.tinfoil.sh:
+  # router.inf6.tinfoil.sh:
   # router.inf7.tinfoil.sh:
 
 models:


### PR DESCRIPTION
from dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the inf6 router in config.yml to remove the deprecated route and prevent traffic from hitting it.

<sup>Written for commit b0ba696160bdef354eb224b584276456041e6473. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

