### PR TITLE
chore: bump shim and build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: tinfoilsh/pri-build-action@v0.5.3
+      - uses: tinfoilsh/pri-build-action@v0.5.5
         with:
           config-file: ${{ github.workspace }}/tinfoil-config.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: "true"

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,6 +1,6 @@
-shim-version: v0.2.14@sha256:24d59ce41ad00a05ab5a37708b0d8b07a7d09abb1b74b75ee4862f688d093949
+shim-version: v0.2.15@sha256:5ca748b384b78b7e686b57ca66d9b3c552038ebab2ce60305004f76e573a8458
 cvm-version: 0.5.8
-cpus: 16
+cpus: 8
 memory: 16384
 
 shim:
@@ -13,6 +13,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.20",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.21",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade build pipeline and runtime to align with latest releases and reduce resource usage. Bumped pri-build-action to v0.5.5 with prerelease enabled, updated shim to v0.2.15 and router to 0.0.21, and lowered CPU allocation from 16 to 8.

<sup>Written for commit b403e7a9c622ea3b0655b8f2918bc0e787588ee1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

