### PR TITLE
feat: add tool-based routing for agents

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -66,3 +66,8 @@ models:
     repo: tinfoilsh/confidential-qwen2-5-05b
     enclaves:
       - qwen2-5-05b.inf5.tinfoil.sh
+
+  websearch:
+    repo: tinfoilsh/confidential-websearch
+    enclaves:
+      - websearch.tinfoil.functions.tinfoil.sh

--- a/main.go
+++ b/main.go
@@ -163,7 +163,8 @@ func main() {
 				if tools, ok := body["tools"].([]interface{}); ok {
 					if slices.ContainsFunc(tools, func(t any) bool {
 						m, _ := t.(map[string]any)
-						return m["type"] == "web_search"
+						typeVal, ok := m["type"].(string)
+						return ok && typeVal == "web_search"
 					}) {
 						modelName = "websearch"
 					}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds tool-based routing for agents so requests with the web_search tool automatically use the websearch enclave; otherwise we use the provided model. This simplifies client requests and routes tools to the correct backend.

- **New Features**
  - Detects the web_search tool in request body and sets modelName to "websearch"; falls back to the "model" field when no tool match.
  - Adds the "websearch" model to config with repo tinfoilsh/confidential-websearch and enclave websearch.tinfoil.functions.tinfoil.sh.

<sup>Written for commit 4ada5d89fb7999ad8bbe930a02dcda6b1cdb6012. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

