### PR TITLE
Use the OpenAI format for websearch

### DIFF
--- a/main.go
+++ b/main.go
@@ -232,14 +232,21 @@ func main() {
 					return
 				}
 
-				// Tool routing logic - route to special enclaves based on tool type
-				if tools, ok := body["tools"].([]interface{}); ok {
-					if slices.ContainsFunc(tools, func(t any) bool {
-						m, _ := t.(map[string]any)
-						typeVal, ok := m["type"].(string)
-						return ok && typeVal == "web_search"
-					}) {
-						modelName = "websearch"
+				// Web search routing - route to websearch enclave
+				// Chat Completions API: check for web_search_options field
+				if _, ok := body["web_search_options"]; ok {
+					modelName = "websearch"
+				}
+				// Responses API: check for tools array with web_search type
+				if modelName == "" {
+					if tools, ok := body["tools"].([]interface{}); ok {
+						if slices.ContainsFunc(tools, func(t any) bool {
+							m, _ := t.(map[string]any)
+							typeVal, ok := m["type"].(string)
+							return ok && typeVal == "web_search"
+						}) {
+							modelName = "websearch"
+						}
 					}
 				}
 

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -9,6 +9,6 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.47"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.48"
     env:
       - DOMAIN


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored web search routing to follow the OpenAI request format. Requests with web_search_options now route to the websearch enclave, with tools-based routing kept as a fallback.

- **Refactors**
  - Detect web_search_options in Chat Completions and set modelName to "websearch".
  - Fall back to tools[type="web_search"] for Responses API when web_search_options is absent.

- **Dependencies**
  - Bumped confidential-model-router image to 0.0.48.

<sup>Written for commit 0c399ce0a29629921004b7543170825dcc8b41fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

