### PR TITLE
chore: Update proxy image version to 0.0.59

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,7 +10,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.57"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.59"
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the proxy container image in tinfoil-config.yml from 0.0.57 to 0.0.59 to use the latest confidential-model-router release.

<sup>Written for commit 705fb29eaf076ee466c854f3d8c5f1a0f62bb8cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

