### PR TITLE
chore: bump version

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -13,6 +13,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.25",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.26",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade confidential-model-router from 0.0.25 to 0.0.26 in tinfoil-config to deploy the latest proxy image. No other changes.

<sup>Written for commit 9c9549231aea3ff8824d2a13b8422e3b8ae31386. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

