### PR TITLE
chore: add new router configuration for inf5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,6 @@
 routers:
   inference.tinfoil.sh:
+  router.inf5.tinfoil.sh:
 
 models:
   nomic-embed-text:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add router.inf5.tinfoil.sh to the routers list in config.yml to enable routing for the INF5 environment.
No other changes.

<sup>Written for commit 9c7cfb98494934b6a457f51d0ce4ff8ba9d1e8a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

