### PR TITLE
fix: responses api streaming counts

### DIFF
--- a/tokencount/extractor.go
+++ b/tokencount/extractor.go
@@ -11,11 +11,27 @@ import (
 	"sync"
 )
 
-// Usage represents token usage information from inference responses
+// Usage represents token usage information from inference responses.
+// Supports both Chat Completions (prompt_tokens/completion_tokens) and
+// Responses API (input_tokens/output_tokens) field names.
 type Usage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+	InputTokens      int `json:"input_tokens"`
+	OutputTokens     int `json:"output_tokens"`
+}
+
+// Normalize maps Responses API fields (input_tokens/output_tokens) into
+// Chat Completions fields (prompt_tokens/completion_tokens) so billing
+// works uniformly regardless of which API produced the usage data.
+func (u *Usage) Normalize() {
+	if u.PromptTokens == 0 && u.InputTokens > 0 {
+		u.PromptTokens = u.InputTokens
+	}
+	if u.CompletionTokens == 0 && u.OutputTokens > 0 {
+		u.CompletionTokens = u.OutputTokens
+	}
 }
 
 // OpenAIResponse represents a standard OpenAI-compatible response
@@ -45,6 +61,7 @@ func (j *JSONTokenExtractor) ExtractUsage() {
 
 	var resp OpenAIResponse
 	if err := json.Unmarshal(j.buffer.Bytes(), &resp); err == nil && resp.Usage != nil {
+		resp.Usage.Normalize()
 		j.usage = resp.Usage
 		log.Printf("[TokenExtractor] Model: %s, Tokens - Input: %d, Output: %d, Total: %d",
 			j.model,
@@ -171,11 +188,19 @@ func (s *StreamingTokenExtractor) processStream() {
 				// Try to parse the chunk
 				var chunk map[string]interface{}
 				if err := json.Unmarshal([]byte(data), &chunk); err == nil {
-					// Check for usage in the chunk
-					if usageData, ok := chunk["usage"]; ok && usageData != nil {
+					// Check for usage in the chunk (Chat Completions API)
+					// or nested under "response" (Responses API streaming)
+					usageData, ok := chunk["usage"]
+					if (!ok || usageData == nil) {
+						if respObj, rOk := chunk["response"].(map[string]interface{}); rOk {
+							usageData, ok = respObj["usage"]
+						}
+					}
+					if ok && usageData != nil {
 						usageBytes, _ := json.Marshal(usageData)
 						var usage Usage
 						if err := json.Unmarshal(usageBytes, &usage); err == nil {
+							usage.Normalize()
 							// Update usage data (continuous stats may send incremental updates)
 							if usage.PromptTokens > 0 {
 								s.usage.PromptTokens = usage.PromptTokens

--- a/tokencount/extractor_streaming_test.go
+++ b/tokencount/extractor_streaming_test.go
@@ -549,6 +549,50 @@ data: [DONE]
 	}
 }
 
+func TestResponsesAPIStreamingUsageExtraction(t *testing.T) {
+	// Responses API puts usage inside response.completed event at chunk["response"]["usage"],
+	// not at the top-level chunk["usage"] like Chat Completions.
+	input := `event: response.created
+data: {"response":{"id":"resp_abc123","status":"in_progress","usage":null},"type":"response.created"}
+
+event: response.output_item.added
+data: {"item":{"id":"msg_001","type":"reasoning"},"output_index":0,"type":"response.output_item.added"}
+
+event: response.reasoning_text.delta
+data: {"content_index":0,"delta":"Hello","item_id":"msg_001","output_index":0,"type":"response.reasoning_text.delta"}
+
+event: response.completed
+data: {"response":{"id":"resp_abc123","status":"completed","output":[{"id":"msg_001","type":"reasoning","content":[{"text":"Hello","type":"reasoning_text"}]}],"usage":{"input_tokens":69,"input_tokens_details":{"cached_tokens":64},"output_tokens":20,"output_tokens_details":{"reasoning_tokens":18},"total_tokens":89}},"type":"response.completed"}
+
+`
+
+	inputReader := io.NopCloser(strings.NewReader(input))
+	pr, pw := io.Pipe()
+
+	var capturedUsage *Usage
+	extractor := NewStreamingTokenExtractor(inputReader, pw, "gpt-oss-120b")
+	extractor.usageHandler = func(usage *Usage) {
+		capturedUsage = usage
+	}
+
+	go extractor.processStream()
+	io.ReadAll(pr)
+
+	if capturedUsage == nil {
+		t.Fatal("Usage handler was not called — Responses API streaming usage was not extracted")
+	}
+	if capturedUsage.TotalTokens != 89 {
+		t.Errorf("Expected total_tokens=89, got %d", capturedUsage.TotalTokens)
+	}
+	// Responses API uses input_tokens/output_tokens; Normalize() should map them
+	if capturedUsage.PromptTokens != 69 {
+		t.Errorf("Expected prompt_tokens=69 (from input_tokens), got %d", capturedUsage.PromptTokens)
+	}
+	if capturedUsage.CompletionTokens != 20 {
+		t.Errorf("Expected completion_tokens=20 (from output_tokens), got %d", capturedUsage.CompletionTokens)
+	}
+}
+
 func TestRealWorldScenarios(t *testing.T) {
 	// Test scenarios based on actual vLLM and OpenAI responses
 	tests := []struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes token usage extraction for the Responses API, including streaming, by normalizing `input_tokens`/`output_tokens` to standard fields. Ensures accurate and consistent billing counts across Chat Completions and Responses.

- **Bug Fixes**
  - Added `input_tokens`/`output_tokens` to usage and normalized to `prompt_tokens`/`completion_tokens`.
  - Streaming extractor now reads usage from `response.usage` events and normalizes; non-streaming also normalizes.
  - Added test covering Responses API streaming to validate totals and mapped counts.

<sup>Written for commit 3d7f1d4199bfb97a62b7e2b12f5279a454b6ae1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

