### PR TITLE
chore: bump container version

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -8,7 +8,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.68"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.70"
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the `proxy` container to use `ghcr.io/tinfoilsh/confidential-model-router:0.0.70` (was `0.0.68`).

<sup>Written for commit a35745b2e8d79713d38945e1a1211c361c1131e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

