### PR TITLE
chore: update router to inf5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,6 @@
 routers:
   inference.tinfoil.sh:
-  # router.inf6.tinfoil.sh:
-  router.inf7.tinfoil.sh:
+  router.inf5.tinfoil.sh:
 
 models:
   nomic-embed-text:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched router config to use router.inf5.tinfoil.sh instead of router.inf7.tinfoil.sh to route traffic to the correct inference cluster. Removed the stale inf6 comment.

<sup>Written for commit 8ebcaf55c21c28ccb9d409fe4f7f4ea5a40f900e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

