### PR TITLE
chore: use inf6 backup

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -25,7 +25,7 @@ models:
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
     enclaves:
-      - llama3-3-70b.inf7.tinfoil.sh
+      - llama3-3-70b.inf6.tinfoil.sh
 
   qwen3-coder-480b:
     repo: tinfoilsh/confidential-qwen3-coder-480b
@@ -39,12 +39,12 @@ models:
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
-      - gpt-oss-120b.inf7.tinfoil.sh
+      - gpt-oss-120b.inf6.tinfoil.sh
 
   gpt-oss-120b-free:
     repo: tinfoilsh/confidential-gpt-oss-120b-free
     enclaves:
-      - gpt-oss-120b-free.inf7.tinfoil.sh
+      - gpt-oss-120b-free.inf6.tinfoil.sh
 
   gpt-oss-safeguard-120b:
     repo: tinfoilsh/confidential-gpt-oss-safeguard-120b


### PR DESCRIPTION
Switch GPT-OSS and Llama to inf6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated model enclave hosts to use inf6 for Llama3-3-70b and GPT-OSS 120b (paid and free). This moves traffic off inf7 to the backup cluster for stability.

- **Migration**
  - Deploy the updated config; no other changes needed.

<sup>Written for commit cb3d34838591ef713f631a06d42f6d6a84aee528. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

