### PR TITLE
Jules/fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY --from=builder /app/proxy .
 
 EXPOSE 8089
 
-CMD ["./proxy"]
+ENTRYPOINT ["./proxy"]

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 			http.Redirect(w, r, "https://docs.tinfoil.sh", http.StatusTemporaryRedirect)
 			return
 		} else if r.URL.Path == "/v1/audio/transcriptions" || strings.HasPrefix(r.URL.Path, "/v1/audio/") {
-			modelName = "audio-processing"
+			modelName = "whisper-large-v3-turbo"
 		} else if r.URL.Path == "/v1/convert/file" {
 			modelName = "doc-upload"
 		} else {

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,4 +11,4 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.13"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.14"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes audio request routing to use whisper-large-v3-turbo and switches the Docker startup to ENTRYPOINT for more reliable container runs.

- **Bug Fixes**
  - Route /v1/audio/transcriptions and /v1/audio/* to whisper-large-v3-turbo (was audio-processing).
  - Use ENTRYPOINT ["./proxy"] instead of CMD in the Dockerfile.

- **Dependencies**
  - Bump confidential-model-router image to ghcr.io/tinfoilsh/confidential-model-router:0.0.14.

<sup>Written for commit d0443b8c8fec9a9edb43edb4aeb5ca782229fe6c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

