### PR TITLE
Update config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -67,7 +67,6 @@ models:
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
-      - kimi-k2-5.tinfoil.containers.tinfoil.dev
       - kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 4


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed deprecated enclave `kimi-k2-5.tinfoil.containers.tinfoil.dev` from the `kimi-k2-5` model so traffic routes only to `kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev` and avoids a retired endpoint.

<sup>Written for commit be888ce4a49bdafb554b22752019261970e4c708. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

