### PR TITLE
move: nomic

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:
-      - nomic-embed-text.tinfoil.containers.tinfoil.sh
+      - nomic-embed-text.tinfoil.containers.tinfoil.dev
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point `nomic-embed-text` to the new enclave domain on tinfoil.dev. Updates `config.yml` to use `nomic-embed-text.tinfoil.containers.tinfoil.dev` instead of the old tinfoil.sh endpoint.

<sup>Written for commit f5f707a20e5cf3489f1b018d2a757634e901ddf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

