### PR TITLE
feat: add second qwen3 vl domain

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -48,6 +48,7 @@ models:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
       - qwen3-vl-30b.inf6.tinfoil.sh
+      - qwen3-vl-30b.inf5.tinfoil.sh
 
   deepseek-v31-terminus:
     repo: tinfoilsh/confidential-deepseek-v31-terminus


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a second Qwen3-VL-30B enclave domain to enable load balancing and improve reliability. The config now includes qwen3-vl-30b.inf5.tinfoil.sh alongside inf6.

<sup>Written for commit fceb9fdccf010d4d913b7283c22d9ca62041ef63. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

