### PR TITLE
feat: add X-Tinfoil-Usage-Metrics response header/trailer

### DIFF
--- a/manager/usage_writer.go
+++ b/manager/usage_writer.go
@@ -1,0 +1,103 @@
+package manager
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/tinfoilsh/confidential-model-router/tokencount"
+)
+
+// usageWriterKey is the context key for storing the usage metrics writer
+type usageWriterKey struct{}
+
+// usageMetricsWriter wraps http.ResponseWriter to capture usage and write trailers
+type usageMetricsWriter struct {
+	http.ResponseWriter
+	usage          *tokencount.Usage
+	trailerEnabled bool
+	mu             sync.Mutex
+}
+
+// SetUsage stores usage data to be written as a header or trailer
+func (w *usageMetricsWriter) SetUsage(usage *tokencount.Usage) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.usage = usage
+}
+
+// EnableTrailer allows writing usage metrics as a trailer
+func (w *usageMetricsWriter) EnableTrailer() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.trailerEnabled = true
+}
+
+// TrailerEnabled reports if trailer writing is enabled
+func (w *usageMetricsWriter) TrailerEnabled() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.trailerEnabled
+}
+
+// FormatUsage returns the formatted usage string for the header value
+func (w *usageMetricsWriter) FormatUsage() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.usage == nil {
+		return ""
+	}
+	return formatUsage(w.usage)
+}
+
+// WriteTrailer writes the usage metrics as an HTTP trailer
+// This should be called after the response body has been fully written
+func (w *usageMetricsWriter) WriteTrailer() {
+	if !w.TrailerEnabled() {
+		return
+	}
+	formatted := w.FormatUsage()
+	if formatted == "" {
+		return
+	}
+	// Set the trailer value - Go's http package will send it after the body
+	w.Header().Set(UsageMetricsResponseHeader, formatted)
+}
+
+// Flush implements http.Flusher
+func (w *usageMetricsWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// Hijack implements http.Hijacker when supported by the underlying ResponseWriter.
+func (w *usageMetricsWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+	return nil, nil, http.ErrNotSupported
+}
+
+// Push implements http.Pusher when supported by the underlying ResponseWriter.
+func (w *usageMetricsWriter) Push(target string, opts *http.PushOptions) error {
+	if pusher, ok := w.ResponseWriter.(http.Pusher); ok {
+		return pusher.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
+
+// ReadFrom implements io.ReaderFrom when supported by the underlying ResponseWriter.
+func (w *usageMetricsWriter) ReadFrom(r io.Reader) (int64, error) {
+	if rf, ok := w.ResponseWriter.(io.ReaderFrom); ok {
+		return rf.ReadFrom(r)
+	}
+	return io.Copy(w.ResponseWriter, r)
+}
+
+// Unwrap returns the underlying ResponseWriter (for http.ResponseController)
+func (w *usageMetricsWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}

--- a/manager/usage_writer_test.go
+++ b/manager/usage_writer_test.go
@@ -1,0 +1,476 @@
+package manager
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tinfoilsh/confidential-model-router/tokencount"
+)
+
+func TestUsageMetricsWriter_SetUsage(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+	usage := &tokencount.Usage{
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		TotalTokens:      150,
+	}
+
+	wrapper.SetUsage(usage)
+
+	if wrapper.usage == nil {
+		t.Fatal("expected usage to be set")
+	}
+	if wrapper.usage.PromptTokens != 100 {
+		t.Errorf("expected PromptTokens=100, got %d", wrapper.usage.PromptTokens)
+	}
+	if wrapper.usage.CompletionTokens != 50 {
+		t.Errorf("expected CompletionTokens=50, got %d", wrapper.usage.CompletionTokens)
+	}
+	if wrapper.usage.TotalTokens != 150 {
+		t.Errorf("expected TotalTokens=150, got %d", wrapper.usage.TotalTokens)
+	}
+}
+
+func TestUsageMetricsWriter_FormatUsage(t *testing.T) {
+	tests := []struct {
+		name     string
+		usage    *tokencount.Usage
+		expected string
+	}{
+		{
+			name: "standard usage",
+			usage: &tokencount.Usage{
+				PromptTokens:     67,
+				CompletionTokens: 42,
+				TotalTokens:      109,
+			},
+			expected: "prompt=67,completion=42,total=109",
+		},
+		{
+			name: "zero values",
+			usage: &tokencount.Usage{
+				PromptTokens:     0,
+				CompletionTokens: 0,
+				TotalTokens:      0,
+			},
+			expected: "prompt=0,completion=0,total=0",
+		},
+		{
+			name: "large values",
+			usage: &tokencount.Usage{
+				PromptTokens:     128000,
+				CompletionTokens: 4096,
+				TotalTokens:      132096,
+			},
+			expected: "prompt=128000,completion=4096,total=132096",
+		},
+		{
+			name:     "nil usage",
+			usage:    nil,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+			if tt.usage != nil {
+				wrapper.SetUsage(tt.usage)
+			}
+
+			result := wrapper.FormatUsage()
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestUsageMetricsWriter_WriteTrailer(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+	usage := &tokencount.Usage{
+		PromptTokens:     67,
+		CompletionTokens: 42,
+		TotalTokens:      109,
+	}
+	wrapper.SetUsage(usage)
+	wrapper.EnableTrailer()
+
+	wrapper.WriteTrailer()
+
+	// Check that the header was set
+	headerValue := rec.Header().Get(UsageMetricsResponseHeader)
+	expected := "prompt=67,completion=42,total=109"
+	if headerValue != expected {
+		t.Errorf("expected header %q, got %q", expected, headerValue)
+	}
+}
+
+func TestUsageMetricsWriter_WriteTrailer_NotEnabled(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+	usage := &tokencount.Usage{
+		PromptTokens:     5,
+		CompletionTokens: 6,
+		TotalTokens:      11,
+	}
+	wrapper.SetUsage(usage)
+
+	wrapper.WriteTrailer()
+
+	headerValue := rec.Header().Get(UsageMetricsResponseHeader)
+	if headerValue != "" {
+		t.Errorf("expected no header when trailer is not enabled, got %q", headerValue)
+	}
+}
+
+func TestUsageMetricsWriter_WriteTrailer_NilUsage(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+	// Don't set any usage
+	wrapper.EnableTrailer()
+	wrapper.WriteTrailer()
+
+	// Header should not be set
+	headerValue := rec.Header().Get(UsageMetricsResponseHeader)
+	if headerValue != "" {
+		t.Errorf("expected no header when usage is nil, got %q", headerValue)
+	}
+}
+
+func TestUsageMetricsWriter_Flush(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+	// Write some data
+	wrapper.Write([]byte("test data"))
+
+	// Flush should not panic and should work
+	wrapper.Flush()
+
+	// Verify data was written
+	if rec.Body.String() != "test data" {
+		t.Errorf("expected 'test data', got %q", rec.Body.String())
+	}
+}
+
+func TestUsageMetricsWriter_Unwrap(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+	unwrapped := wrapper.Unwrap()
+	if unwrapped != rec {
+		t.Error("Unwrap should return the underlying ResponseWriter")
+	}
+}
+
+func TestUsageWriterKey_Context(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+	ctx := context.WithValue(context.Background(), usageWriterKey{}, wrapper)
+
+	// Retrieve from context
+	retrieved, ok := ctx.Value(usageWriterKey{}).(*usageMetricsWriter)
+	if !ok {
+		t.Fatal("failed to retrieve usageMetricsWriter from context")
+	}
+	if retrieved != wrapper {
+		t.Error("retrieved wrapper should match original")
+	}
+}
+
+func TestUsageMetricsWriter_ConcurrentAccess(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+	done := make(chan bool)
+
+	// Concurrent writes
+	for i := 0; i < 10; i++ {
+		go func(n int) {
+			usage := &tokencount.Usage{
+				PromptTokens:     n * 10,
+				CompletionTokens: n * 5,
+				TotalTokens:      n * 15,
+			}
+			wrapper.SetUsage(usage)
+			_ = wrapper.FormatUsage()
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Should not panic and usage should be set
+	if wrapper.usage == nil {
+		t.Error("usage should be set after concurrent access")
+	}
+}
+
+// Integration test simulating the full flow
+func TestUsageMetrics_NonStreamingFlow(t *testing.T) {
+	// Simulate non-streaming response
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if usage metrics requested
+		if r.Header.Get(UsageMetricsRequestHeader) != "true" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"response": "no metrics"}`))
+			return
+		}
+
+		// Wrap writer
+		wrapper := &usageMetricsWriter{ResponseWriter: w}
+
+		// Simulate usage extraction (normally done by tokencount)
+		usage := &tokencount.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 25,
+			TotalTokens:      125,
+		}
+		wrapper.SetUsage(usage)
+
+		// Set header (for non-streaming, set directly)
+		w.Header().Set(UsageMetricsResponseHeader, wrapper.FormatUsage())
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"response": "with metrics"}`))
+	})
+
+	// Test with usage metrics requested
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{}`))
+	req.Header.Set(UsageMetricsRequestHeader, "true")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Check response header
+	usageHeader := rec.Header().Get(UsageMetricsResponseHeader)
+	expected := "prompt=100,completion=25,total=125"
+	if usageHeader != expected {
+		t.Errorf("expected usage header %q, got %q", expected, usageHeader)
+	}
+}
+
+func TestUsageMetrics_StreamingFlow(t *testing.T) {
+	// Simulate streaming response with trailer
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if usage metrics requested
+		if r.Header.Get(UsageMetricsRequestHeader) != "true" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Announce trailer
+		w.Header().Set("Trailer", UsageMetricsResponseHeader)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Transfer-Encoding", "chunked")
+
+		// Wrap writer
+		wrapper := &usageMetricsWriter{ResponseWriter: w}
+
+		// Write streaming data
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("data: {\"chunk\": 1}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		w.Write([]byte("data: {\"chunk\": 2}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		w.Write([]byte("data: [DONE]\n\n"))
+
+		// Simulate usage extraction at end of stream
+		usage := &tokencount.Usage{
+			PromptTokens:     50,
+			CompletionTokens: 10,
+			TotalTokens:      60,
+		}
+		wrapper.SetUsage(usage)
+		wrapper.EnableTrailer()
+
+		// Write trailer
+		wrapper.WriteTrailer()
+	})
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{"stream": true}`))
+	req.Header.Set(UsageMetricsRequestHeader, "true")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Check trailer announcement
+	trailerAnnouncement := rec.Header().Get("Trailer")
+	if trailerAnnouncement != UsageMetricsResponseHeader {
+		t.Errorf("expected Trailer header %q, got %q", UsageMetricsResponseHeader, trailerAnnouncement)
+	}
+
+	// Check the usage header was set (httptest.ResponseRecorder stores trailers in Header)
+	usageHeader := rec.Header().Get(UsageMetricsResponseHeader)
+	expected := "prompt=50,completion=10,total=60"
+	if usageHeader != expected {
+		t.Errorf("expected usage trailer %q, got %q", expected, usageHeader)
+	}
+
+	// Verify body was written
+	body := rec.Body.String()
+	if !strings.Contains(body, "chunk") {
+		t.Error("expected streaming chunks in body")
+	}
+}
+
+func TestUsageMetrics_OptOut(t *testing.T) {
+	// Test that when header is not set, no usage metrics are added
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only set usage if requested
+		if r.Header.Get(UsageMetricsRequestHeader) == "true" {
+			// Would set header here
+			w.Header().Set(UsageMetricsResponseHeader, "prompt=1,completion=1,total=2")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"response": "test"}`))
+	})
+
+	// Test WITHOUT usage metrics header
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{}`))
+	// Not setting X-Tinfoil-Request-Usage-Metrics header
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Should NOT have usage header
+	usageHeader := rec.Header().Get(UsageMetricsResponseHeader)
+	if usageHeader != "" {
+		t.Errorf("expected no usage header when not requested, got %q", usageHeader)
+	}
+}
+
+// Test with real tokencount.Usage pointer manipulation
+func TestUsageMetricsWriter_UsagePointerSafety(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+	// Set usage
+	usage := &tokencount.Usage{
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		TotalTokens:      150,
+	}
+	wrapper.SetUsage(usage)
+
+	// Modify original usage struct
+	usage.PromptTokens = 200
+	usage.CompletionTokens = 100
+	usage.TotalTokens = 300
+
+	// The wrapper should have the modified values (pointer semantics)
+	formatted := wrapper.FormatUsage()
+	if !strings.Contains(formatted, "prompt=200") {
+		t.Errorf("expected updated prompt tokens in format, got %q", formatted)
+	}
+}
+
+// Test header constants
+func TestUsageMetricsHeaderConstants(t *testing.T) {
+	if UsageMetricsRequestHeader != "X-Tinfoil-Request-Usage-Metrics" {
+		t.Errorf("unexpected request header constant: %q", UsageMetricsRequestHeader)
+	}
+	if UsageMetricsResponseHeader != "X-Tinfoil-Usage-Metrics" {
+		t.Errorf("unexpected response header constant: %q", UsageMetricsResponseHeader)
+	}
+}
+
+// Benchmark formatting
+func BenchmarkFormatUsage(b *testing.B) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+	wrapper.SetUsage(&tokencount.Usage{
+		PromptTokens:     128000,
+		CompletionTokens: 4096,
+		TotalTokens:      132096,
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = wrapper.FormatUsage()
+	}
+}
+
+// Test that Write passes through correctly
+func TestUsageMetricsWriter_WritePassthrough(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+	testData := []byte("Hello, World!")
+	n, err := wrapper.Write(testData)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if n != len(testData) {
+		t.Errorf("expected to write %d bytes, wrote %d", len(testData), n)
+	}
+	if rec.Body.String() != "Hello, World!" {
+		t.Errorf("expected body %q, got %q", "Hello, World!", rec.Body.String())
+	}
+}
+
+// Test Header passthrough
+func TestUsageMetricsWriter_HeaderPassthrough(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+
+	wrapper.Header().Set("Content-Type", "application/json")
+	wrapper.Header().Set("X-Custom", "value")
+
+	if rec.Header().Get("Content-Type") != "application/json" {
+		t.Error("Content-Type header not passed through")
+	}
+	if rec.Header().Get("X-Custom") != "value" {
+		t.Error("Custom header not passed through")
+	}
+}
+
+// Mock a response that includes reading body and triggering usage extraction
+func TestUsageMetrics_FullRequestResponse(t *testing.T) {
+	// This test simulates what happens in a real request
+
+	// Create a mock backend server
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Simulated response with usage
+		io.WriteString(w, `{"id":"test","choices":[{"message":{"content":"Hi"}}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
+	}))
+	defer backend.Close()
+
+	// Verify response can be read
+	resp, err := http.Get(backend.URL)
+	if err != nil {
+		t.Fatalf("failed to get response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(body, []byte("usage")) {
+		t.Error("expected response to contain usage data")
+	}
+}


### PR DESCRIPTION
Tinfoil customers run EHBP proxy servers in front of their users. EHBP encrypts request/response bodies end-to-end, meaning the proxy cannot see token counts in the JSON body for billing purposes.

This PR adds an opt-in mechanism to expose token usage via HTTP headers (which are not encrypted).

New constants added:
1. `X-Tinfoil-Request-Usage-Metrics` -> client sets this
2. `X-Tinfoil-Usage-Metrics` -> router returns this

For the non-streaming path:
1. Buffer the entire JSON response (up to 10MB)
2. Parse `usage` from the JSON body
3. Set `X-Tinfoil-Usage-Metrics: prompt=X,completion=Y,total=Z` as a regular header
4. Restore the body for downstream

For streaming:
1. Announces the trailer: `Trailer: X-Tinfoil-Usage-Metrics`
2. Calls `wrapper.EnableTrailer()` to signal that usage should be sent as a trailer
3. The `usageHandler` callback stores usage on the wrapper when the final chunk is processed