### PR TITLE
fix: reintroduce rate limiting

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -67,6 +67,8 @@ models:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
       - kimi-k2-5.inf8.tinfoil.sh
+    rate_limit:
+      max_requests_per_minute: 4
 
   qwen2-5-05b:
     repo: tinfoilsh/confidential-qwen2-5-05b

--- a/config/config.go
+++ b/config/config.go
@@ -13,11 +13,19 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// RateLimitConfig describes optional per-API-key request rate limits for a model.
+// When configured, requests from API keys that exceed the per-minute budget
+// are sent to vLLM with a lower scheduling priority.
+type RateLimitConfig struct {
+	MaxRequestsPerMinute int64 `yaml:"max_requests_per_minute"`
+}
+
 // Model represents the configuration for a single model
 type Model struct {
-	Repo      string          `yaml:"repo"`
-	Hostnames []string        `yaml:"enclaves"`
-	Overload  *OverloadConfig `yaml:"overload,omitempty"`
+	Repo      string           `yaml:"repo"`
+	Hostnames []string         `yaml:"enclaves"`
+	Overload  *OverloadConfig  `yaml:"overload,omitempty"`
+	RateLimit *RateLimitConfig `yaml:"rate_limit,omitempty"`
 }
 
 // OverloadConfig describes optional overload thresholds for a model.

--- a/main.go
+++ b/main.go
@@ -183,6 +183,12 @@ func main() {
 		var modelName string
 		var err error
 
+		// Extract API key early for rate limiting decisions
+		apiKey := ""
+		if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+			apiKey = strings.TrimPrefix(auth, "Bearer ")
+		}
+
 		if modelName, err = parseModelFromSubdomain(r, *domain); err != nil {
 			jsonError(w, fmt.Sprintf("Invalid request: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 			return
@@ -295,8 +301,27 @@ func main() {
 						})
 					}
 				}
+				rateLimitModel := modelName
 				if useWebsearch {
 					modelName = "websearch"
+				}
+
+				// Strip any user-supplied priority to prevent circumventing rate limits
+				// or jumping ahead of other users.
+				_, hadPriority := body["priority"]
+				delete(body, "priority")
+
+				// Check rate limiting and inject lower vLLM priority if over budget
+				bodyModified := hadPriority
+				if rlCfg := em.GetRateLimitConfig(rateLimitModel); rlCfg != nil {
+					if apiKey != "" && em.RequestTracker().RecordAndCheck(apiKey, rateLimitModel, rlCfg.MaxRequestsPerMinute) {
+						body["priority"] = 1
+						bodyModified = true
+						manager.RateLimitDemotionsTotal.WithLabelValues(rateLimitModel).Inc()
+						log.WithFields(log.Fields{
+							"model": rateLimitModel,
+						}).Debug("rate limited: injecting lower vLLM priority")
+					}
 				}
 
 				// If streaming request, ensure continuous_usage_stats is enabled
@@ -336,6 +361,18 @@ func main() {
 					r.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
 					r.ContentLength = int64(len(bodyBytes))
 					log.Debugf("Modified streaming request body to include continuous_usage_stats, client requested usage: %v", clientRequestedUsage)
+				}
+
+				// Re-encode body if rate limiting modified it (non-streaming path)
+				if bodyModified {
+					newBodyBytes, err := json.Marshal(body)
+					if err != nil {
+						jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusInternalServerError)
+						return
+					}
+					bodyBytes = newBodyBytes
+					r.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
+					r.ContentLength = int64(len(bodyBytes))
 				}
 
 				r.Body.Close()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/tinfoilsh/confidential-model-router/billing"
 	"github.com/tinfoilsh/confidential-model-router/config"
