### PR TITLE
feat: add kimi enclave

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -57,6 +57,7 @@ models:
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking
     enclaves:
+      - kimi-k2-thinking.inf10.tinfoil.sh
 
   deepseek-v31-terminus:
     repo: tinfoilsh/confidential-deepseek-v31-terminus


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added the inf10 enclave for the Kimi K2 Thinking model in config.yml to enable routing to kimi-k2-thinking.inf10.tinfoil.sh. This makes the model available in the inf10 environment.

<sup>Written for commit b2d45c70ab3d653ff977c0d67086b16cf9bc9134. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

