### PR TITLE
chore: move enclaves back from inf7=>inf5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,7 @@ models:
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - doc-upload.inf7.tinfoil.sh
+      - doc-upload.inf5.tinfoil.sh
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-whisper-large-v3
@@ -20,12 +20,12 @@ models:
   voxtral-small-24b:
     repo: tinfoilsh/confidential-voxtral-small-24b
     enclaves:
-      - voxtral-small-24b.inf7.tinfoil.sh
+      - voxtral-small-24b.inf5.tinfoil.sh
 
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
     enclaves:
-      - llama3-3-70b.inf6.tinfoil.sh
+      - llama3-3-70b.inf5.tinfoil.sh
 
   qwen3-coder-480b:
     repo: tinfoilsh/confidential-qwen3-coder-480b
@@ -39,22 +39,22 @@ models:
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
-      - gpt-oss-120b.inf6.tinfoil.sh
+      - gpt-oss-120b.inf5.tinfoil.sh
 
   gpt-oss-120b-free:
     repo: tinfoilsh/confidential-gpt-oss-120b-free
     enclaves:
-      - gpt-oss-120b-free.inf6.tinfoil.sh
+      - gpt-oss-120b-free.inf5.tinfoil.sh
 
   gpt-oss-safeguard-120b:
     repo: tinfoilsh/confidential-gpt-oss-safeguard-120b
     enclaves:
-      - gpt-oss-safeguard-120b.inf7.tinfoil.sh
+      - gpt-oss-safeguard-120b.inf5.tinfoil.sh
 
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.inf7.tinfoil.sh
+      - qwen3-vl-30b.inf5.tinfoil.sh
 
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch enclave endpoints to inf5 for seven models to route traffic back to inf5. Replaces inf6/inf7 hostnames with inf5 for: doc-upload, voxtral-small-24b, llama3-3-70b, gpt-oss-120b, gpt-oss-120b-free, gpt-oss-safeguard-120b, qwen3-vl-30b.

<sup>Written for commit 3d4f682f241ce2606209bba33dc52be5afb68194. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

