### PR TITLE
chore: use new config format

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,5 +1,5 @@
 shim-version: v0.3.10@sha256:825cfafbc6dde8967ac60e44264f4686fcf2ed33fae112ab4b1c69c6673cdc8e
-cvm-version: 0.5.16
+cvm-version: 0.6.0
 cpus: 8
 memory: 16384
 
@@ -9,8 +9,6 @@ shim:
 
 containers:
   - name: "proxy"
-    image: ""
-    args: [
-      "ghcr.io/tinfoilsh/confidential-model-router:0.0.44",
-      "-d","$(awk -F': *' '$1~/^domain$/{print $2; exit}' /mnt/ramdisk/external-config.yml)",
-    ]
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.45"
+    env:
+      - DOMAIN


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move tinfoil-config.yml to the new container config format, switching the proxy to an env-based DOMAIN and updating CVM/router versions for compatibility.

- **Refactors**
  - Set proxy image directly and read DOMAIN from env; removed args-based domain extraction.

- **Dependencies**
  - cvm-version: 0.5.16 → 0.6.0
  - confidential-model-router: 0.0.44 → 0.0.45

<sup>Written for commit e86181fe8a7745bff6a6d9cacc305221a6c50a99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

