### PR TITLE
chore: change enclave for doc-upload

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,7 @@ models:
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - doc-upload.inf5.tinfoil.sh
+      - confidential-doc-upload.tinfoil.containers.tinfoil.sh
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-whisper-large-v3


### PR DESCRIPTION
Updated the enclave for doc-upload configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the doc-upload enclave hostname to confidential-doc-upload.tinfoil.containers.tinfoil.sh to match the new infrastructure.
This ensures deployments route to the correct confidential container endpoint.

<sup>Written for commit 3fc37a8e868b532a227866ed8408cdf25cca138c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

