### PR TITLE
chore: bump container

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -9,6 +9,6 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.46"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.47"
     env:
       - DOMAIN


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped the proxy container image from 0.0.46 to 0.0.47 to pick up the latest fixes and improvements. Updated tinfoil-config.yml to reference ghcr.io/tinfoilsh/confidential-model-router:0.0.47.

<sup>Written for commit b7bfae9d6550d828f98fef4efdc3e32068495695. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

