### PR TITLE
chore: bump container

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -16,6 +16,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.31",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.33",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the proxy container image to ghcr.io/tinfoilsh/confidential-model-router:0.0.33. Ensures deployments pull the latest router version.

<sup>Written for commit 32326c683479382941384c4d7de2caebd059697b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

