### PR TITLE
chore: enclave address for llama3-3-70b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -26,7 +26,7 @@ models:
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
     enclaves:
-      - llama3-3-70b.inf5.tinfoil.sh
+      - llama3-3-70b.tinfoil.containers.tinfoil.dev
 
   deepseek-r1-0528:
     repo: tinfoilsh/confidential-deepseek-r1-0528


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update llama3-3-70b enclave host in config.yml to llama3-3-70b.tinfoil.containers.tinfoil.dev. Ensures traffic routes to the correct containerized enclave.

<sup>Written for commit 32d95660d578d5718e877f8986f3189ded13ce83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

