### PR TITLE
chore: move nomic

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:
-      - confidential-nomic-embed-text.tinfoil.containers.tinfoil.sh
+      - nomic-embed-text.inf9.tinfoil.sh
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point the `nomic-embed-text` model to the new enclave host `nomic-embed-text.inf9.tinfoil.sh`. This routes traffic to the new infra and replaces the old `confidential-nomic-embed-text.tinfoil.containers.tinfoil.sh` endpoint.

<sup>Written for commit c3093235ddb705fd9623e9b733e6445b19a15549. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

