### PR TITLE
Jules/param router

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
@@ -43,6 +44,7 @@ func FromBytes(data []byte) (*Config, error) {
 // Loads configuration from a URL or file
 func Load(url string, sha256_required bool) (*Config, error) {
 	cleanURL, expectedSHA := parseURLWithSHA(url)
+	log.Debugf("loading config from %s (sha256_required=%v)", cleanURL, sha256_required)
 	if sha256_required {
 		if expectedSHA == "" {
 			return nil, fmt.Errorf("sha256 required for %s", url)
@@ -82,6 +84,7 @@ func Load(url string, sha256_required bool) (*Config, error) {
 		if !strings.EqualFold(actual, expectedSHA) {
 			return nil, fmt.Errorf("runtime config sha256 mismatch: expected %s, got %s", expectedSHA, actual)
 		}
+		log.Debug("config sha256 verification passed")
 	}
 
 	return FromBytes(data)

--- a/main.go
+++ b/main.go
@@ -32,7 +32,8 @@ var (
 	port            = flag.String("l", "8089", "port to listen on")
 	controlPlaneURL = flag.String("C", "https://api.tinfoil.sh", "control plane URL")
 	verbose         = flag.Bool("v", false, "enable verbose logging")
-	configURL       = flag.String("c", "https://raw.githubusercontent.com/tinfoilsh/confidential-model-router/main/config.yml", "Path to config.yml, only used to update enclave hostnames and not measurements")
+	initConfigURL   = flag.String("i", "", "Optional path to initial config.yml (requires to append @sha256:<hex> for integrity)")
+	updateConfigURL = flag.String("u", "https://raw.githubusercontent.com/tinfoilsh/confidential-model-router/main/config.yml", "Path to runtime config.yml")
 )
 
 func jsonError(w http.ResponseWriter, message string, code int) {
@@ -65,7 +66,7 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	em, err := manager.NewEnclaveManager(configFile, *controlPlaneURL, *configURL)
+	em, err := manager.NewEnclaveManager(configFile, *controlPlaneURL, *initConfigURL, *updateConfigURL)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for an initial config with SHA‑256 integrity checking and a separate runtime update URL. Enforces HTTPS for remote configs and adds debug logs during config loading.

- **New Features**
  - New config loader: Load(url, sha256_required) with optional SHA‑256 via "@sha256:<hex>".
  - Initial config (-i) must include "@sha256:<hex>" and can be local file or HTTPS URL.
  - Runtime updates use a separate URL (-u). SHA check is optional if provided.
  - Rejects "http://" for remote configs; only "https://" or local files are allowed.
  - Added debug logs for config source and hash verification.

- **Migration**
  - Replace -c with -i (initial) and -u (updates).
  - For -i, append "@sha256:<hex>" to the path/URL.
  - Ensure remote config URLs use HTTPS.

<sup>Written for commit 7e064e76fb02c71b25142c549d05dd781e07e8be. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

