### PR TITLE
chore: model update in config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,10 +38,6 @@ models:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
       - gpt-oss-120b.inf5.tinfoil.sh
-    
-  gpt-oss-20b:
-    repo: opal-org/gpt-oss-20b
-    enclaves:
 
   gpt-oss-120b-free:
     repo: tinfoilsh/confidential-gpt-oss-120b-free
@@ -71,7 +67,7 @@ models:
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
-      - kimi-k2-5.inf8.tinfoil.sh
+      - kimi-k2-5.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 4
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch `kimi-k2-5` enclave from `kimi-k2-5.inf8.tinfoil.sh` to `kimi-k2-5.tinfoil.containers.tinfoil.dev` and remove the deprecated `gpt-oss-20b` entry. Keeps routing aligned with the new container domain and cleans up a stale model.

<sup>Written for commit 8f76ac702540f5a4179a8a298a8588883b296866. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

