### PR TITLE
fix: temporarily remove TDX router

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,5 @@
 routers:
   inference.tinfoil.sh:
-  router.inf5.tinfoil.sh:
   router.inf6.tinfoil.sh:
 
 models:


### PR DESCRIPTION
Removing this router while we figure out a better solution for delivering updated TDX PCS collateral for verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily remove the TDX router to stop routing to outdated PCS collateral while we finalize a new delivery path. Deleted `router.inf5.tinfoil.sh` from the `routers` list in `config.yml`; other routers are unchanged.

<sup>Written for commit 6e8dc34a207008119198c845f948e01abae50d20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

