### PR TITLE
Jules/kimi

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -20,9 +20,9 @@ models:
       - whisper.inf6.tinfoil.sh
 
   llama3-3-70b:
-    repo: tinfoilsh/confidential-llama-qwen
+    repo: tinfoilsh/confidential-llama3-3-70b
     enclaves:
-      - llama-qwen.inf8.tinfoil.sh
+      - llama3-3-70b.inf5.tinfoil.sh
 
   qwen3-coder-480b:
     repo: tinfoilsh/confidential-llama-qwen

--- a/config.yml
+++ b/config.yml
@@ -54,6 +54,11 @@ models:
     enclaves:
       - titan-qwen2-5-05b.inf5.tinfoil.sh
 
+  kimi-k2-thinking:
+    repo: tinfoilsh/confidential-kimi-k2-thinking
+    enclaves:
+      - kimi-k2-thinking.inf8.tinfoil.sh
+
   deepseek-v31-terminus:
     repo: tinfoilsh/confidential-deepseek-v31-terminus
     enclaves:

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -13,6 +13,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.22",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.23",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the Kimi K2 Thinking model and fixes the llama3-3-70b config to use the correct repo and enclave. Also bumps the model router to 0.0.23.

- **New Features**
  - Added kimi-k2-thinking with repo tinfoilsh/confidential-kimi-k2-thinking and enclave kimi-k2-thinking.inf8.tinfoil.sh.

- **Dependencies**
  - Updated confidential-model-router to 0.0.23.

<sup>Written for commit 21a28960977a2179427a77c5cdbc30d8e9c38f1d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



