### PR TITLE
fix: fix potential concurency bug with mutex

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -377,7 +377,6 @@ func (em *EnclaveManager) sync() error {
 			// Updating enclaves for each model
 			log.Tracef("updating enclaves for model %s", modelName)
 			hostnames := configModel.Hostnames
-			model.mu.Unlock()
 
 			// Remove enclaves that are no longer in the config
 			for existingHost := range model.Enclaves {
@@ -387,6 +386,7 @@ func (em *EnclaveManager) sync() error {
 					delete(model.Enclaves, existingHost)
 				}
 			}
+			model.mu.Unlock()
 
 			// Add new enclave from the config and update attestation if needed
 			for _, host := range hostnames {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix a concurrency bug in EnclaveManager.sync by keeping model.mu locked while removing outdated enclaves. Unlock now happens after the removal loop, preventing concurrent map writes and inconsistent state.

<sup>Written for commit c049f7695386e4edf4364d42df3cc154004a2f01. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

