### PR TITLE
chore: update qwen3 vl config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -49,7 +49,7 @@ models:
     enclaves:
       - gpt-oss-120b-free.inf5.tinfoil.sh
 
-  qwen3-vl-30b:
+  qwen3-vl-30b-instruct:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
       - qwen3-vl-30b.inf6.tinfoil.sh


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the Qwen3 VL model key to qwen3-vl-30b-instruct to target the instruct variant and align with deployment naming. Repo and enclave entries remain unchanged.

<sup>Written for commit 72d2aaaff5f13d090b301617777c8258b4d770c2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

