### PR TITLE
move: gpt-oss-safeguard

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -45,7 +45,7 @@ models:
   gpt-oss-safeguard-120b:
     repo: tinfoilsh/confidential-gpt-oss-safeguard-120b
     enclaves:
-      - gpt-oss-safeguard-120b.inf9.tinfoil.sh
+      - gpt-oss-safeguard-120b.tinfoil.containers.tinfoil.dev
 
   qwen3-tts:
     repo: tinfoilsh/confidential-qwen3-tts


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `gpt-oss-safeguard-120b` enclave host to gpt-oss-safeguard-120b.tinfoil.containers.tinfoil.dev to route traffic to the new containers environment.

<sup>Written for commit c36a111f5f25bd75fe8211bdee8f80a419ee1fc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

