### PR TITLE
chore: update tinfoil-config.yml

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,16 +1,14 @@
-shim-version: v0.3.18@sha256:7d9f98be78c91ede89f43c948a12d084fae34312effe9395ca7ed572991cb561
-cvm-version: 0.6.7
+cvm-version: 0.7.1
 cpus: 8
 memory: 16384
 
 shim:
-  listen-port: 443
   upstream-port: 8089
   tls-wildcard: true
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.65"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.67"
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates CVM to 0.7.1 and the `confidential-model-router` image to 0.0.67, and removes deprecated shim fields to rely on defaults.

- **Dependencies**
  - CVM: 0.7.1 (was 0.6.7)
  - `ghcr.io/tinfoilsh/confidential-model-router`: 0.0.67 (was 0.0.65)

- **Refactors**
  - Remove `shim-version` and `shim.listen-port` entries to align with current defaults.

<sup>Written for commit 7bb05b0bc7a52c7c91a151120a05bd18c64f5b4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

