### PR TITLE
fix: update verifier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
-	github.com/tinfoilsh/verifier v0.11.2
+	github.com/tinfoilsh/verifier v0.11.3
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/theupdateframework/go-tuf/v2 v2.4.1 h1:K6ewW064rKZCPkRo1W/CTbTtm/+IB4
 github.com/theupdateframework/go-tuf/v2 v2.4.1/go.mod h1:Nex2enPVYDFCklrnbTzl3OVwD7fgIAj0J5++z/rvCj8=
 github.com/tinfoilsh/go-sev-guest v0.0.0-20250704193550-c725e6216008 h1:utg5iGJKOGTefc5gWxH2+XaXpra8R1utGA3x1WO61AY=
 github.com/tinfoilsh/go-sev-guest v0.0.0-20250704193550-c725e6216008/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
-github.com/tinfoilsh/verifier v0.11.2 h1:rGSoyJTrY9TlnySng3zcTyN1nw1OtU1SiqRjGAtqax4=
-github.com/tinfoilsh/verifier v0.11.2/go.mod h1:DuRa6ryH0eAPzyRvzCWoODEAcRsDYFNZdhDWciNndsw=
+github.com/tinfoilsh/verifier v0.11.3 h1:Jo/J8CpteU2tD9P65DDBhGvipsYiVdiF8yIZTQVLA0s=
+github.com/tinfoilsh/verifier v0.11.3/go.mod h1:DuRa6ryH0eAPzyRvzCWoODEAcRsDYFNZdhDWciNndsw=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -9,6 +9,6 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.52"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.53"
     env:
       - DOMAIN


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update verifier to v0.11.3 and router image to v0.0.53 to pull in recent fixes and keep dependencies current.

- **Dependencies**
  - github.com/tinfoilsh/verifier: v0.11.2 → v0.11.3
  - ghcr.io/tinfoilsh/confidential-model-router: 0.0.52 → 0.0.53

<sup>Written for commit 9441c6180875e20d640e0ba8645af9bae12a6bef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

