### PR TITLE
chore: bump shim cvm and container

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,5 +1,5 @@
-shim-version: v0.3.2@sha256:2bbbf67720a258f8fb92a470f2368215b97fa5ee92afa117d376e776e34e2373
-cvm-version: 0.5.15
+shim-version: v0.3.5@sha256:f44c65a1f7db476be20c3431bb6facea8c2966606a07fbb5724a619f82bfa558
+cvm-version: 0.5.16
 cpus: 8
 memory: 16384
 platform: small_0d_amd
@@ -9,13 +9,11 @@ stage0-version: stage0-v0.0.4
 shim:
   listen-port: 443
   upstream-port: 8089
-  publish-attestation: true
-  tls-challenge: dns
 
 containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.33",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.34",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped shim to v0.3.5 (new digest), CVM to 0.5.16, and the proxy container to 0.0.34 to pick up recent fixes. Removed publish-attestation and tls-challenge from the shim config.

<sup>Written for commit a25fab0e20d104a5a002deafa8f6ebc79ac78b23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

