### PR TITLE
chore: update proxy image version and refresh interval

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,7 +10,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.56"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.57"
     env:
       - DOMAIN
-      - REFRESH_INTERVAL=5m
+      - REFRESH_INTERVAL=1m


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the proxy container to ghcr.io/tinfoilsh/confidential-model-router:0.0.57 and changed REFRESH_INTERVAL from 5m to 1m to get the latest router fixes and refresh configs faster.

<sup>Written for commit 4896c43c59d531d13e486a3e407e024e9989eac7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

