### PR TITLE
chore: bump cvm

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,5 +1,5 @@
 shim-version: v0.3.12@sha256:b81f2295ae6750d61e94f810ce24077360001b6ec795d13643f3170df29e304d
-cvm-version: 0.6.1
+cvm-version: 0.6.2
 cpus: 8
 memory: 16384
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump CVM from 0.6.1 to 0.6.2 in tinfoil-config.yml to pick up the latest patch fixes.

<sup>Written for commit 10b2a6cbe7da6c9e3031f08d74ed497366325bdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

