### PR TITLE
chore: Add gpt-oss-20b configuration to config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -37,6 +37,11 @@ models:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
       - gpt-oss-120b.inf5.tinfoil.sh
+    
+  gpt-oss-20b:
+    repo: opal-org/gpt-oss-20b
+    enclaves:
+      - gpt-oss-20b.sky-computing-lab.containers.tinfoil.dev
 
   gpt-oss-120b-free:
     repo: tinfoilsh/confidential-gpt-oss-120b-free


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `gpt-oss-20b` to `config.yml` to enable routing and usage of this model.
Includes repo `opal-org/gpt-oss-20b` and enclave `gpt-oss-20b.sky-computing-lab.containers.tinfoil.dev`.

<sup>Written for commit 472fa4afb45585384e50ed5edc0e873763b97768. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

