### PR TITLE
chore: change REFRESH_INTERVAL format in tinfoil-config.yml

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -13,4 +13,4 @@ containers:
     image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.57"
     env:
       - DOMAIN
-      - REFRESH_INTERVAL=1m
+      - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed REFRESH_INTERVAL env var syntax in tinfoil-config.yml by switching from inline assignment to YAML key/value (REFRESH_INTERVAL: "1m"). This avoids parsing issues and ensures the container receives the correct interval.

<sup>Written for commit 8413b8ceae1142a7dacc0338da6f5899de26365b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

