### PR TITLE
feat: add qwen2.5 to model config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -47,7 +47,7 @@ models:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
       - qwen3-vl-30b.inf5.tinfoil.sh
-  
+
   titan-qwen2-5-05b:
     repo: tinfoilsh/confidential-titan-qwen2-5-05b
     enclaves:
@@ -65,3 +65,8 @@ models:
     overload:
       max_requests_waiting: 75
       retry_after_minutes: 3
+
+  qwen2-5-05b:
+    repo: tinfoilsh/confidential-qwen2-5-05b
+    enclaves:
+      - qwen2-5-05b.inf5.tinfoil.sh


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add qwen2-5-05b to the models config so it can be selected and routed in production. Uses repo tinfoilsh/confidential-qwen2-5-05b with enclave qwen2-5-05b.inf5.tinfoil.sh.

<sup>Written for commit 9a82620c47663c2150beb23417807b0d6bccbe9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

