### PR TITLE
chore: remove Deepseek R1

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -58,14 +58,6 @@ models:
     enclaves:
       - kimi-k2-thinking.inf10.tinfoil.sh
 
-  deepseek-v31-terminus:
-    repo: tinfoilsh/confidential-deepseek-v31-terminus
-    enclaves:
-      - deepseek-v31-terminus.inf7.tinfoil.sh
-    overload:
-      max_requests_waiting: 75
-      retry_after_minutes: 3
-
   qwen2-5-05b:
     repo: tinfoilsh/confidential-qwen2-5-05b
     enclaves:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the Deepseek R1 model entry (deepseek-v31-terminus) from config to decommission it and stop routing any traffic to its enclave. This cleans up unused overload settings and removes the associated enclave host.

- **Migration**
  - Update any client references from deepseek-v31-terminus to a supported model.

<sup>Written for commit ecedb376931b632ccf41c8b6bb4142f3c533a244. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

