### PR TITLE
Update config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ models:
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
-      - kimi-k2-5.tinfoil.containers.tinfoil.dev
+      - kimi-k2-5.inf8.tinfoil.sh
     rate_limit:
       max_requests_per_minute: 4
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `config.yml` to switch the `kimi-k2-5` model’s enclave hostname to `kimi-k2-5.inf8.tinfoil.sh`, replacing `kimi-k2-5.tinfoil.containers.tinfoil.dev`. This ensures requests route to the correct enclave; no other settings changed.

<sup>Written for commit 6392580df64a01db79711260620c5eae856b4b8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

