### PR TITLE
chore: change enclave domain for kimi-k2-thinking

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -55,7 +55,7 @@ models:
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking
     enclaves:
-      - kimi-k2-thinking.inf10.tinfoil.sh
+      - kimi-k2-thinking.inf9.tinfoil.sh
 
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated kimi-k2-thinking enclave domain from kimi-k2-thinking.inf10.tinfoil.sh to kimi-k2-thinking.inf9.tinfoil.sh to route deployments to the correct environment.

<sup>Written for commit 82f4da5fc4b7afc7fa72d03f3a23645841fb4bb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

