### PR TITLE
Fix: update enclave for voxtral-small-24b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -20,7 +20,7 @@ models:
   voxtral-small-24b:
     repo: tinfoilsh/confidential-voxtral-small-24b
     enclaves:
-      - voxtral-small-24b.inf6.tinfoil.sh
+      - voxtral-small-24b.inf5.tinfoil.sh
 
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated voxtral-small-24b to use the correct enclave (inf5) so requests route to the active deployment and the model loads reliably.

- **Bug Fixes**
  - Updated config.yml to reference voxtral-small-24b.inf5.tinfoil.sh (replaces stale inf6 endpoint).

<sup>Written for commit 08d323dc9c77865e120f1fdf6b578322b50bb7f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

