### PR TITLE
chore: update whisper config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -19,10 +19,10 @@ models:
     enclaves:
       - doc-upload.inf6.tinfoil.sh
 
-  audio-processing:
-    repo: tinfoilsh/confidential-audio-processing
+  whisper-large-v3-turbo:
+    repo: tinfoilsh/confidential-whisper-large-v3
     enclaves:
-      - audio-processing.model.tinfoil.sh
+      - whisper.inf6.tinfoil.sh
 
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama-qwen


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the audio model to Whisper Large v3 Turbo. Replaces the old audio-processing entry with a new model name, repo, and enclave.

- **Migration**
  - Update references from "audio-processing" to "whisper-large-v3-turbo".
  - Allowlist whisper.inf6.tinfoil.sh if you use network ACLs.

<sup>Written for commit 83e5d40c19213a37cf9133e82f48ce084dbc8748. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

