### PR TITLE
Jules/pin repos

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -12,7 +12,7 @@ models:
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - doc-upload.inf6.tinfoil.sh
+      - doc-upload.inf5.tinfoil.sh
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-whisper-large-v3

--- a/config/config.go
+++ b/config/config.go
@@ -12,9 +12,9 @@ import (
 
 // Model represents the configuration for a single model
 type Model struct {
-	Repo     string          `yaml:"repo"`
-	Enclaves []string        `yaml:"enclaves"`
-	Overload *OverloadConfig `yaml:"overload,omitempty"`
+	Repo      string          `yaml:"repo"`
+	Hostnames []string        `yaml:"enclaves"`
+	Overload  *OverloadConfig `yaml:"overload,omitempty"`
 }
 
 // OverloadConfig describes optional overload thresholds for a model.

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ var (
 	port            = flag.String("l", "8089", "port to listen on")
 	controlPlaneURL = flag.String("C", "https://api.tinfoil.sh", "control plane URL")
 	verbose         = flag.Bool("v", false, "enable verbose logging")
-	configURL       = flag.String("c", "https://raw.githubusercontent.com/tinfoilsh/confidential-model-router/main/config.yml", "Path to config.yml, only used for enclaves and not measurements")
+	configURL       = flag.String("c", "https://raw.githubusercontent.com/tinfoilsh/confidential-model-router/main/config.yml", "Path to config.yml, only used to update enclave hostnames and not measurements")
 )
 
 func jsonError(w http.ResponseWriter, message string, code int) {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -353,7 +353,6 @@ func (em *EnclaveManager) sync() error {
 					enclave.shutdown()
 				}
 				model.mu.Unlock()
-				em.models.Delete(modelName)
 				return
 			}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin model repos and only update enclave hostnames from the remote config. This stabilizes deployments and simplifies enclave sync.

- **Refactors**
  - Load repos from the local config and ignore remote repo changes (logs a warning).
  - Simplified sync: remove hostnames not in config, add new ones, and update overload settings.
  - Renamed Model.Enclaves to Model.Hostnames (YAML key remains "enclaves").
  - Clarified config flag description; updated doc-upload hostname to inf5.

- **Bug Fixes**
  - Do not delete models when removed from remote config; shut down their enclaves but keep the model in memory.

<sup>Written for commit 53e8c37ec6a6a951eac78d72523bd161d50b9510. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

