### PR TITLE
fix: remove instruct in qwen3 vl model name

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -49,7 +49,7 @@ models:
     enclaves:
       - gpt-oss-120b-free.inf5.tinfoil.sh
 
-  qwen3-vl-30b-instruct:
+  qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
       - qwen3-vl-30b.inf6.tinfoil.sh


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the Qwen3 VL model in config from qwen3-vl-30b-instruct to qwen3-vl-30b to align with the repo/enclave and prevent model resolution errors.

<sup>Written for commit a5f1d061caff7219901336942c24594ba1d20b55. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

