### PR TITLE
fix: nomic-embed long name

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -19,7 +19,7 @@ models:
     enclaves:
       - nomic-embed-text.model.tinfoil.sh
 
-  nomic-embed-text-long:
+  nomic-embed-text-v1.5:
     repo: tinfoilsh/confidential-nomic-embed-text-long
     enclaves:
       - nomic-embed-text-long.model.tinfoil.sh


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the Nomic embed model key in config.yml from nomic-embed-text-long to nomic-embed-text-v1.5 to match the published version. This avoids misconfigured references while keeping repo and enclave URLs unchanged.

<sup>Written for commit ff102841d89f4d654b7add685903ec3b911f35d0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

