### PR TITLE
chore: log refresh interval during initialization

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,6 +170,7 @@ func main() {
 	}
 
 	log.Debugf("Configuration: domain=%s, port=%s, controlPlaneURL=%s", *domain, *port, *controlPlaneURL)
+	log.Infof("Refresh interval: %s", *refreshInterval)
 
 	em, err := manager.NewEnclaveManager(configFile, *controlPlaneURL, *initConfigURL, *updateConfigURL, *refreshInterval)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Log the refresh interval during initialization to make configuration visible and simplify debugging.

<sup>Written for commit 1a712e7f36bccbd97f52a3eada9067519a7e0d59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

