### PR TITLE
chore: Downgrade proxy image version to 0.0.65

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,7 +10,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.66"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.65"
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Downgraded the proxy container image to `ghcr.io/tinfoilsh/confidential-model-router:0.0.65` (from 0.0.66) to revert to the previous version.

<sup>Written for commit 70304b870cd9696425b46ec41b0541c221830583. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

