### PR TITLE
chore: update shim version to v0.3.18

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,4 +1,4 @@
-shim-version: v0.3.17@sha256:6dff221ec3c4de5c4f44472bc21b47574b7d118902aaa0a55fd367eeaa1f33c5
+shim-version: v0.3.18@sha256:7d9f98be78c91ede89f43c948a12d084fae34312effe9395ca7ed572991cb561
 cvm-version: 0.6.7
 cpus: 8
 memory: 16384


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update shim-version in tinfoil-config.yml from v0.3.17 to v0.3.18 to pull in the latest upstream fixes and stability improvements. Uses the new image digest (sha256:7d9f98be...) for reproducible builds; no app behavior changes expected.

<sup>Written for commit a33c1c147769caa4dad901fcb27b68568745c270. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

