### PR TITLE
feat: remove second qwen3 vl model

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -48,7 +48,6 @@ models:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
       - qwen3-vl-30b.inf6.tinfoil.sh
-      - qwen3-vl-30b.inf5.tinfoil.sh
 
   deepseek-v31-terminus:
     repo: tinfoilsh/confidential-deepseek-v31-terminus


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the second enclave for Qwen3-VL-30B in config.yml, leaving only qwen3-vl-30b.inf6.tinfoil.sh. This prevents split routing and keeps model registration consistent.

<sup>Written for commit 8020be6ff8dde61d653e006db7ad82d857812120. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

