### PR TITLE
chore: bump version

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,5 +1,5 @@
 shim-version: v0.3.12@sha256:b81f2295ae6750d61e94f810ce24077360001b6ec795d13643f3170df29e304d
-cvm-version: 0.6.2
+cvm-version: 0.6.6
 cpus: 8
 memory: 16384
 
@@ -9,6 +9,6 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.49"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.50"
     env:
       - DOMAIN


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps CVM to 0.6.6 and updates the proxy image to 0.0.50 to pick up latest fixes and maintain compatibility. No app behavior changes expected.

- **Dependencies**
  - cvm-version: 0.6.2 → 0.6.6
  - confidential-model-router: 0.0.49 → 0.0.50

<sup>Written for commit faab84a973536fa0c3ec171d8f07ea12102c1b2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

