### PR TITLE
Emit billing events for per-request models

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,11 +179,11 @@ func main() {
 				sendJSON(w, status)
 				return
 			} else if r.URL.Path == "/.well-known/prometheus-targets" {
-			// Prometheus HTTP service discovery endpoint
-			// See: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config
-			sendJSON(w, em.PrometheusTargets())
-			return
-		} else if r.URL.Path == "/metrics" {
+				// Prometheus HTTP service discovery endpoint
+				// See: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config
+				sendJSON(w, em.PrometheusTargets())
+				return
+			} else if r.URL.Path == "/metrics" {
 				// Expose Prometheus metrics
 				promhttp.Handler().ServeHTTP(w, r)
 				return
@@ -249,12 +249,14 @@ func main() {
 				useWebsearch := false
 				if _, ok := body["web_search_options"]; ok {
 					useWebsearch = true
-				} else if tools, ok := body["tools"].([]interface{}); ok {
-					useWebsearch = slices.ContainsFunc(tools, func(t any) bool {
-						m, _ := t.(map[string]any)
-						typeVal, ok := m["type"].(string)
-						return ok && typeVal == "web_search"
-					})
+				} else if r.URL.Path == "/v1/responses" {
+					if tools, ok := body["tools"].([]interface{}); ok {
+						useWebsearch = slices.ContainsFunc(tools, func(t any) bool {
+							m, _ := t.(map[string]any)
+							typeVal, ok := m["type"].(string)
+							return ok && typeVal == "web_search"
+						})
+					}
 				}
 				if useWebsearch {
 					r = r.WithContext(context.WithValue(r.Context(), manager.RequestModelKey{}, modelName))

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -27,6 +27,8 @@ const (
 	UsageMetricsResponseHeader = "X-Tinfoil-Usage-Metrics"
 	// maxUsageMetricsBodyBytes caps buffering for non-streaming usage extraction.
 	maxUsageMetricsBodyBytes = int64(10 << 20)
+	// websearchModel is charged per-request in addition to per-token.
+	websearchModel = "websearch"
 )
 
 // billingCloser wraps a response body and emits a zero-token billing event
@@ -127,6 +129,9 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 
 			// Add billing event
 			if billingCollector != nil {
+				if modelName == websearchModel {
+					emitZeroTokenEvent()
+				}
 				event := billing.Event{
 					Timestamp:        time.Now(),
 					UserID:           userID,

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -1,0 +1,132 @@
+package manager
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+
+	"github.com/tinfoilsh/confidential-model-router/billing"
+)
+
+func setupTestProxy(t *testing.T, handler http.Handler) (*httputil.ReverseProxy, *billing.Collector) {
+	t.Helper()
+	backend := httptest.NewServer(handler)
+	t.Cleanup(backend.Close)
+
+	backendURL, _ := url.Parse(backend.URL)
+	collector := billing.NewCollector("")
+	t.Cleanup(collector.Stop)
+
+	proxy := newProxy(backendURL.Host, "", "test-model", collector)
+	proxy.Director = func(req *http.Request) {
+		req.URL.Scheme = backendURL.Scheme
+		req.URL.Host = backendURL.Host
+	}
+	proxy.Transport = http.DefaultTransport
+
+	return proxy, collector
+}
+
+func TestProxyBilling_NonJSONEmitsEvent(t *testing.T) {
+	proxy, collector := setupTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("binary document data"))
+	}))
+
+	req := httptest.NewRequest("POST", "/v1/documents", nil)
+	req.Header.Set("Authorization", "Bearer test-key-1234567890")
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	events := collector.GetEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 billing event for non-JSON response, got %d", len(events))
+	}
+	e := events[0]
+	if e.PromptTokens != 0 || e.CompletionTokens != 0 || e.TotalTokens != 0 {
+		t.Errorf("expected zero-token event, got prompt=%d completion=%d total=%d",
+			e.PromptTokens, e.CompletionTokens, e.TotalTokens)
+	}
+	if e.Model != "test-model" {
+		t.Errorf("expected model %q, got %q", "test-model", e.Model)
+	}
+	if e.APIKey != "test-key-1234567890" {
+		t.Errorf("expected api key %q, got %q", "test-key-1234567890", e.APIKey)
+	}
+}
+
+func TestProxyBilling_JSONWithUsageEmitsSingleEvent(t *testing.T) {
+	proxy, collector := setupTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}`))
+	}))
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer test-key-1234567890")
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	events := collector.GetEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 billing event (no double-emit), got %d", len(events))
+	}
+	e := events[0]
+	if e.PromptTokens != 10 {
+		t.Errorf("expected prompt_tokens=10, got %d", e.PromptTokens)
+	}
+	if e.CompletionTokens != 20 {
+		t.Errorf("expected completion_tokens=20, got %d", e.CompletionTokens)
+	}
+	if e.TotalTokens != 30 {
+		t.Errorf("expected total_tokens=30, got %d", e.TotalTokens)
+	}
+}
+
+func TestProxyBilling_JSONWithoutUsageEmitsEvent(t *testing.T) {
+	proxy, collector := setupTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"text":"hello world"}`))
+	}))
+
+	req := httptest.NewRequest("POST", "/v1/audio/transcriptions", nil)
+	req.Header.Set("Authorization", "Bearer test-key-1234567890")
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	events := collector.GetEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 billing event for JSON without usage, got %d", len(events))
+	}
+	e := events[0]
+	if e.PromptTokens != 0 || e.CompletionTokens != 0 || e.TotalTokens != 0 {
+		t.Errorf("expected zero-token event, got prompt=%d completion=%d total=%d",
+			e.PromptTokens, e.CompletionTokens, e.TotalTokens)
+	}
+}
+
+func TestProxyBilling_ErrorResponseNoEvent(t *testing.T) {
+	proxy, collector := setupTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer test-key-1234567890")
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	events := collector.GetEvents()
+	if len(events) != 0 {
+		t.Fatalf("expected 0 billing events for error response, got %d", len(events))
+	}
+}

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -9,6 +9,6 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.50"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.51"
     env:
       - DOMAIN


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Emit billing events for per-request models that don’t return usage and for websearch. Add a zero-token per-request event and bill websearch tokens under the original model.

- **Bug Fixes**
  - Emit zero-token events when usage is missing or the response isn’t JSON; wrap non-streaming 200 OK responses to fire on Close only if usage wasn’t handled; dedupe to avoid double events.
  - For websearch, send a separate per-request zero-token event and bill token usage under the underlying model; detect web_search tools only on /v1/responses; keep the per-request event as model=websearch.

- **Dependencies**
  - Bump router image to ghcr.io/tinfoilsh/confidential-model-router:0.0.51.

<sup>Written for commit bb8fa2fc6e172e7e252df37706b5bec66c1fc4ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

