### PR TITLE
chore: Update proxy container image version to 0.0.66

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,7 +10,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.65"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.66"
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the `proxy` container to `ghcr.io/tinfoilsh/confidential-model-router:0.0.66`. This pulls the latest router fixes and improvements.

<sup>Written for commit 14560c93b8383e06e6c63472058fa00ae21e9e1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

