### PR TITLE
feat: expose /models endpoint from control plane

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,7 +124,14 @@ func main() {
 				promhttp.Handler().ServeHTTP(w, r)
 				return
 			} else if r.URL.Path == "/v1/models" {
-				resp, err := http.Get(*controlPlaneURL + "/v1/models")
+				ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+				defer cancel()
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, *controlPlaneURL+"/v1/models", nil)
+				if err != nil {
+					jsonError(w, fmt.Sprintf("failed to create request: %v", err), http.StatusInternalServerError)
+					return
+				}
+				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
 					jsonError(w, fmt.Sprintf("failed to fetch models: %v", err), http.StatusBadGateway)
 					return

--- a/main.go
+++ b/main.go
@@ -123,6 +123,17 @@ func main() {
 				// Expose Prometheus metrics
 				promhttp.Handler().ServeHTTP(w, r)
 				return
+			} else if r.URL.Path == "/v1/models" {
+				resp, err := http.Get(*controlPlaneURL + "/v1/models")
+				if err != nil {
+					jsonError(w, fmt.Sprintf("failed to fetch models: %v", err), http.StatusBadGateway)
+					return
+				}
+				defer resp.Body.Close()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(resp.StatusCode)
+				io.Copy(w, resp.Body)
+				return
 			} else if r.URL.Path == "/v1/audio/transcriptions" || strings.HasPrefix(r.URL.Path, "/v1/audio/") {
 				modelName = "whisper-large-v3-turbo"
 			} else if r.URL.Path == "/v1/convert/file" {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose the /v1/models endpoint by proxying to the control plane so clients can list available models via our API.

- **New Features**
  - Added handler for /v1/models that forwards to the control plane URL.
  - Preserves upstream status code and streams JSON response.
  - Returns 502 Bad Gateway with a JSON error on fetch failure.

- **Bug Fixes**
  - Added a 30s request timeout to prevent hanging when the control plane is slow.

<sup>Written for commit 8cd4f692a4a637132e403c9b4dd131787136d6b7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



