### PR TITLE
chore: bump container image

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -11,6 +11,6 @@ containers:
   - name: "proxy"
     image: ""
     args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.42",
+      "ghcr.io/tinfoilsh/confidential-model-router:0.0.44",
       "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
     ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped the proxy’s confidential-model-router image from 0.0.42 to 0.0.44 in tinfoil-config.yml. This picks up the latest fixes and keeps the container current.

<sup>Written for commit b7cff7666e5a25856f2730ef83ebb4c1c2ddbafa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

