### PR TITLE
fix: remove inf5 router for now

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,5 @@
 routers:
   inference.tinfoil.sh:
-  router.inf5.tinfoil.sh:
 
 models:
   nomic-embed-text:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed router.inf5.tinfoil.sh from the routers config to stop routing to the disabled inf5 endpoint. All traffic now routes only through inference.tinfoil.sh.

<sup>Written for commit d58085fa56721fa2cdd89c8340d83be2d86e9fe7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

