### PR TITLE
chore: remove enclave for qwen3-coder-480b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,7 +30,6 @@ models:
   qwen3-coder-480b:
     repo: tinfoilsh/confidential-qwen3-coder-480b
     enclaves:
-      - qwen3-coder-480b.inf7.tinfoil.sh
 
   deepseek-r1-0528:
     repo: tinfoilsh/confidential-deepseek-r1-0528


### PR DESCRIPTION
Removed enclave entry for qwen3-coder-480b.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the enclave entry for qwen3-coder-480b from config.yml so this model no longer lists an enclave.

<sup>Written for commit 6498faa5df2b9ffb5a39788b30a6f9f9fcc70857. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

