### PR TITLE
fix: make refresh interval default 5m

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ var (
 	initConfigURL   = flag.String("i", getEnvOrDefault("INIT_CONFIG_URL", ""), "optional path to initial config.yml (requires to append @sha256:<hex> for integrity) (env: INIT_CONFIG_URL)")
 	updateConfigURL = flag.String("u", getEnvOrDefault("UPDATE_CONFIG_URL", "https://raw.githubusercontent.com/tinfoilsh/confidential-model-router/main/config.yml"), "path to runtime config.yml (env: UPDATE_CONFIG_URL)")
 	domain          = flag.String("d", getEnvOrDefault("DOMAIN", "localhost"), "domain used by this router (env: DOMAIN)")
-	refreshInterval = flag.Duration("r", getEnvOrDefaultDuration("REFRESH_INTERVAL", 5*time.Second), "refresh interval for syncing enclave config (env: REFRESH_INTERVAL)")
+	refreshInterval = flag.Duration("r", getEnvOrDefaultDuration("REFRESH_INTERVAL", 5*time.Minute), "refresh interval for syncing enclave config (env: REFRESH_INTERVAL)")
 )
 
 func jsonError(w http.ResponseWriter, message string, code int) {

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,7 +10,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.55"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.56"
     env:
       - DOMAIN
       - REFRESH_INTERVAL=5m


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the default enclave config refresh interval from 5 seconds to 5 minutes to reduce polling, network traffic, and log noise. Also bump the router image in tinfoil-config.yml to 0.0.56; you can still override the interval via -r or REFRESH_INTERVAL.

<sup>Written for commit 398ff6c18488a8d692f76146c1696c80fd0d0e05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

