### PR TITLE
chore: bump release number

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -13,6 +13,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.21",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.22",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update proxy container to ghcr.io/tinfoilsh/confidential-model-router:0.0.22 to pick up the latest release and fixes.

<sup>Written for commit 84f8a7d6bd784a28be284d5b498ec8265528e07e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

