### PR TITLE
feat: remove llama-free config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,11 +4,6 @@ routers:
   router.inf7.tinfoil.sh:
 
 models:
-  llama-free:
-    repo: tinfoilsh/confidential-llama3-3-70b
-    enclaves:
-      - llama3-3-70b.model.tinfoil.sh
-
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the llama-free model entry from config.yml to retire the deprecated model. This cleans up the models list and prevents misconfiguration or deployments referencing llama-free.

<sup>Written for commit d18550e932e11ab014a8c000e6fec9c1eb313bc0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

