### PR TITLE
chore: bump container

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,7 +10,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.61"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.63"
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade the proxy container image to ghcr.io/tinfoilsh/confidential-model-router:0.0.63 in tinfoil-config.yml (was 0.0.61). This pulls the latest router fixes and keeps us on the current upstream release.

<sup>Written for commit cac7952eadcb66f5532f6328b0b388f43d0f4599. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

