### PR TITLE
chore: bump container

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,6 +11,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.39",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.40",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump confidential-model-router image from 0.0.39 to 0.0.40 for the proxy container. This pulls in the latest fixes and improvements.

<sup>Written for commit 149c0b7fb6557170db09ad1470f0fa9501f09d21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

