### PR TITLE
chore: bump version

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -13,6 +13,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.23",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.24",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped the proxy’s confidential-model-router image from 0.0.23 to 0.0.24 to apply the latest patch release and keep deployments current.

Updated tinfoil-config.yml args to reference ghcr.io/tinfoilsh/confidential-model-router:0.0.24.

<sup>Written for commit 81b624a0395c86722b0cefde2ae44a5657b4cd85. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

