### PR TITLE
Tanya/bump shim

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,4 +1,4 @@
-shim-version: v0.2.15@sha256:5ca748b384b78b7e686b57ca66d9b3c552038ebab2ce60305004f76e573a8458
+shim-version: v0.3.0@sha256:fe34a829a626cfa73cc305fc5c210e0cedc61524af3829c548d9505673ef8c5a
 cvm-version: 0.5.8
 cpus: 8
 memory: 16384

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -13,6 +13,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.24",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.25",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade shim to v0.3.0 to enable EHBP v2. Update proxy image to ghcr.io/tinfoilsh/confidential-model-router:0.0.25 for compatibility.

<sup>Written for commit ff79e3b8d778aac242d156b50e7d1d51b7d94258. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

