### PR TITLE
chore: move some enclaves from inf5 to inf7

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -56,11 +56,6 @@ models:
     enclaves:
       - qwen3-vl-30b.inf7.tinfoil.sh
 
-  titan-qwen2-5-05b:
-    repo: tinfoilsh/confidential-titan-qwen2-5-05b
-    enclaves:
-      - titan-qwen2-5-05b.inf7.tinfoil.sh
-
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking
     enclaves:

--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,7 @@ models:
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - doc-upload.inf5.tinfoil.sh
+      - doc-upload.inf7.tinfoil.sh
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-whisper-large-v3
@@ -20,12 +20,12 @@ models:
   voxtral-small-24b:
     repo: tinfoilsh/confidential-voxtral-small-24b
     enclaves:
-      - voxtral-small-24b.inf5.tinfoil.sh
+      - voxtral-small-24b.inf7.tinfoil.sh
 
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
     enclaves:
-      - llama3-3-70b.inf5.tinfoil.sh
+      - llama3-3-70b.inf7.tinfoil.sh
 
   qwen3-coder-480b:
     repo: tinfoilsh/confidential-qwen3-coder-480b
@@ -39,27 +39,27 @@ models:
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
-      - gpt-oss-120b.inf5.tinfoil.sh
+      - gpt-oss-120b.inf7.tinfoil.sh
 
   gpt-oss-120b-free:
     repo: tinfoilsh/confidential-gpt-oss-120b-free
     enclaves:
-      - gpt-oss-120b-free.inf5.tinfoil.sh
+      - gpt-oss-120b-free.inf7.tinfoil.sh
 
   gpt-oss-safeguard-120b:
     repo: tinfoilsh/confidential-gpt-oss-safeguard-120b
     enclaves:
-      - gpt-oss-safeguard-120b.inf5.tinfoil.sh
+      - gpt-oss-safeguard-120b.inf7.tinfoil.sh
 
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.inf5.tinfoil.sh
+      - qwen3-vl-30b.inf7.tinfoil.sh
 
   titan-qwen2-5-05b:
     repo: tinfoilsh/confidential-titan-qwen2-5-05b
     enclaves:
-      - titan-qwen2-5-05b.inf5.tinfoil.sh
+      - titan-qwen2-5-05b.inf7.tinfoil.sh
 
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move seven model enclaves from inf5 to inf7 by updating hostnames in config.yml, and remove the titan-qwen2-5-05b config. Traffic for doc-upload, voxtral-small-24b, llama3-3-70b, gpt-oss-120b (standard/free/safeguard), and qwen3-vl-30b now routes to inf7 with no API changes.

<sup>Written for commit 6c0d27491f33b1937efec31de49d5c166fe5848a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

