### PR TITLE
chore: move Kimi k2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -65,7 +65,7 @@ models:
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking
     enclaves:
-      - kimi-k2-thinking.inf8.tinfoil.sh
+      - kimi-k2-thinking.inf10.tinfoil.sh
 
   qwen2-5-05b:
     repo: tinfoilsh/confidential-qwen2-5-05b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the kimi-k2-thinking enclave in config.yml from inf8 to inf10 to point deployments at the new host.

This updates routing to kimi-k2-thinking.inf10.tinfoil.sh with no code or model changes.

<sup>Written for commit 45f774825a42c95b403f7fa64edb4c4af68df206. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

