### PR TITLE
chore: update proxy image version to 0.0.55

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,6 +10,6 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.54"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.55"
     env:
       - DOMAIN


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the proxy container image in tinfoil-config.yml from 0.0.54 to 0.0.55 to use the latest confidential-model-router release.

<sup>Written for commit 49dbcb4dbc089cb8f9cfcf3f93ee310c43d6a4f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

