### PR TITLE
chore: delete qwen3-coder-480b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -27,10 +27,6 @@ models:
     enclaves:
       - llama3-3-70b.inf6.tinfoil.sh
 
-  qwen3-coder-480b:
-    repo: tinfoilsh/confidential-qwen3-coder-480b
-    enclaves:
-
   deepseek-r1-0528:
     repo: tinfoilsh/confidential-deepseek-r1-0528
     enclaves:


### PR DESCRIPTION
Removed qwen3-coder-480b configuration from YAML.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the qwen3-coder-480b model from config.yml. Cleans up unused config and avoids references to a retired repo.

<sup>Written for commit e0e7f2f3ca972d2405c1881c0f2feddbecee5a6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

