### PR TITLE
chore: bump version

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,4 +11,4 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.14"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.15"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump proxy container image to ghcr.io/tinfoilsh/confidential-model-router:0.0.15 in tinfoil-config.yml to use the latest release.

<sup>Written for commit 6956e0755568bd1c96d0c3c751c4bf23fe6f210b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

