### PR TITLE
chore: update kimi-k2-thinking

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -61,7 +61,7 @@ models:
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking
     enclaves:
-      - kimi-k2-thinking.inf9.tinfoil.sh
+      - kimi-k2-thinking.tinfoil.containers.tinfoil.dev
 
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch enclave hostname for the kimi-k2-thinking model in config.yml to kimi-k2-thinking.tinfoil.containers.tinfoil.dev. Ensures the model points to the new containers domain and avoids routing issues.

<sup>Written for commit 01f8011d608cd42b922e3160b8678396c6445c0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

