### PR TITLE
chore: bump container

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,6 +11,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.38",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.39",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update proxy container image to ghcr.io/tinfoilsh/confidential-model-router:0.0.39. Replaces 0.0.38 in tinfoil-config.yml to use the latest router build.

<sup>Written for commit 61005dcc0cf0b1008a1361cddfd2dade37849f2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

