### PR TITLE
feat: openai compatible error format

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ var (
 	domain          = flag.String("d", getEnvOrDefault("DOMAIN", "localhost"), "domain used by this router (env: DOMAIN)")
 )
 
-func jsonError(w http.ResponseWriter, message string, code int) {
+func jsonError(w http.ResponseWriter, message string, errType string, code int) {
 	switch {
 	case code >= 500:
 		log.Errorf("jsonError: %s", message)
@@ -67,15 +67,18 @@ func jsonError(w http.ResponseWriter, message string, code int) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(map[string]string{
-		"error": message,
+	json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{
+			"message": message,
+			"type":    errType,
+		},
 	})
 }
 
 func sendJSON(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(data); err != nil {
-		jsonError(w, err.Error(), http.StatusInternalServerError)
+		jsonError(w, err.Error(), manager.ErrTypeServer, http.StatusInternalServerError)
 	}
 }
 
@@ -167,7 +170,7 @@ func main() {
 		var err error
 
 		if modelName, err = parseModelFromSubdomain(r, *domain); err != nil {
-			jsonError(w, fmt.Sprintf("failed to parse subdomain: %v", err), http.StatusBadRequest)
+			jsonError(w, fmt.Sprintf("failed to parse subdomain: %v", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 			return
 		} else if modelName == "" { // The request does not use a subdomain. We route using specific inference routing logic.
 			if r.URL.Path == "/" {
@@ -192,12 +195,12 @@ func main() {
 				defer cancel()
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, *controlPlaneURL+"/v1/models", nil)
 				if err != nil {
-					jsonError(w, fmt.Sprintf("failed to create request: %v", err), http.StatusInternalServerError)
+					jsonError(w, fmt.Sprintf("failed to create request: %v", err), manager.ErrTypeServer, http.StatusInternalServerError)
 					return
 				}
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
-					jsonError(w, fmt.Sprintf("failed to fetch models: %v", err), http.StatusBadGateway)
+					jsonError(w, fmt.Sprintf("failed to fetch models: %v", err), manager.ErrTypeServer, http.StatusBadGateway)
 					return
 				}
 				defer resp.Body.Close()
@@ -210,7 +213,7 @@ func main() {
 				var bodyBytes []byte
 				modelName, bodyBytes, err = extractModelFromMultipart(r)
 				if err != nil {
-					jsonError(w, fmt.Sprintf("failed to parse request: %v", err), http.StatusBadRequest)
+					jsonError(w, fmt.Sprintf("failed to parse request: %v", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
 				if modelName == "" {
@@ -224,23 +227,23 @@ func main() {
 				bodyBytes, err := io.ReadAll(r.Body)
 
 				if err != nil {
-					jsonError(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusBadRequest)
+					jsonError(w, fmt.Sprintf("failed to read request body: %v", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
 				if err := json.Unmarshal(bodyBytes, &body); err != nil {
-					jsonError(w, fmt.Sprintf("failed to parse request body: %v", err), http.StatusBadRequest)
+					jsonError(w, fmt.Sprintf("failed to parse request body: %v", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
 
 				// Extract model name from request body
 				modelInterface, ok := body["model"]
 				if !ok {
-					jsonError(w, "model parameter not found in request body", http.StatusBadRequest)
+					jsonError(w, "model parameter not found in request body", manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
 				modelName, ok = modelInterface.(string)
 				if !ok {
-					jsonError(w, "model parameter must be a string", http.StatusBadRequest)
+					jsonError(w, "model parameter must be a string", manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
 
@@ -292,7 +295,7 @@ func main() {
 					// Re-encode the modified body
 					newBodyBytes, err := json.Marshal(body)
 					if err != nil {
-						jsonError(w, fmt.Sprintf("failed to process request body: %v", err), http.StatusInternalServerError)
+						jsonError(w, fmt.Sprintf("failed to process request body: %v", err), manager.ErrTypeServer, http.StatusInternalServerError)
 						return
 					}
 					bodyBytes = newBodyBytes
@@ -309,13 +312,13 @@ func main() {
 
 		model, found := em.GetModel(modelName)
 		if !found {
-			jsonError(w, "model not found", http.StatusNotFound)
+			jsonError(w, "model not found", manager.ErrTypeInvalidRequest, http.StatusNotFound)
 			return
 		}
 
 		enclave := model.NextEnclave()
 		if enclave == nil {
-			jsonError(w, "no enclaves available", http.StatusServiceUnavailable)
+			jsonError(w, "no enclaves available", manager.ErrTypeServer, http.StatusServiceUnavailable)
 			return
 		}
 
@@ -336,7 +339,7 @@ func main() {
 			manager.RequestsRejectedTotal.WithLabelValues(modelName).Inc()
 			manager.RetryAfterSeconds.WithLabelValues(modelName).Observe(float64(secs))
 
-			jsonError(w, fmt.Sprintf("backend overloaded, retry after %d seconds", secs), http.StatusTooManyRequests)
+			jsonError(w, fmt.Sprintf("backend overloaded, retry after %d seconds", secs), manager.ErrTypeInvalidRequest, http.StatusTooManyRequests)
 			return
 		}
 

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -38,6 +38,14 @@ const (
 	ErrTypeServer            = "server_error"
 )
 
+// Client-facing error messages, aligned with OpenAI's standard error messages
+// where applicable. See https://platform.openai.com/docs/guides/error-codes
+const (
+	ErrMsgServerError   = "The server had an error while processing your request."
+	ErrMsgOverloaded    = "The engine is currently overloaded, please try again later."
+	ErrMsgModelNotFound = "The model does not exist."
+)
+
 // RequestModelKey stores the model name extracted from the request body,
 // used to bill token usage under the underlying model for tool requests.
 type RequestModelKey struct{}
@@ -80,7 +88,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 		w.WriteHeader(http.StatusBadGateway)
 		json.NewEncoder(w).Encode(map[string]any{
 			"error": map[string]string{
-				"message": "upstream enclave unavailable",
+				"message": ErrMsgServerError,
 				"type":    ErrTypeServer,
 			},
 		})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make error responses OpenAI-compatible across the router and proxy. Standardize the error object and client-facing messages for better compatibility.

- **New Features**
  - Added OpenAI error type constants: invalid_request_error, insufficient_quota, server_error.
  - Updated jsonError to accept an error type and return {"error": {"message": "...", "type": "..."}}; applied across request paths with OpenAI-aligned messages (invalid body, missing/invalid params, model not found, overloaded, server errors).
  - Implemented proxy.ErrorHandler to return a consistent 502 payload using server_error and the standard server message.

- **Migration**
  - Update clients to read error.message and error.type instead of a plain error string.
  - HTTP status codes are unchanged.

<sup>Written for commit fb852fbddafb6c5f78420492b676f59933a5e1e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

