### PR TITLE
chore: kimi

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -68,6 +68,7 @@ models:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
       - kimi-k2-5.tinfoil.containers.tinfoil.dev
+      - kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 4
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added new enclave `kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev` to the `tinfoilsh/confidential-kimi-k2-5` model config to enable routing to the inf8 cluster and increase capacity. No other config changes.

<sup>Written for commit ad8b1d73f355d85b7edb58620b1403b62039d0fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

