### PR TITLE
move: qwenvl

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -55,7 +55,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.inf9.tinfoil.sh
+      - qwen3-vl-30b.tinfoil.containers.tinfoil.dev
 
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated `config.yml` to point `qwen3-vl-30b` to the new enclave host `qwen3-vl-30b.tinfoil.containers.tinfoil.dev` instead of `qwen3-vl-30b.inf9.tinfoil.sh`. This ensures requests route to the correct deployment.

<sup>Written for commit af417bb12fb81c056186c91941686907903b569c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

