### PR TITLE
Add speech endpoint

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -47,7 +47,7 @@ models:
     enclaves:
       - gpt-oss-safeguard-120b.inf5.tinfoil.sh
 
-  qwen3-tts-1.7b:
+  qwen3-tts:
     repo: tinfoilsh/confidential-qwen3-tts
     enclaves:
       - qwen3-tts.inf6.tinfoil.sh

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,7 +10,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.59"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.61"
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an OpenAI-compatible /v1/audio/speech endpoint for text-to-speech. Uses the model from the JSON body or defaults to qwen3-tts; updates config naming and router image.

- New Features
  - Add /v1/audio/speech handler that reads model from JSON body; defaults to qwen3-tts.
  - Rename model key qwen3-tts-1.7b to qwen3-tts to match repo/enclave for routing.

- Dependencies
  - Bump confidential-model-router image to 0.0.61.

<sup>Written for commit e53437ef7a913a6a424f7c159dc30b1553909989. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

