### PR TITLE
chore: change some models to inf9

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -22,12 +22,12 @@ models:
   voxtral-small-24b:
     repo: tinfoilsh/confidential-voxtral-small-24b
     enclaves:
-      - voxtral-small-24b.tinfoil.containers.tinfoil.dev
+      - voxtral-small-24b.inf9.tinfoil.sh
 
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
     enclaves:
-      - llama3-3-70b.tinfoil.containers.tinfoil.dev
+      - llama3-3-70b.inf9.tinfoil.sh
 
   deepseek-r1-0528:
     repo: tinfoilsh/confidential-deepseek-r1-0528
@@ -55,7 +55,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.tinfoil.containers.tinfoil.dev
+      - qwen3-vl-30b.inf9.tinfoil.sh
 
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched enclave endpoints for `voxtral-small-24b`, `llama3-3-70b`, and `qwen3-vl-30b` to the `*.inf9.tinfoil.sh` cluster in `config.yml`, moving them off `tinfoil.containers.tinfoil.dev`. No functional changes; requests to these models now route through inf9.

<sup>Written for commit e77ccefbd50eec5c55ac86242bd079c687b724e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

