### PR TITLE
chore: add voxtral to config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -17,6 +17,11 @@ models:
     enclaves:
       - whisper.inf6.tinfoil.sh
 
+  voxtral-small-24b:
+    repo: tinfoilsh/confidential-voxtral-small-24b
+    enclaves:
+      - voxtral-small-24b.inf6.tinfoil.sh
+
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
     enclaves:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added voxtral-small-24b to the models config to make the model available and route requests to its enclave. Uses repo tinfoilsh/confidential-voxtral-small-24b and enclave voxtral-small-24b.inf6.tinfoil.sh.

<sup>Written for commit 63944c663df84fb6e2eaa34067b57e8ccf63d298. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

