### PR TITLE
chore: add gpt-oss-safeguard-120b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,6 +42,11 @@ models:
     enclaves:
       - gpt-oss-120b-free.inf5.tinfoil.sh
 
+  gpt-oss-safeguard-120b:
+    repo: tinfoilsh/confidential-gpt-oss-safeguard-120b
+    enclaves:
+      - gpt-oss-safeguard-120b.inf5.tinfoil.sh
+
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added gpt-oss-safeguard-120b to the config to enable model routing and deployment. Includes repo reference (tinfoilsh/confidential-gpt-oss-safeguard-120b) and its inf5 enclave (gpt-oss-safeguard-120b.inf5.tinfoil.sh).

<sup>Written for commit 34e574f91afac38951b9944e067b8d7afb4a0d99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

