### PR TITLE
chore: update enclave for kimi-k2-thinking configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -55,7 +55,7 @@ models:
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking
     enclaves:
-      - kimi-k2-thinking.inf10.tinfoil.sh
+      - kimi-k2-thinking.inf8.tinfoil.sh
 
   qwen2-5-05b:
     repo: tinfoilsh/confidential-qwen2-5-05b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pointed kimi-k2-thinking to the new enclave host (kimi-k2-thinking.inf8.tinfoil.sh) instead of inf10 to match current infra and route traffic correctly. No other changes.

<sup>Written for commit a91149401be02a5ffdd40e6f6f12dc7d22a2253e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

