### PR TITLE
feat: add support for the openai responses api

### DIFF
--- a/main.go
+++ b/main.go
@@ -224,7 +224,7 @@ func main() {
 					// Update Content-Length header to match new body size
 					r.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
 					r.ContentLength = int64(len(bodyBytes))
-					log.Debugf("Modified streaming request body to include continuous_usage_stats, API type: %s, client requested usage: %v", r.Header.Get("X-Tinfoil-API-Type"), clientRequestedUsage)
+					log.Debugf("Modified streaming request body for usage tracking, API type: %s, client requested usage: %v", r.Header.Get("X-Tinfoil-API-Type"), clientRequestedUsage)
 				}
 
 				r.Body.Close()

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -71,9 +71,10 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 
 		// Check if client requested usage stats (from header set in main.go)
 		clientRequestedUsage := req.Header.Get("X-Tinfoil-Client-Requested-Usage") == "true"
+		apiType := tokencount.APIType(req.Header.Get("X-Tinfoil-API-Type"))
 
 		// Extract tokens with the usage handler
-		newBody, _, err := tokencount.ExtractTokensFromResponseWithHandler(resp, modelName, usageHandler, clientRequestedUsage)
+		newBody, _, err := tokencount.ExtractTokensFromResponseWithHandler(resp, modelName, usageHandler, clientRequestedUsage, apiType)
 		if err != nil {
 			log.WithError(err).Error("Failed to extract tokens from response")
 			// Don't fail the request, just log the error


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds first-class support for the OpenAI Responses API with accurate token usage extraction for both JSON and streaming responses. Streams stay clean unless the client opts into usage, preserving backwards compatibility.

- New Features
  - Detects /v1/responses requests and tags them internally to select the right extractor.
  - For streaming: forces include_usage for Responses API and continuous_usage_stats for Chat Completions; tracks if the client explicitly requested usage.
  - Extracts usage from Responses API (JSON and response.completed events) and Chat Completions; computes totals when missing; filters usage from the stream if not requested.
  - Plumbs API type through the proxy to the token extractor; adds targeted tests for Responses API (streaming and non-streaming).

<sup>Written for commit c1e7e7d4b0a11b07bd6d8024e554af69b50c7ead. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



