### PR TITLE
chore: switch nomic domain

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -12,7 +12,7 @@ models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:
-      - nomic-embed-text.inf5.tinfoil.sh
+      - nomic-embed-text.inf6.tinfoil.sh
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the nomic-embed-text enclave from inf5 to inf6 to point to the new domain. Ensures requests route to the current deployment and avoids issues on the deprecated host.

<sup>Written for commit 00ddd9b011f7eff591c0c55c433ec437ab76010c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

