### PR TITLE
feat: add gpt-oss-120b free

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -44,6 +44,11 @@ models:
     enclaves:
       - gpt-oss-120b.model.tinfoil.sh
 
+  gpt-oss-120b-free:
+    repo: tinfoilsh/confidential-gpt-oss-120b-free
+    enclaves:
+      - gpt-oss-120b-free.inf6.tinfoil.sh
+
   deepseek-v31-terminus:
     repo: tinfoilsh/confidential-deepseek-v31-terminus
     enclaves:


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds gpt-oss-120b-free to the models registry to expose a free-tier variant. Config maps to tinfoilsh/confidential-gpt-oss-120b-free and routes requests to gpt-oss-120b-free.inf6.tinfoil.sh.

<sup>Written for commit cb03169be1d332f8e5ea7d9e235d13fe42489de1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



