### PR TITLE
chore: update cvm-version and container image version

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,5 +1,5 @@
 shim-version: v0.3.2@sha256:2bbbf67720a258f8fb92a470f2368215b97fa5ee92afa117d376e776e34e2373
-cvm-version: 0.5.8
+cvm-version: 0.5.10
 cpus: 8
 memory: 16384
 
@@ -13,6 +13,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.28",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.30",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated tinfoil-config to use the latest CVM and proxy container image for stability and recent fixes.

- **Dependencies**
  - cvm-version: 0.5.8 → 0.5.10
  - confidential-model-router: 0.0.28 → 0.0.30

<sup>Written for commit 6ae1f11b1a061824c6dfc67fa76041957fad3484. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

