### PR TITLE
fix: prevent double-billing for websearch requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -260,8 +260,9 @@ func main() {
 					return
 				}
 
-				// Check if request uses web search — route to websearch enclave
-				// but keep modelName as the underlying model for billing.
+				// Check if request uses web search — route to websearch enclave.
+				// The original model name is preserved in the request body so the
+				// websearch service knows which model to use for inference.
 				useWebsearch := false
 				if _, ok := body["web_search_options"]; ok {
 					useWebsearch = true
@@ -275,7 +276,6 @@ func main() {
 					}
 				}
 				if useWebsearch {
-					r = r.WithContext(context.WithValue(r.Context(), manager.RequestModelKey{}, modelName))
 					modelName = "websearch"
 				}
 

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -46,10 +46,6 @@ const (
 	ErrMsgModelNotFound = "The model does not exist."
 )
 
-// RequestModelKey stores the model name extracted from the request body,
-// used to bill token usage under the underlying model for tool requests.
-type RequestModelKey struct{}
-
 // billingCloser wraps a response body and emits a zero-token billing event
 // on Close() if the usageHandler was never called. This ensures per-request
 // models (e.g. docling, whisper) that don't return usage fields still
@@ -160,28 +156,27 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 			// Add billing event
 			if billingCollector != nil {
 				if modelName == websearchModel {
+					// Only emit the per-request websearch fee. Skip the
+					// token-based event because the websearch service's
+					// responder call goes through the proxy with the
+					// user's API key and gets billed there directly.
 					emitZeroTokenEvent()
+				} else {
+					event := billing.Event{
+						Timestamp:        time.Now(),
+						UserID:           userID,
+						APIKey:           apiKey,
+						Model:            modelName,
+						PromptTokens:     usage.PromptTokens,
+						CompletionTokens: usage.CompletionTokens,
+						TotalTokens:      usage.TotalTokens,
+						RequestID:        requestID,
+						Enclave:          host,
+						RequestPath:      requestPath,
+						Streaming:        streaming,
+					}
+					billingCollector.AddEvent(event)
 				}
-				// Use the underlying model for token billing when set (e.g., websearch
-				// bills tokens under the model specified in the inference request).
-				billingModel := modelName
-				if bm, ok := req.Context().Value(RequestModelKey{}).(string); ok && bm != "" {
-					billingModel = bm
-				}
-				event := billing.Event{
-					Timestamp:        time.Now(),
-					UserID:           userID,
-					APIKey:           apiKey,
-					Model:            billingModel,
-					PromptTokens:     usage.PromptTokens,
-					CompletionTokens: usage.CompletionTokens,
-					TotalTokens:      usage.TotalTokens,
-					RequestID:        requestID,
-					Enclave:          host,
-					RequestPath:      requestPath,
-					Streaming:        streaming,
-				}
-				billingCollector.AddEvent(event)
 			}
 		}
 

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -1,7 +1,6 @@
 package manager
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -136,7 +135,7 @@ func TestProxyBilling_ErrorResponseNoEvent(t *testing.T) {
 	}
 }
 
-func TestProxyBilling_WebsearchEmitsTwoEvents(t *testing.T) {
+func TestProxyBilling_WebsearchEmitsOnlyZeroTokenEvent(t *testing.T) {
 	proxy, collector := setupTestProxyWithModel(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -145,31 +144,23 @@ func TestProxyBilling_WebsearchEmitsTwoEvents(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
 	req.Header.Set("Authorization", "Bearer test-key-1234567890")
-	req = req.WithContext(context.WithValue(req.Context(), RequestModelKey{}, "deepseek-r1-0528"))
 	rec := httptest.NewRecorder()
 
 	proxy.ServeHTTP(rec, req)
 
 	events := collector.GetEvents()
-	if len(events) != 2 {
-		t.Fatalf("expected 2 billing events for websearch, got %d", len(events))
+	if len(events) != 1 {
+		t.Fatalf("expected 1 billing event for websearch (zero-token only), got %d", len(events))
 	}
 
-	// First event: zero-token per-request event billed as "websearch"
+	// Only the zero-token per-request event billed as "websearch".
+	// Token usage is billed when the responder calls the underlying
+	// model through the proxy with the user's API key.
 	if events[0].PromptTokens != 0 || events[0].CompletionTokens != 0 || events[0].TotalTokens != 0 {
-		t.Errorf("expected first event to be zero-token, got prompt=%d completion=%d total=%d",
+		t.Errorf("expected zero-token event, got prompt=%d completion=%d total=%d",
 			events[0].PromptTokens, events[0].CompletionTokens, events[0].TotalTokens)
 	}
 	if events[0].Model != websearchModel {
-		t.Errorf("expected first event model %q, got %q", websearchModel, events[0].Model)
-	}
-
-	// Second event: token usage billed under the underlying model
-	if events[1].PromptTokens != 5 || events[1].CompletionTokens != 15 || events[1].TotalTokens != 20 {
-		t.Errorf("expected second event with tokens, got prompt=%d completion=%d total=%d",
-			events[1].PromptTokens, events[1].CompletionTokens, events[1].TotalTokens)
-	}
-	if events[1].Model != "deepseek-r1-0528" {
-		t.Errorf("expected second event model %q, got %q", "deepseek-r1-0528", events[1].Model)
+		t.Errorf("expected event model %q, got %q", websearchModel, events[0].Model)
 	}
 }


### PR DESCRIPTION
 The proxy was emitting both a zero-token websearch fee and a token-usage
 event, but the websearch enclave's responder call already generates its
 own token-usage event through the proxy resulting in tokens being
 billed twice. Now the proxy only emits the per-request websearch fee and
 lets the responder's callback handle token billing.