### PR TITLE
chore: remove kimi enclave

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -57,7 +57,6 @@ models:
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking
     enclaves:
-      - kimi-k2-thinking.inf8.tinfoil.sh
 
   deepseek-v31-terminus:
     repo: tinfoilsh/confidential-deepseek-v31-terminus


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the kimi-k2-thinking enclave from config.yml to stop targeting the inf8 host. This cleans up the model config and prevents calls to an inactive endpoint.

<sup>Written for commit 4c0015b15655bf64c4e74388f867c1b130fce9c3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

