### PR TITLE
chore: update gpt-oss

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -37,7 +37,7 @@ models:
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
-      - gpt-oss-120b.inf5.tinfoil.sh
+      - gpt-oss-120b-inf5.tinfoil.containers.tinfoil.dev
 
   gpt-oss-safeguard-120b:
     repo: tinfoilsh/confidential-gpt-oss-safeguard-120b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the `gpt-oss-120b` enclave hostname to the new containers domain so traffic routes to the correct INF5 deployment.
Changed gpt-oss-120b.inf5.tinfoil.sh → gpt-oss-120b-inf5.tinfoil.containers.tinfoil.dev.

<sup>Written for commit d2c8e1e2c3fb02c4b21f1e801ef22e563204fb97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

