### PR TITLE
chore: change domains for nomic and docling

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -12,12 +12,12 @@ models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:
-      - nomic-embed-text.model.tinfoil.sh
+      - nomic-embed-text.inf5.tinfoil.sh
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - doc-upload.model.tinfoil.sh
+      - doc-upload.inf5.tinfoil.sh
 
   audio-processing:
     repo: tinfoilsh/confidential-audio-processing


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the nomic-embed-text and doc-upload enclave domains from *.model.tinfoil.sh to *.inf5.tinfoil.sh to point configs at the new inf5 environment.

<sup>Written for commit 99e780115e057eba062b7f1615c9fb62d5516ff3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

