### PR TITLE
chore: kimi-k2-5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,7 +42,6 @@ models:
   gpt-oss-20b:
     repo: opal-org/gpt-oss-20b
     enclaves:
-      - gpt-oss-20b.sky-computing-lab.containers.tinfoil.dev
 
   gpt-oss-120b-free:
     repo: tinfoilsh/confidential-gpt-oss-120b-free
@@ -72,7 +71,7 @@ models:
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
-      - kimi-k2-5.inf8.tinfoil.sh
+      - kimi-k2-5.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 4
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated enclave host for `kimi-k2-5` to `kimi-k2-5.tinfoil.containers.tinfoil.dev` and removed the deprecated enclave entry for `gpt-oss-20b`.
This routes traffic to the correct cluster and cleans up stale config.

<sup>Written for commit efbba35e15ca9b3b3abda4fc15622e797ada895f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

