### PR TITLE
fix: roll back stage0 for now

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -2,9 +2,6 @@ shim-version: v0.3.5@sha256:f44c65a1f7db476be20c3431bb6facea8c2966606a07fbb5724a
 cvm-version: 0.5.16
 cpus: 8
 memory: 16384
-platform: small_0d_amd
-cvmimage-version: cvmimage-v0.0.7
-stage0-version: stage0-v0.0.4
 
 shim:
   listen-port: 443
@@ -14,6 +11,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.34",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.35",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rolled back stage0 configuration and removed related fields to revert to a stable setup. Also updated the proxy image to confidential-model-router v0.0.35.

- **Bug Fixes**
  - Removed stage0-related settings from tinfoil-config.yml: platform, cvmimage-version, stage0-version.

- **Dependencies**
  - Bumped proxy image to ghcr.io/tinfoilsh/confidential-model-router:0.0.35.

<sup>Written for commit a132bdc16daa33812d6b0ae777549662a77ca4a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

