### PR TITLE
fix/refmeasure

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,6 +11,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.40",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.41",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION
- **fix: verification fails if reference measurements are not available**
- **chore: bump container**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures enclave verification fails when a source measurement is missing and improves error logs, preventing unverified enclaves from being added. Also bumps the router container to 0.0.41.

- **Bug Fixes**
  - Require a non-nil source measurement; fail fast if missing.
  - Keep strict equality check; error on mismatch.
  - More specific error logs in sync and addEnclave.

- **Dependencies**
  - Update proxy image to ghcr.io/tinfoilsh/confidential-model-router:0.0.41.

<sup>Written for commit 3bd626db2773076fa573ec5705d9ebeec8916d22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

