### PR TITLE
chore: change gpt-oss domain

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,7 +42,7 @@ models:
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
-      - gpt-oss-120b.model.tinfoil.sh
+      - gpt-oss-120b.inf5.tinfoil.sh
 
   gpt-oss-120b-free:
     repo: tinfoilsh/confidential-gpt-oss-120b-free


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the gpt-oss-120b enclave domain in config.yml from gpt-oss-120b.model.tinfoil.sh to gpt-oss-120b.inf5.tinfoil.sh to point to the new endpoint. This ensures traffic routes to the correct enclave.

<sup>Written for commit 5e9094f437805fde9f0ee7c8bc4dd08ebc634885. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

