### PR TITLE
fix: use X-Forwarded-Host to determine subdomain

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,11 +64,11 @@ func sendJSON(w http.ResponseWriter, data any) {
 
 func parseModelFromSubdomain(r *http.Request, domain string) (string, error) {
 	// Check if the request is for a subdomain and derive model from leftmost subdomain.
-	host := r.Host
+	host := r.Header.Get("X-Forwarded-Host")
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
 	}
-	log.Debugf("host: %s", host)
+	log.Debugf("host (from X-Forwarded-Host): %s", host)
 	if !strings.HasSuffix(host, "."+domain) {
 		return "", nil
 	}

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,5 +11,8 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.17"
-    args: ["-d", "$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)"]
+    image: ""
+    args: [
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.18",
+      "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
+    ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix subdomain detection behind reverse proxies by reading X-Forwarded-Host, ensuring correct model routing. Updated proxy config to use confidential-model-router v0.0.18.

- **Bug Fixes**
  - Read subdomain from X-Forwarded-Host instead of r.Host.
  - Preserve host:port splitting and update log message for clarity.

- **Dependencies**
  - Bump router to ghcr.io/tinfoilsh/confidential-model-router:0.0.18.
  - Adjust proxy container args to pass the image and the -d domain flag explicitly.

<sup>Written for commit e9318249758dc84f693329ecd3c484554d143100. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

