### PR TITLE
chore: remove inf6 gpt-oss

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -39,8 +39,6 @@ models:
     enclaves:
       - gpt-oss-120b.inf9.tinfoil.sh
       - gpt-oss-120b-2.inf9.tinfoil.sh
-      - gpt-oss-120b.inf6.tinfoil.sh
-      - gpt-oss-120b-2.inf6.tinfoil.sh
     overload:
       max_requests_waiting: 8
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed `gpt-oss-120b.inf6.tinfoil.sh` and `gpt-oss-120b-2.inf6.tinfoil.sh` from `models.enclaves` in `config.yml` to stop routing traffic to the deprecated inf6 cluster.

<sup>Written for commit 0ae13826d5c8735c0140d75af516527c858e89d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

