### PR TITLE
Update config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,6 +38,7 @@ models:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
       - gpt-oss-120b.inf9.tinfoil.sh
+      - gpt-oss-120b-2.inf9.tinfoil.sh
 
   gpt-oss-safeguard-120b:
     repo: tinfoilsh/confidential-gpt-oss-safeguard-120b

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 routers:
   inference.tinfoil.sh:
-  router.inf5.tinfoil.sh:
+  router.inf9.tinfoil.sh:
   router.inf6.tinfoil.sh:
 
 models:
@@ -22,12 +22,12 @@ models:
   voxtral-small-24b:
     repo: tinfoilsh/confidential-voxtral-small-24b
     enclaves:
-      - voxtral-small-24b.inf5.tinfoil.sh
+      - voxtral-small-24b.inf9.tinfoil.sh
 
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
     enclaves:
-      - llama3-3-70b.tinfoil.containers.tinfoil.dev
+      - llama3-3-70b.inf9.tinfoil.sh
 
   deepseek-r1-0528:
     repo: tinfoilsh/confidential-deepseek-r1-0528
@@ -37,12 +37,12 @@ models:
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
-      - gpt-oss-120b-inf5.tinfoil.containers.tinfoil.dev
+      - gpt-oss-120b.inf9.tinfoil.sh
 
   gpt-oss-safeguard-120b:
     repo: tinfoilsh/confidential-gpt-oss-safeguard-120b
     enclaves:
-      - gpt-oss-safeguard-120b.inf5.tinfoil.sh
+      - gpt-oss-safeguard-120b.inf9.tinfoil.sh
 
   qwen3-tts:
     repo: tinfoilsh/confidential-qwen3-tts
@@ -52,7 +52,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.tinfoil.containers.tinfoil.dev
+      - qwen3-vl-30b.inf9.tinfoil.sh
 
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch inference routing from `inf5`/`*.containers.tinfoil.dev` to `inf9.tinfoil.sh` by updating the router and model enclave hosts in `config.yml`. Also add a second `gpt-oss-120b` enclave on `inf9` for redundancy.

- **Migration**
  - Verify `router.inf9.tinfoil.sh` and all `inf9` enclaves (including `gpt-oss-120b-2.inf9.tinfoil.sh`) are healthy before rollout.
  - Update any ops scripts or alerts still pointing to `inf5` or `*.containers.tinfoil.dev`.

<sup>Written for commit 3445f9908c55450cbacb5008a86b741d055b870b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