+	"github.com/tinfoilsh/confidential-model-router/ratelimit"
 )
 
 type Enclave struct {
@@ -37,6 +38,7 @@ type Model struct {
 	SourceMeasurement *attestation.Measurement `json:"measurement"`
 	Enclaves          map[string]*Enclave      `json:"enclaves"`
 	Overload          *config.OverloadConfig   `json:"overload,omitempty"`
+	RateLimit         *config.RateLimitConfig  `json:"rate_limit,omitempty"`
 
 	counter uint64
 	mu      sync.RWMutex
@@ -48,6 +50,7 @@ type EnclaveManager struct {
 	updateConfigURL      string
 	sigstoreClient       *sigstore.Client
 	billingCollector     *billing.Collector
+	requestTracker       *ratelimit.RequestTracker
 	refreshInterval      time.Duration
 	errorsMu             sync.Mutex
 	errors               []string
@@ -68,6 +71,22 @@ func (em *EnclaveManager) GetModel(modelName string) (*Model, bool) {
 		return nil, false
 	}
 	return model.(*Model), true
+}
+
+// RequestTracker returns the shared request tracker for rate limiting.
+func (em *EnclaveManager) RequestTracker() *ratelimit.RequestTracker {
+	return em.requestTracker
+}
+
+// GetRateLimitConfig returns the rate limit config for a model, or nil if not configured.
+func (em *EnclaveManager) GetRateLimitConfig(modelName string) *config.RateLimitConfig {
+	model, found := em.GetModel(modelName)
+	if !found {
+		return nil
+	}
+	model.mu.RLock()
+	defer model.mu.RUnlock()
+	return model.RateLimit
 }
 
 // attestationFetch retrieves the attestation document from a given enclave hostname.
@@ -339,6 +358,7 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, initConfigURL 
 		updateConfigURL:  updateConfigURL,
 		sigstoreClient:   sigstoreClient,
 		billingCollector: billing.NewCollector(controlPlaneURL),
+		requestTracker:   ratelimit.NewRequestTracker(),
 		refreshInterval:  refreshInterval,
 	}
 
@@ -358,6 +378,7 @@ func (em *EnclaveManager) addModel(modelName string, modelConfig config.Model) {
 		SourceMeasurement: nil,
 		Enclaves:          make(map[string]*Enclave),
 		Overload:          modelConfig.Overload,
+		RateLimit:         modelConfig.RateLimit,
 	})
 }
 
@@ -454,6 +475,7 @@ func (em *EnclaveManager) sync() error {
 			log.Tracef("Updating config for model %s", modelName)
 			model.mu.Lock()
 			model.Overload = configModel.Overload
+			model.RateLimit = configModel.RateLimit
 			for _, enclave := range model.Enclaves {
 				enclave.updateOverloadConfig(model.Overload)
 			}

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -60,4 +60,13 @@ var (
 		},
 		[]string{"model", "enclave"},
 	)
+
+	// RateLimitDemotionsTotal tracks requests deprioritized due to token rate limits
+	RateLimitDemotionsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_ratelimit_demotions_total",
+			Help: "Total number of requests sent with lower vLLM priority due to token rate limits",
+		},
+		[]string{"model"},
+	)
 )

--- a/ratelimit/tracker.go
+++ b/ratelimit/tracker.go
@@ -1,0 +1,101 @@
+package ratelimit
+
+import (
+	"sync"
+	"time"
+)
+
+// RequestTracker tracks request counts per API key per model with
+// fixed one-minute windows. Safe for concurrent use.
+type RequestTracker struct {
+	mu          sync.Mutex
+	buckets     map[string]*bucketEntry // key: "apiKey\x00model"
+	nowFunc     func() time.Time
+	lastCleanup time.Time
+}
+
+type bucketEntry struct {
+	count       int64
+	windowStart time.Time
+}
+
+// Option configures a RequestTracker.
+type Option func(*RequestTracker)
+
+// WithNowFunc injects a custom clock (for testing).
+func WithNowFunc(f func() time.Time) Option {
+	return func(t *RequestTracker) {
+		t.nowFunc = f
+	}
+}
+
+// NewRequestTracker creates a new RequestTracker.
+func NewRequestTracker(opts ...Option) *RequestTracker {
+	t := &RequestTracker{
+		buckets: make(map[string]*bucketEntry),
+		nowFunc: time.Now,
+	}
+	for _, o := range opts {
+		o(t)
+	}
+	t.lastCleanup = t.nowFunc()
+	return t
+}
+
+func bucketKey(apiKey, model string) string {
+	return apiKey + "\x00" + model
+}
+
+// RecordAndCheck atomically increments the request count and returns true
+// if the API key has exceeded the limit for the given model in the current
+// one-minute window.
+func (t *RequestTracker) RecordAndCheck(apiKey, model string, limit int64) bool {
+	if apiKey == "" {
+		return false
+	}
+
+	now := t.nowFunc()
+	key := bucketKey(apiKey, model)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	b, ok := t.buckets[key]
+	if !ok {
+		b = &bucketEntry{
+			count:       1,
+			windowStart: now.Truncate(time.Minute),
+		}
+		t.buckets[key] = b
+	} else {
+		// Reset window if the minute has changed
+		windowStart := now.Truncate(time.Minute)
+		if windowStart.After(b.windowStart) {
+			b.count = 0
+			b.windowStart = windowStart
+		}
+		b.count++
+	}
+
+	// Lazy cleanup: at most once per minute
+	if now.Sub(t.lastCleanup) >= time.Minute {
+		t.cleanup(now)
+		t.lastCleanup = now
+	}
+
+	if limit <= 0 {
+		return false
+	}
+	return b.count >= limit
+}
+
+// cleanup removes entries whose windows are more than 2 minutes old.
+// Must be called with t.mu held.
+func (t *RequestTracker) cleanup(now time.Time) {
+	cutoff := now.Add(-2 * time.Minute)
+	for key, b := range t.buckets {
+		if b.windowStart.Before(cutoff) {
+			delete(t.buckets, key)
+		}
+	}
+}

