### PR TITLE
ci: switch to container-release-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,15 @@
 name: Docker Build and Publish
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. v1.0.0)'
+        required: true
+        type: string
+
+concurrency:
+  group: build-and-release
 
 jobs:
   docker-build:
@@ -11,6 +17,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -32,11 +40,12 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
             type=sha,format=short
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         env:
           SOURCE_DATE_EPOCH: 0
@@ -46,21 +55,22 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ github.ref_name }}
+            VERSION=${{ inputs.version }}
 
   release:
     needs: docker-build
     runs-on: ubuntu-latest
     permissions:
+      pull-requests: write
       contents: write
       packages: write
       id-token: write
       attestations: write
 
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-      - uses: tinfoilsh/pri-build-action@5d450a7f30904866efc401e24484b935b7ed52dd # v0.6.1
+      - uses: tinfoilsh/container-release-action@63f9a2f3e3eab910919aff711131060bae939fc0 # v0.2.0
         with:
-          config-file: ${{ github.workspace }}/tinfoil-config.yml
+          digest: ${{ needs.docker-build.outputs.digest }}
+          version: ${{ inputs.version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: "true"
+          release-branch: ${{ github.ref_name }}


### PR DESCRIPTION
This deprecates the tag-push release flow. Releases should now be done by manually triggering the build.yml workflow either via the Github website or the gh CLI. This change enables pinning the container hash in tinfoil-config.yml and automates the creation of the version tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches releases to a manual `build.yml` workflow using `tinfoilsh/container-release-action`. Removes tag-push releases; the workflow auto-creates the version tag on the current branch, pins the image digest in `tinfoil-config.yml` via PR, and prevents overlapping runs.

- New Features
  - Trigger releases via the GitHub UI or `gh` with the `version` input (e.g., v1.0.0); publishes semver and short `sha` tags.
  - Pins the built image digest in `tinfoil-config.yml` via PR and uses concurrency to avoid overlapping runs.

- Migration
  - Run the “Docker Build and Publish” workflow and pass `version` to release. Stop pushing `v*` tags to trigger releases.

<sup>Written for commit aa98383e6d90f597aa95996b08b143b27b14761b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

