### PR TITLE
chore: gpt-oss-free domain config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -47,7 +47,7 @@ models:
   gpt-oss-120b-free:
     repo: tinfoilsh/confidential-gpt-oss-120b-free
     enclaves:
-      - gpt-oss-120b-free.inf6.tinfoil.sh
+      - gpt-oss-120b-free.inf5.tinfoil.sh
 
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the gpt-oss-120b-free enclave domain in config.yml from inf6 to inf5 to route requests to the correct host. This ensures the free model points to the active enclave.

<sup>Written for commit 347bc6a5ee9481a7da922f39e07f63d6ca0a657c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

