### PR TITLE
chore: remove mistral and qwen2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -9,20 +9,10 @@ models:
     enclaves:
       - llama3-3-70b.model.tinfoil.sh
 
-  mistral-small-3-1-24b:
-    repo: tinfoilsh/confidential-mistral-small-3-1
-    enclaves:
-      - mistral.model.tinfoil.sh
-
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:
       - nomic-embed-text.model.tinfoil.sh
-
-  qwen2-5-72b:
-    repo: tinfoilsh/confidential-qwen2-5-72b
-    enclaves:
-      - qwen2-5-72b-2.model.tinfoil.sh
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed Mistral (mistral-small-3-1-24b) and Qwen2-5-72b from config.yml to drop unsupported models and prevent accidental usage. No other changes.

- **Migration**
  - Remove or replace any references to these model IDs in code or config.

<sup>Written for commit 030e9ae4b7481f9c135ba3b016edba251b2c59b0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

