### PR TITLE
chore: change enclave domain for nomic-embed-text model

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,7 +5,7 @@ models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:
-      - nomic-embed-text.inf6.tinfoil.sh
+      - confidential-nomic-embed-text.tinfoil.containers.tinfoil.sh
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload


### PR DESCRIPTION
Updated enclave for nomic-embed-text model to use new domain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the enclave domain for the nomic-embed-text model to confidential-nomic-embed-text.tinfoil.containers.tinfoil.sh. This points traffic to the new containers enclave and keeps config in sync with current infrastructure.

<sup>Written for commit ccc80929b954c39567c3a33e0fcc730e20afd9e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

