### PR TITLE
chore: Update shim version to v0.3.17

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,4 +1,4 @@
-shim-version: v0.3.12@sha256:b81f2295ae6750d61e94f810ce24077360001b6ec795d13643f3170df29e304d
+shim-version: v0.3.17@sha256:6dff221ec3c4de5c4f44472bc21b47574b7d118902aaa0a55fd367eeaa1f33c5
 cvm-version: 0.6.7
 cpus: 8
 memory: 16384


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Tinfoil shim to v0.3.17 (sha256:6dff221ec3c4de5c4f44472bc21b47574b7d118902aaa0a55fd367eeaa1f33c5) in tinfoil-config.yml to pick up the latest upstream fixes.

<sup>Written for commit cdcd9acf0278455e042036c219ec2def129d3bd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

