### PR TITLE
fix: data race in enclave manager sync errors

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -243,13 +243,13 @@ func (em *EnclaveManager) Shutdown() {
 
 // NextEnclave gets the next sequential enclave
 func (m *Model) NextEnclave() *Enclave {
-	if len(m.Enclaves) == 0 {
-		return nil
-	}
-
 	count := atomic.AddUint64(&m.counter, 1)
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	if len(m.Enclaves) == 0 {
+		return nil
+	}
 
 	// Convert map to slice for indexed access
 	enclaves := make([]*Enclave, 0, len(m.Enclaves))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed data races in EnclaveManager: guarded the errors slice with a mutex, made Status return a copy, and locked sync/worker mutations. Also fixed NextEnclave by reading the enclaves map under RLock to prevent concurrent access and panics.

<sup>Written for commit 5d46eafb3185bbbe00a28a6ac375ef342d6f07f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

