### PR TITLE
chore: change enclave for qwen2-5-05b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -74,7 +74,7 @@ models:
   qwen2-5-05b:
     repo: tinfoilsh/confidential-qwen2-5-05b
     enclaves:
-      - qwen2-5-05b.inf5.tinfoil.sh
+      - title-model.tinfoil.functions.tinfoil.sh
 
   websearch:
     repo: tinfoilsh/confidential-websearch


### PR DESCRIPTION
Updated enclave entry for qwen2-5-05b in config.yml.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point qwen2-5-05b to the new enclave endpoint title-model.tinfoil.functions.tinfoil.sh. Routes requests to the correct functions deployment.

<sup>Written for commit e3b8d52a55b634abf5586b4dcb9e3126fdba6dd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

