### PR TITLE
fix: roll back pri-build-action version in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-      - uses: tinfoilsh/pri-build-action@a53bda520fac25778e31aa6b3a6ac686cbca0cda # v0.7.14
+      - uses: tinfoilsh/pri-build-action@5d450a7f30904866efc401e24484b935b7ed52dd # v0.6.1
         with:
           config-file: ${{ github.workspace }}/tinfoil-config.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rolled back pri-build-action in build.yml from v0.7.14 to v0.6.1 to stabilize the CI workflow and fix recent build issues.

<sup>Written for commit b62021aaf1d304c88a39fe2cb36acb537af0ed5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

