### PR TITLE
chore: bump container

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,6 +11,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.37",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.38",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the proxy container to use ghcr.io/tinfoilsh/confidential-model-router:0.0.38 instead of 0.0.37. Ensures deployments pull the latest router image.

<sup>Written for commit 58ea13cbef8dd17c72830545e149c994877b1000. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

