### PR TITLE
chore: move qwen3 vl to inf5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -47,7 +47,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.inf6.tinfoil.sh
+      - qwen3-vl-30b.inf5.tinfoil.sh
 
   deepseek-v31-terminus:
     repo: tinfoilsh/confidential-deepseek-v31-terminus


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point qwen3-vl-30b to the inf5 enclave in config.yml to match the current deployment. Ensures requests route to the correct host and avoids failures on inf6.

<sup>Written for commit 1ba76e42328af66225ef6305c19ef21a972b011e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

