### PR TITLE
Jules/titan qwen

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -48,6 +48,13 @@ models:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
       - qwen3-vl-30b.inf5.tinfoil.sh
+  
+  titan-qwen2-5-05b:
+    repo: tinfoilsh/confidential-titan-qwen2-5-05b
+    enclaves:
+      - titan-qwen2-5-05b.inf5.tinfoil.sh
+
+  
 
   deepseek-v31-terminus:
     repo: tinfoilsh/confidential-deepseek-v31-terminus

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,4 +11,4 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.15"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.16"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the titan-qwen2-5-05b model and updates the router to support it. Enables deployment and routing to the new enclave.

- **New Features**
  - Added titan-qwen2-5-05b with repo tinfoilsh/confidential-titan-qwen2-5-05b and enclave titan-qwen2-5-05b.inf5.tinfoil.sh.

- **Dependencies**
  - Bumped confidential-model-router image from 0.0.15 to 0.0.16.

<sup>Written for commit 79d08560efb24cb81333b4dc3ee3716c1a1a2091. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

