### PR TITLE
chore: move

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -55,7 +55,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.tinfoil.containers.tinfoil.dev
+      - qwen3-vl-30b.inf9.tinfoil.sh
 
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking

--- a/config.yml
+++ b/config.yml
@@ -1,13 +1,13 @@
 routers:
   inference.tinfoil.sh:
-  router.inf9.tinfoil.sh:
+  router.inf5.tinfoil.sh:
   router.inf6.tinfoil.sh:
 
 models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:
-      - nomic-embed-text.inf5.tinfoil.sh
+      - confidential-nomic-embed-text.tinfoil.containers.tinfoil.sh
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
@@ -27,7 +27,7 @@ models:
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
     enclaves:
-      - llama3-3-70b.inf9.tinfoil.sh
+      - llama3-3-70b.tinfoil.containers.tinfoil.dev
 
   deepseek-r1-0528:
     repo: tinfoilsh/confidential-deepseek-r1-0528
@@ -37,8 +37,7 @@ models:
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
-      - gpt-oss-120b.inf9.tinfoil.sh
-      - gpt-oss-120b-2.inf9.tinfoil.sh
+      - gpt-oss-120b-inf5.tinfoil.containers.tinfoil.dev
     overload:
       max_requests_waiting: 8
       retry_after_minutes: 1
@@ -56,7 +55,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.inf9.tinfoil.sh
+      - qwen3-vl-30b.tinfoil.containers.tinfoil.dev
 
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking

--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:
-      - confidential-nomic-embed-text.tinfoil.containers.tinfoil.sh
+      - nomic-embed-text.tinfoil.containers.tinfoil.sh
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
@@ -22,7 +22,7 @@ models:
   voxtral-small-24b:
     repo: tinfoilsh/confidential-voxtral-small-24b
     enclaves:
-      - voxtral-small-24b.inf9.tinfoil.sh
+      - voxtral-small-24b.tinfoil.containers.tinfoil.dev
 
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point routing to `router.inf5.tinfoil.sh` and migrate model enclaves to the new `tinfoil.containers` hosts (`.tinfoil.sh` and `.tinfoil.dev`), decommissioning all `inf9` endpoints. Consolidate `gpt-oss-120b` to a single `inf5` endpoint.

<sup>Written for commit a13f99ab9348ba9977b493ecc600b9d93cc97b21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

