### PR TITLE
chore: update enclave for qwen3-coder-480b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -25,7 +25,7 @@ models:
   qwen3-coder-480b:
     repo: tinfoilsh/confidential-qwen3-coder-480b
     enclaves:
-      - qwen3-coder-480b.inf8.tinfoil.sh
+      - qwen3-coder-480b.inf7.tinfoil.sh
 
   deepseek-r1-0528:
     repo: tinfoilsh/confidential-deepseek-r1-0528


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the enclave host for qwen3-coder-480b from inf8 to inf7. Ensures requests route to the correct enclave.

<sup>Written for commit addee2edc9e2f6f528dc1a1ec63b4e4d254b7de1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

