### PR TITLE
chore: bump container version

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,6 +11,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.35",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.37",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the proxy container image in tinfoil-config.yml from ghcr.io/tinfoilsh/confidential-model-router:0.0.35 to ghcr.io/tinfoilsh/confidential-model-router:0.0.37.

<sup>Written for commit 767f10af2ee8b78d0cadd7e98893f9b6cd65f7b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

