### PR TITLE
chore: update cvm

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,5 +1,5 @@
 shim-version: v0.3.12@sha256:b81f2295ae6750d61e94f810ce24077360001b6ec795d13643f3170df29e304d
-cvm-version: 0.6.6
+cvm-version: 0.6.7
 cpus: 8
 memory: 16384
 
@@ -9,6 +9,6 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.51"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.52"
     env:
       - DOMAIN


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped CVM from 0.6.6 to 0.6.7 and updated the proxy container to confidential-model-router 0.0.52 to pick up latest fixes. No other config changes.

<sup>Written for commit 9d97f4532f9bc1da4a9cb4ca1883ca0062dbe9cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

