### PR TITLE
chore: bump cvm and shim

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,5 +1,5 @@
-shim-version: v0.3.10@sha256:825cfafbc6dde8967ac60e44264f4686fcf2ed33fae112ab4b1c69c6673cdc8e
-cvm-version: 0.6.0
+shim-version: v0.3.12@sha256:b81f2295ae6750d61e94f810ce24077360001b6ec795d13643f3170df29e304d
+cvm-version: 0.6.1
 cpus: 8
 memory: 16384
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated tinfoil-config to use CVM 0.6.1 and shim v0.3.12. Pulls in the latest patch fixes; no other changes.

- **Dependencies**
  - cvm: 0.6.0 → 0.6.1
  - shim: v0.3.10 → v0.3.12 (updated sha256)

<sup>Written for commit f3ed1228f62cda70951e972dd85f6c36f61bb584. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

