### PR TITLE
nit: enable TLS wildcard in tinfoil-config

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -6,6 +6,7 @@ memory: 16384
 shim:
   listen-port: 443
   upstream-port: 8089
+  tls-wildcard: true
 
 containers:
   - name: "proxy"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable TLS wildcard in tinfoil-config so the shim accepts *.domain TLS and routes subdomains on 443 to 8089. This allows handling multiple subdomains without per-host certificates.

<sup>Written for commit c72994a09aa0df9eaa301c2d8c6c50be1d6ad878. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

