### PR TITLE
Add support for model aliases

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -26,6 +26,9 @@ models:
 
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
+    aliases:
+      - tinfoil-free
+      - tinfoil-summary-model
     enclaves:
       - llama3-3-70b.tinfoil.containers.tinfoil.dev
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type RateLimitConfig struct {
 type Model struct {
 	Repo      string           `yaml:"repo"`
 	Hostnames []string         `yaml:"enclaves"`
+	Aliases   []string         `yaml:"aliases,omitempty"`
 	Overload  *OverloadConfig  `yaml:"overload,omitempty"`
 	RateLimit *RateLimitConfig `yaml:"rate_limit,omitempty"`
 }

--- a/main.go
+++ b/main.go
@@ -163,23 +163,6 @@ func extractModelFromMultipart(r *http.Request) (string, []byte, error) {
 	return "", bodyBytes, nil
 }
 
-// replaceMultipartFieldValue finds a form field by its header pattern in raw
-// multipart bytes and splices in a replacement value.
-func replaceMultipartFieldValue(body []byte, fieldName, oldValue, newValue string) []byte {
-	marker := []byte("name=\"" + fieldName + "\"\r\n\r\n" + oldValue + "\r\n")
-	idx := bytes.Index(body, marker)
-	if idx == -1 {
-		return body
-	}
-	valueStart := idx + len("name=\""+fieldName+"\"\r\n\r\n")
-	valueEnd := valueStart + len(oldValue)
-	result := make([]byte, 0, len(body)-len(oldValue)+len(newValue))
-	result = append(result, body[:valueStart]...)
-	result = append(result, []byte(newValue)...)
-	result = append(result, body[valueEnd:]...)
-	return result
-}
-
 func main() {
 	flag.Parse()
 	if *verbose {
@@ -280,13 +263,10 @@ func main() {
 				if modelName == "" {
 					modelName = "voxtral-small-24b"
 				}
-				resolved := em.ResolveModelName(modelName)
-				if resolved != modelName {
-					bodyBytes = replaceMultipartFieldValue(bodyBytes, "model", modelName, resolved)
-					modelName = resolved
-				}
-				r.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
-				r.ContentLength = int64(len(bodyBytes))
+				// Resolve alias for routing. The original model name is preserved
+				// in the body; if aliases are added to audio models, the enclave's
+				// --served-model-name must include them.
+				modelName = em.ResolveModelName(modelName)
 				r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 			} else if r.URL.Path == "/v1/convert/file" {
 				modelName = "doc-upload"

--- a/main.go
+++ b/main.go
@@ -163,6 +163,23 @@ func extractModelFromMultipart(r *http.Request) (string, []byte, error) {
 	return "", bodyBytes, nil
 }
 
+// replaceMultipartFieldValue finds a form field by its header pattern in raw
+// multipart bytes and splices in a replacement value.
+func replaceMultipartFieldValue(body []byte, fieldName, oldValue, newValue string) []byte {
+	marker := []byte("name=\"" + fieldName + "\"\r\n\r\n" + oldValue + "\r\n")
+	idx := bytes.Index(body, marker)
+	if idx == -1 {
+		return body
+	}
+	valueStart := idx + len("name=\""+fieldName+"\"\r\n\r\n")
+	valueEnd := valueStart + len(oldValue)
+	result := make([]byte, 0, len(body)-len(oldValue)+len(newValue))
+	result = append(result, body[:valueStart]...)
+	result = append(result, []byte(newValue)...)
+	result = append(result, body[valueEnd:]...)
+	return result
+}
+
 func main() {
 	flag.Parse()
 	if *verbose {
@@ -246,6 +263,11 @@ func main() {
 				} else {
 					modelName = "qwen3-tts"
 				}
+				modelName = em.ResolveModelName(modelName)
+				body["model"] = modelName
+				bodyBytes, _ = json.Marshal(body)
+				r.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
+				r.ContentLength = int64(len(bodyBytes))
 				r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 			} else if r.URL.Path == "/v1/audio/transcriptions" || strings.HasPrefix(r.URL.Path, "/v1/audio/") {
 				// Extract model from multipart form, default to voxtral-small-24b
@@ -258,6 +280,13 @@ func main() {
 				if modelName == "" {
 					modelName = "voxtral-small-24b"
 				}
+				resolved := em.ResolveModelName(modelName)
+				if resolved != modelName {
+					bodyBytes = replaceMultipartFieldValue(bodyBytes, "model", modelName, resolved)
+					modelName = resolved
+				}
+				r.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
+				r.ContentLength = int64(len(bodyBytes))
 				r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 			} else if r.URL.Path == "/v1/convert/file" {
 				modelName = "doc-upload"
@@ -286,6 +315,10 @@ func main() {
 					return
 				}
 
+				originalModelName := modelName
+				modelName = em.ResolveModelName(modelName)
+				body["model"] = modelName
+
 				// Check if request uses web search — route to websearch enclave.
 				// The original model name is preserved in the request body so the
 				// websearch service knows which model to use for inference.
@@ -312,7 +345,7 @@ func main() {
 				delete(body, "priority")
 
 				// Check rate limiting and inject lower vLLM priority if over budget
-				bodyModified := hadPriority
+				bodyModified := hadPriority || (originalModelName != modelName)
 				if rlCfg := em.GetRateLimitConfig(rateLimitModel); rlCfg != nil {
 					if apiKey != "" && em.RequestTracker().RecordAndCheck(apiKey, rateLimitModel, rlCfg.MaxRequestsPerMinute) {
 						body["priority"] = 1

--- a/main_test.go
+++ b/main_test.go
@@ -126,6 +126,32 @@ func TestBodyPreservedAfterExtraction(t *testing.T) {
 	t.Log("Body preserved correctly for forwarding to backend")
 }
 
+func TestReplaceMultipartFieldValue(t *testing.T) {
+	// Build a multipart body where the model name also appears inside the file data
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	writer.WriteField("model", "old-alias")
+	filePart, _ := writer.CreateFormFile("file", "test.wav")
+	filePart.Write([]byte("audio data containing old-alias in content"))
+	writer.Close()
+
+	original := body.Bytes()
+	result := replaceMultipartFieldValue(original, "model", "old-alias", "canonical-model-name")
+
+	// The model field value should be replaced
+	if bytes.Contains(result, []byte("name=\"model\"\r\n\r\nold-alias\r\n")) {
+		t.Error("model field value was not replaced")
+	}
+	if !bytes.Contains(result, []byte("name=\"model\"\r\n\r\ncanonical-model-name\r\n")) {
+		t.Error("model field value should contain the new value")
+	}
+
+	// The file data should still contain the old model name (not replaced)
+	if !bytes.Contains(result, []byte("audio data containing old-alias in content")) {
+		t.Error("file data should not be modified")
+	}
+}
+
 // TestAudioTranscriptionRouting tests the full HTTP handler routing logic for audio endpoints
 func TestAudioTranscriptionRouting(t *testing.T) {
 	tests := []struct {
@@ -168,12 +194,12 @@ func TestAudioTranscriptionRouting(t *testing.T) {
 			// Create a test handler that mimics the routing logic
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				var modelName string
+				var bodyBytes []byte
+				var err error
 
 				// This is the exact logic from main.go for audio paths
-				if r.URL.Path == "/v1/audio/transcriptions" || r.URL.Path == "/v1/audio/speech" || 
+				if r.URL.Path == "/v1/audio/transcriptions" || r.URL.Path == "/v1/audio/speech" ||
 				   len(r.URL.Path) > 10 && r.URL.Path[:10] == "/v1/audio/" {
-					var bodyBytes []byte
-					var err error
 					modelName, bodyBytes, err = extractModelFromMultipart(r)
 					if err != nil {
 						http.Error(w, err.Error(), http.StatusBadRequest)

--- a/main_test.go
+++ b/main_test.go
@@ -126,32 +126,6 @@ func TestBodyPreservedAfterExtraction(t *testing.T) {
 	t.Log("Body preserved correctly for forwarding to backend")
 }
 
-func TestReplaceMultipartFieldValue(t *testing.T) {
-	// Build a multipart body where the model name also appears inside the file data
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-	writer.WriteField("model", "old-alias")
-	filePart, _ := writer.CreateFormFile("file", "test.wav")
-	filePart.Write([]byte("audio data containing old-alias in content"))
-	writer.Close()
-
-	original := body.Bytes()
-	result := replaceMultipartFieldValue(original, "model", "old-alias", "canonical-model-name")
-
-	// The model field value should be replaced
-	if bytes.Contains(result, []byte("name=\"model\"\r\n\r\nold-alias\r\n")) {
-		t.Error("model field value was not replaced")
-	}
-	if !bytes.Contains(result, []byte("name=\"model\"\r\n\r\ncanonical-model-name\r\n")) {
-		t.Error("model field value should contain the new value")
-	}
-
-	// The file data should still contain the old model name (not replaced)
-	if !bytes.Contains(result, []byte("audio data containing old-alias in content")) {
-		t.Error("file data should not be modified")
-	}
-}
-
 // TestAudioTranscriptionRouting tests the full HTTP handler routing logic for audio endpoints
 func TestAudioTranscriptionRouting(t *testing.T) {
 	tests := []struct {
@@ -199,7 +173,7 @@ func TestAudioTranscriptionRouting(t *testing.T) {
 
 				// This is the exact logic from main.go for audio paths
 				if r.URL.Path == "/v1/audio/transcriptions" || r.URL.Path == "/v1/audio/speech" ||
-				   len(r.URL.Path) > 10 && r.URL.Path[:10] == "/v1/audio/" {
+					len(r.URL.Path) > 10 && r.URL.Path[:10] == "/v1/audio/" {
 					modelName, bodyBytes, err = extractModelFromMultipart(r)
 					if err != nil {
 						http.Error(w, err.Error(), http.StatusBadRequest)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -391,16 +391,26 @@ func (em *EnclaveManager) addModel(modelName string, modelConfig config.Model) {
 		Overload:          modelConfig.Overload,
 		RateLimit:         modelConfig.RateLimit,
 	})
-	for _, alias := range modelConfig.Aliases {
+	em.registerAliases(modelName, modelConfig.Aliases, em.aliases)
+}
+
+// registerAliases registers aliases for a model into the provided alias map,
+// skipping any that conflict with canonical model names or existing aliases.
+func (em *EnclaveManager) registerAliases(modelName string, aliases []string, aliasMap *sync.Map) {
+	if _, isAlias := aliasMap.Load(modelName); isAlias {
+		log.Errorf("model %q is itself an alias; cannot register aliases for it, skipping", modelName)
+		return
+	}
+	for _, alias := range aliases {
 		if _, isCanonical := em.models.Load(alias); isCanonical {
 			log.Errorf("alias %q for model %q conflicts with canonical model name, skipping", alias, modelName)
 			continue
 		}
-		if existing, loaded := em.aliases.Load(alias); loaded && existing.(string) != modelName {
+		if existing, loaded := aliasMap.Load(alias); loaded && existing.(string) != modelName {
 			log.Errorf("alias %q for model %q conflicts with existing alias for model %q, skipping", alias, modelName, existing.(string))
 			continue
 		}
-		em.aliases.Store(alias, modelName)
+		aliasMap.Store(alias, modelName)
 	}
 }
 
@@ -465,23 +475,19 @@ func (em *EnclaveManager) sync() error {
 	}
 
 	// Rebuild aliases from updated config
+	newAliases := &sync.Map{}
+	for modelName, modelConfig := range config.Models {
+		em.registerAliases(modelName, modelConfig.Aliases, newAliases)
+	}
+	// Swap in the new alias map
 	em.aliases.Range(func(key, _ any) bool {
 		em.aliases.Delete(key)
 		return true
 	})
-	for modelName, modelConfig := range config.Models {
-		for _, alias := range modelConfig.Aliases {
-			if _, isCanonical := em.models.Load(alias); isCanonical {
-				log.Errorf("alias %q for model %q conflicts with canonical model name, skipping", alias, modelName)
-				continue
-			}
-			if existing, loaded := em.aliases.Load(alias); loaded && existing.(string) != modelName {
-				log.Errorf("alias %q for model %q conflicts with existing alias for model %q, skipping", alias, modelName, existing.(string))
-				continue
-			}
-			em.aliases.Store(alias, modelName)
-		}
-	}
+	newAliases.Range(func(key, value any) bool {
+		em.aliases.Store(key, value)
+		return true
+	})
 
 	var wg sync.WaitGroup
 	em.models.Range(func(key, value any) bool {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -46,6 +46,7 @@ type Model struct {
 
 type EnclaveManager struct {
 	models               *sync.Map // model name -> *Model
+	aliases              *sync.Map // alias name -> canonical model name
 	initConfigURL        string
 	updateConfigURL      string
 	sigstoreClient       *sigstore.Client
@@ -64,9 +65,15 @@ func (em *EnclaveManager) ModelExists(modelName string) bool {
 	return found
 }
 
-// GetModel gets a model by name
+// GetModel gets a model by name, resolving aliases if necessary
 func (em *EnclaveManager) GetModel(modelName string) (*Model, bool) {
 	model, found := em.models.Load(modelName)
+	if !found {
+		// Check if it's an alias
+		if canonical, ok := em.aliases.Load(modelName); ok {
+			model, found = em.models.Load(canonical.(string))
+		}
+	}
 	if !found {
 		return nil, false
 	}
@@ -354,6 +361,7 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, initConfigURL 
 
 	em := &EnclaveManager{
 		models:           &sync.Map{},
+		aliases:          &sync.Map{},
 		initConfigURL:    initConfigURL,
 		updateConfigURL:  updateConfigURL,
 		sigstoreClient:   sigstoreClient,
@@ -380,6 +388,9 @@ func (em *EnclaveManager) addModel(modelName string, modelConfig config.Model) {
 		Overload:          modelConfig.Overload,
 		RateLimit:         modelConfig.RateLimit,
 	})
+	for _, alias := range modelConfig.Aliases {
+		em.aliases.Store(alias, modelName)
+	}
 }
 
 // updateModelMeasurements checks if there's a new tag, and if so, updates the model's tag and measurement
@@ -440,6 +451,17 @@ func (em *EnclaveManager) sync() error {
 	hwMeasurements, err := em.sigstoreClient.LatestHardwareMeasurements()
 	if err != nil {
 		return fmt.Errorf("failed to fetch hardware measurements: %v", err)
+	}
+
+	// Rebuild aliases from updated config
+	em.aliases.Range(func(key, _ any) bool {
+		em.aliases.Delete(key)
+		return true
+	})
+	for modelName, modelConfig := range config.Models {
+		for _, alias := range modelConfig.Aliases {
+			em.aliases.Store(alias, modelName)
+		}
 	}
 
 	var wg sync.WaitGroup

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -65,15 +65,18 @@ func (em *EnclaveManager) ModelExists(modelName string) bool {
 	return found
 }
 
+// ResolveModelName returns the canonical model name, resolving aliases if necessary.
+func (em *EnclaveManager) ResolveModelName(modelName string) string {
+	if canonical, ok := em.aliases.Load(modelName); ok {
+		return canonical.(string)
+	}
+	return modelName
+}
+
 // GetModel gets a model by name, resolving aliases if necessary
 func (em *EnclaveManager) GetModel(modelName string) (*Model, bool) {
-	model, found := em.models.Load(modelName)
-	if !found {
-		// Check if it's an alias
-		if canonical, ok := em.aliases.Load(modelName); ok {
-			model, found = em.models.Load(canonical.(string))
-		}
-	}
+	resolved := em.ResolveModelName(modelName)
+	model, found := em.models.Load(resolved)
 	if !found {
 		return nil, false
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -45,8 +45,8 @@ type Model struct {
 }
 
 type EnclaveManager struct {
-	models               *sync.Map // model name -> *Model
-	aliases              *sync.Map // alias name -> canonical model name
+	models               *sync.Map                // model name -> *Model
+	aliases              atomic.Pointer[sync.Map] // alias name -> canonical model name
 	initConfigURL        string
 	updateConfigURL      string
 	sigstoreClient       *sigstore.Client
@@ -65,9 +65,14 @@ func (em *EnclaveManager) ModelExists(modelName string) bool {
 	return found
 }
 
+// loadAliases returns the current alias map.
+func (em *EnclaveManager) loadAliases() *sync.Map {
+	return em.aliases.Load()
+}
+
 // ResolveModelName returns the canonical model name, resolving aliases if necessary.
 func (em *EnclaveManager) ResolveModelName(modelName string) string {
-	if canonical, ok := em.aliases.Load(modelName); ok {
+	if canonical, ok := em.loadAliases().Load(modelName); ok {
 		return canonical.(string)
 	}
 	return modelName
@@ -364,7 +369,6 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, initConfigURL 
 
 	em := &EnclaveManager{
 		models:           &sync.Map{},
-		aliases:          &sync.Map{},
 		initConfigURL:    initConfigURL,
 		updateConfigURL:  updateConfigURL,
 		sigstoreClient:   sigstoreClient,
@@ -372,6 +376,7 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, initConfigURL 
 		requestTracker:   ratelimit.NewRequestTracker(),
 		refreshInterval:  refreshInterval,
 	}
+	em.aliases.Store(&sync.Map{})
 
 	for modelName, modelConfig := range cfg.Models {
 		em.addModel(modelName, modelConfig)
@@ -391,7 +396,7 @@ func (em *EnclaveManager) addModel(modelName string, modelConfig config.Model) {
 		Overload:          modelConfig.Overload,
 		RateLimit:         modelConfig.RateLimit,
 	})
-	em.registerAliases(modelName, modelConfig.Aliases, em.aliases)
+	em.registerAliases(modelName, modelConfig.Aliases, em.loadAliases())
 }
 
 // registerAliases registers aliases for a model into the provided alias map,
@@ -474,20 +479,12 @@ func (em *EnclaveManager) sync() error {
 		return fmt.Errorf("failed to fetch hardware measurements: %v", err)
 	}
 
-	// Rebuild aliases from updated config
+	// Rebuild aliases from updated config and atomically swap
 	newAliases := &sync.Map{}
 	for modelName, modelConfig := range config.Models {
 		em.registerAliases(modelName, modelConfig.Aliases, newAliases)
 	}
-	// Swap in the new alias map
-	em.aliases.Range(func(key, _ any) bool {
-		em.aliases.Delete(key)
-		return true
-	})
-	newAliases.Range(func(key, value any) bool {
-		em.aliases.Store(key, value)
-		return true
-	})
+	em.aliases.Store(newAliases)
 
 	var wg sync.WaitGroup
 	em.models.Range(func(key, value any) bool {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -392,6 +392,14 @@ func (em *EnclaveManager) addModel(modelName string, modelConfig config.Model) {
 		RateLimit:         modelConfig.RateLimit,
 	})
 	for _, alias := range modelConfig.Aliases {
+		if _, isCanonical := em.models.Load(alias); isCanonical {
+			log.Errorf("alias %q for model %q conflicts with canonical model name, skipping", alias, modelName)
+			continue
+		}
+		if existing, loaded := em.aliases.Load(alias); loaded && existing.(string) != modelName {
+			log.Errorf("alias %q for model %q conflicts with existing alias for model %q, skipping", alias, modelName, existing.(string))
+			continue
+		}
 		em.aliases.Store(alias, modelName)
 	}
 }
@@ -463,6 +471,14 @@ func (em *EnclaveManager) sync() error {
 	})
 	for modelName, modelConfig := range config.Models {
 		for _, alias := range modelConfig.Aliases {
+			if _, isCanonical := em.models.Load(alias); isCanonical {
+				log.Errorf("alias %q for model %q conflicts with canonical model name, skipping", alias, modelName)
+				continue
+			}
+			if existing, loaded := em.aliases.Load(alias); loaded && existing.(string) != modelName {
+				log.Errorf("alias %q for model %q conflicts with existing alias for model %q, skipping", alias, modelName, existing.(string))
+				continue
+			}
 			em.aliases.Store(alias, modelName)
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add model alias support across the gateway. Aliases resolve to a canonical model for consistent routing and rate limits; JSON bodies are rewritten while multipart bodies are preserved.

- New Features
  - Add `aliases` to the model config; example for `llama3-3-70b`: `tinfoil-free`, `tinfoil-summary-model`.
  - Maintain an alias map with `ResolveModelName` and alias-aware `GetModel`; atomically rebuild/swap on config sync with collision logging and safeguards against alias chains and canonical name conflicts.

- Bug Fixes
  - Forward the original `model` upstream for websearch and audio; use the canonical name only for routing/rate limits.
  - Recompute `Content-Length` after JSON rewrites; do not rewrite multipart bodies (resolve alias only for routing).

<sup>Written for commit 73c2ed0b2f3afba0579e769cd892ba999d0f0ed4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

