### PR TITLE
fix: use entrypoint for dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY --from=builder /app/proxy .
 
 EXPOSE 8089
 
-CMD ["./proxy"]
+ENTRYPOINT ["./proxy"]

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -13,6 +13,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.18",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.19",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the container to use ENTRYPOINT so ./proxy runs reliably and accepts runtime args. Also bumped the confidential-model-router image to 0.0.19.

- **Bug Fixes**
  - Use ENTRYPOINT ["./proxy"] so args from tinfoil-config append to the command instead of replacing it.

- **Dependencies**
  - Update router image tag from 0.0.18 to 0.0.19.

<sup>Written for commit 42fed4f5d0ffcc0e535ff3526e8d51b912cea43d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

