### PR TITLE
chore: move deepseek-r1-0528

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,7 +30,7 @@ models:
   deepseek-r1-0528:
     repo: tinfoilsh/confidential-deepseek-r1-0528
     enclaves:
-      - deepseek-r1-0528.inf9.tinfoil.sh
+      - deepseek-r1-0528.inf7.tinfoil.sh
 
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b


### PR DESCRIPTION
Updated enclave hostname for deepseek-r1-0528.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move deepseek-r1-0528 to the inf7 enclave by updating its hostname in config.yml, shifting traffic from inf9 to the new host. No functional changes; requests now route to the new deployment.

<sup>Written for commit 3383e9bb72f177f5c1f30c613f843b2769d99b1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

