### PR TITLE
chore: switch domain for doc-upload

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -17,7 +17,7 @@ models:
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - doc-upload.inf5.tinfoil.sh
+      - doc-upload.inf6.tinfoil.sh
 
   audio-processing:
     repo: tinfoilsh/confidential-audio-processing


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch doc-upload enclave from doc-upload.inf5.tinfoil.sh to doc-upload.inf6.tinfoil.sh to point at the new deployment. Routes traffic to the updated enclave with no code changes.

<sup>Written for commit 560992e5df68ffb100bfaabe19d35c1c99597f33. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