--- a/ratelimit/tracker_test.go
+++ b/ratelimit/tracker_test.go
@@ -1,0 +1,124 @@
+package ratelimit
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRecordAndCheck(t *testing.T) {
+	tracker := NewRequestTracker()
+
+	// First two requests under limit of 3
+	if tracker.RecordAndCheck("key1", "model1", 3) {
+		t.Fatal("should not be rate limited at 1/3")
+	}
+	if tracker.RecordAndCheck("key1", "model1", 3) {
+		t.Fatal("should not be rate limited at 2/3")
+	}
+
+	// Third request hits limit
+	if !tracker.RecordAndCheck("key1", "model1", 3) {
+		t.Fatal("should be rate limited at 3/3")
+	}
+
+	// Over limit
+	if !tracker.RecordAndCheck("key1", "model1", 3) {
+		t.Fatal("should be rate limited at 4/3")
+	}
+}
+
+func TestDifferentKeysAreIndependent(t *testing.T) {
+	tracker := NewRequestTracker()
+
+	for i := 0; i < 5; i++ {
+		tracker.RecordAndCheck("key1", "model1", 100)
+	}
+	tracker.RecordAndCheck("key2", "model1", 100)
+	tracker.RecordAndCheck("key1", "model2", 100)
+
+	// key1/model1 has 5 requests
+	if !tracker.RecordAndCheck("key1", "model1", 3) {
+		t.Fatal("key1/model1 should be rate limited")
+	}
+	// key2/model1 has 1 request
+	if tracker.RecordAndCheck("key2", "model1", 3) {
+		t.Fatal("key2/model1 should not be rate limited")
+	}
+	// key1/model2 has 1 request
+	if tracker.RecordAndCheck("key1", "model2", 3) {
+		t.Fatal("key1/model2 should not be rate limited")
+	}
+}
+
+func TestWindowReset(t *testing.T) {
+	now := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	tracker := NewRequestTracker(WithNowFunc(func() time.Time { return now }))
+
+	for i := 0; i < 5; i++ {
+		tracker.RecordAndCheck("key1", "model1", 100)
+	}
+	if !tracker.RecordAndCheck("key1", "model1", 3) {
+		t.Fatal("should be rate limited in current window")
+	}
+
+	// Advance to next minute
+	now = time.Date(2025, 1, 1, 10, 31, 0, 0, time.UTC)
+	if tracker.RecordAndCheck("key1", "model1", 3) {
+		t.Fatal("should not be rate limited after window reset")
+	}
+}
+
+func TestEmptyAPIKeyIgnored(t *testing.T) {
+	tracker := NewRequestTracker()
+
+	if tracker.RecordAndCheck("", "model1", 1) {
+		t.Fatal("empty API key should never be rate limited")
+	}
+}
+
+func TestZeroLimitNeverRateLimits(t *testing.T) {
+	tracker := NewRequestTracker()
+	for i := 0; i < 100; i++ {
+		tracker.RecordAndCheck("key1", "model1", 100)
+	}
+
+	if tracker.RecordAndCheck("key1", "model1", 0) {
+		t.Fatal("zero limit should never rate limit")
+	}
+	if tracker.RecordAndCheck("key1", "model1", -1) {
+		t.Fatal("negative limit should never rate limit")
+	}
+}
+
+func TestCleanup(t *testing.T) {
+	now := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	tracker := NewRequestTracker(WithNowFunc(func() time.Time { return now }))
+
+	tracker.RecordAndCheck("key1", "model1", 100)
+
+	// Advance 3 minutes and trigger cleanup via RecordAndCheck
+	now = time.Date(2025, 1, 1, 10, 3, 1, 0, time.UTC)
+	tracker.RecordAndCheck("key2", "model1", 100) // triggers cleanup
+
+	tracker.mu.Lock()
+	_, exists := tracker.buckets[bucketKey("key1", "model1")]
+	tracker.mu.Unlock()
+	if exists {
+		t.Fatal("stale entry should have been cleaned up")
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	tracker := NewRequestTracker()
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tracker.RecordAndCheck("key1", "model1", 100)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
This undoes the revert in #165.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reintroduces per-API-key, per-model request rate limiting. Over-budget requests are sent with lower vLLM priority, not rejected. Prevents clients from overriding priority and adds a Prometheus metric to monitor demotions.

- **New Features**
  - Config: rate_limit.max_requests_per_minute per model (enabled for kimi-k2-5 at 4/min).
  - Rate limiting: thread-safe 1‑minute windows; demotes over-budget requests by setting priority=1.
  - Router: extracts API key from Authorization, strips client-supplied priority, re-encodes body when modified.
  - Manager: stores/syncs rate limit config per model; shared RequestTracker.
  - Metrics: router_ratelimit_demotions_total (label: model).

<sup>Written for commit e732c4fd013a1ace1afaeb9ace3fd6a76cf49cf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

