### PR TITLE
chore: bump container

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -9,6 +9,6 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.45"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.46"
     env:
       - DOMAIN


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the proxy container image in tinfoil-config.yml from 0.0.45 to 0.0.46 to use the latest patch release.

<sup>Written for commit 7047a89121f743a637de04511143da7c43c57031. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

