### PR TITLE
feat: add prometheus service discovery endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,7 +136,12 @@ func main() {
 				status["version"] = version
 				sendJSON(w, status)
 				return
-			} else if r.URL.Path == "/metrics" {
+			} else if r.URL.Path == "/.well-known/prometheus-targets" {
+			// Prometheus HTTP service discovery endpoint
+			// See: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config
+			sendJSON(w, em.PrometheusTargets())
+			return
+		} else if r.URL.Path == "/metrics" {
 				// Expose Prometheus metrics
 				promhttp.Handler().ServeHTTP(w, r)
 				return


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Prometheus HTTP service discovery endpoint at /.well-known/prometheus-targets so Prometheus can auto-discover enclave targets per model. /metrics remains unchanged.

- **New Features**
  - Serve GET /.well-known/prometheus-targets with HTTP SD JSON.
  - Build target groups from EnclaveManager models and enclaves.
  - Add labels: model_name and __param_model.

<sup>Written for commit 3cc6cc4d20242f7a1344358e1b22ce63d230e0f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

