### PR TITLE
chore: Update config.yml with new qwen3-vl endpoint

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -62,7 +62,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.inf5.tinfoil.sh
+      - qwen3-vl-30b.tinfoil.containers.tinfoil.dev
 
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the `qwen3-vl-30b` model's enclave in `config.yml` to `qwen3-vl-30b.tinfoil.containers.tinfoil.dev`. This routes traffic to the new endpoint and replaces `qwen3-vl-30b.inf5.tinfoil.sh`.

<sup>Written for commit ec9fb3a36b6bc9969f987929fecefed9037b2dce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

