### PR TITLE
fix: configure refresh interval to 5m

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -13,3 +13,4 @@ containers:
     image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.55"
     env:
       - DOMAIN
+      - REFRESH_INTERVAL=5m


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Configured the confidential-model-router to refresh every 5 minutes by adding REFRESH_INTERVAL=5m to tinfoil-config.yml.

<sup>Written for commit ca1084763062866e232ec2529fce28a8aa325100. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

