### PR TITLE
dev

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
 routers:
-  inference.tinfoil.sh:
+  # inference.tinfoil.sh:
   # router.inf6.tinfoil.sh:
   router.inf7.tinfoil.sh:
 


### PR DESCRIPTION
from dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commented out inference.tinfoil.sh in config.yml to disable the inference router. This stops traffic to that host until it’s re-enabled.

<sup>Written for commit fa886a9720cc84ce2572a8040043040ee52f54e8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

