### PR TITLE
chore: bump container version

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,7 +10,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.63"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.65"
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped the proxy container image to ghcr.io/tinfoilsh/confidential-model-router:0.0.65 to pick up recent fixes and improvements.

<sup>Written for commit 8d7df8f64dcfbf54e258501a5df843ba193a024b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

