### PR TITLE
chore: add gpt-oss nodes and protect latency

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -39,6 +39,11 @@ models:
     enclaves:
       - gpt-oss-120b.inf9.tinfoil.sh
       - gpt-oss-120b-2.inf9.tinfoil.sh
+      - gpt-oss-120b.inf6.tinfoil.sh
+      - gpt-oss-120b-2.inf6.tinfoil.sh
+    overload:
+      max_requests_waiting: 8
+      retry_after_minutes: 1
 
   gpt-oss-safeguard-120b:
     repo: tinfoilsh/confidential-gpt-oss-safeguard-120b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added two new `gpt-oss-120b` enclaves (inf6) and enabled overload protection to keep latency stable during traffic spikes.

- **New Features**
  - Added enclaves: `gpt-oss-120b.inf6.tinfoil.sh`, `gpt-oss-120b-2.inf6.tinfoil.sh`.
  - Set overload limits: `max_requests_waiting: 8`, `retry_after_minutes: 1`.

<sup>Written for commit 95cd3446837db0ab03061ce240aacd442d4fa13b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

