### PR TITLE
chore: remove temp model nomic-long

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -19,11 +19,6 @@ models:
     enclaves:
       - nomic-embed-text.model.tinfoil.sh
 
-  nomic-embed-text-v1.5:
-    repo: tinfoilsh/confidential-nomic-embed-text-long
-    enclaves:
-      - nomic-embed-text-long.model.tinfoil.sh
-
   qwen2-5-72b:
     repo: tinfoilsh/confidential-qwen2-5-72b
     enclaves:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the temporary nomic-embed-text-v1.5 (nomic-long) model from config.yml. This cleans up unused configuration and prevents accidental routing to the long enclave.

<sup>Written for commit a0ddc6ca07282e00bdac6d77224e96ad4725e0e1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

