### PR TITLE
chore: Update proxy image version to 0.0.54

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,6 +10,6 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.53"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.54"
     env:
       - DOMAIN


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps the proxy image in tinfoil-config.yml to ghcr.io/tinfoilsh/confidential-model-router:0.0.54. Ensures deployments use the latest router build for current fixes and compatibility.

<sup>Written for commit ef13c989776eea92d7429fbb435fbe476acf1b19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

