### PR TITLE
Update config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -12,7 +12,7 @@ models:
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - doc-upload.inf6.tinfoil.sh
+      - doc-upload.inf5.tinfoil.sh
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-whisper-large-v3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the doc-upload model to use the inf5 enclave, aligning config with the current deployment. Changed enclave host from doc-upload.inf6.tinfoil.sh to doc-upload.inf5.tinfoil.sh.

<sup>Written for commit e612594623bcf35ef870a3877089e464afcba942. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

