### PR TITLE
chore: remove gpt-oss-free

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -39,11 +39,6 @@ models:
     enclaves:
       - gpt-oss-120b.inf5.tinfoil.sh
 
-  gpt-oss-120b-free:
-    repo: tinfoilsh/confidential-gpt-oss-120b-free
-    enclaves:
-      - gpt-oss-120b-free.inf5.tinfoil.sh
-
   gpt-oss-safeguard-120b:
     repo: tinfoilsh/confidential-gpt-oss-safeguard-120b
     enclaves:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the `gpt-oss-120b-free` model (and its enclave) from `config.yml` to retire the free variant and prevent routing to it. No other models are affected.

<sup>Written for commit e57e552157f8f17b3601fcf0fd9eb9aa951a261f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

