### PR TITLE
fix: audio path goes to whisper

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 			http.Redirect(w, r, "https://docs.tinfoil.sh", http.StatusTemporaryRedirect)
 			return
 		} else if r.URL.Path == "/v1/audio/transcriptions" || strings.HasPrefix(r.URL.Path, "/v1/audio/") {
-			modelName = "audio-processing"
+			modelName = "whisper-large-v3-turbo"
 		} else if r.URL.Path == "/v1/convert/file" {
 			modelName = "doc-upload"
 		} else {

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,4 +11,4 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.13"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.14"


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed audio API routing so /v1/audio/transcriptions and /v1/audio/* requests use the whisper-large-v3-turbo model. This ensures transcriptions go through Whisper instead of the generic audio-processing model.

- **Dependencies**
  - Bumped confidential-model-router image to 0.0.14.

<sup>Written for commit 74ac48311ad9f796de6d926df044e41a7df7d870. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



