### PR TITLE
fix: normalize usage for responses streaming

### DIFF
--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -207,6 +207,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				Usage *tokencount.Usage `json:"usage"`
 			}
 			if err := json.Unmarshal(bodyBytes, &jsonResp); err == nil && jsonResp.Usage != nil {
+				jsonResp.Usage.Normalize()
 				// Call usage handler for billing
 				usageHandler(jsonResp.Usage)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalize `tokencount` usage for streamed responses before calling the billing handler. This prevents mismatched units or nil fields and keeps billing metrics consistent with non-streaming responses.

<sup>Written for commit ec41914bf0736ba9ab3937e1c33d910f772e83e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

