### PR TITLE
chore/bump

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -23,6 +23,11 @@ models:
     enclaves:
       - voxtral-small-24b.inf9.tinfoil.sh
 
+  voxtral-mini-4b-realtime:
+    repo: tinfoilsh/confidential-realtime-models
+    enclaves:
+      - realtime-models.tinfoil.containers.tinfoil.dev
+
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
     enclaves:
@@ -47,9 +52,9 @@ models:
       - gpt-oss-safeguard-120b.tinfoil.containers.tinfoil.dev
 
   qwen3-tts:
-    repo: tinfoilsh/confidential-qwen3-tts
+    repo: tinfoilsh/confidential-realtime-models
     enclaves:
-      - qwen3-tts.inf6.tinfoil.sh
+      - realtime-models.tinfoil.containers.tinfoil.dev
 
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,4 +1,4 @@
-cvm-version: 0.7.1
+cvm-version: 0.7.3
 cpus: 8
 memory: 16384
 
@@ -8,7 +8,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.70"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.71"
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION
- **feat: add voxtral mini and update repo for qwen3-tts**
- **chore: bump container and cvm**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `voxtral-mini-4b-realtime` and migrates `qwen3-tts` to the shared `confidential-realtime-models` repo and realtime enclave. Also bumps CVM and model router versions.

- **New Features**
  - Added `voxtral-mini-4b-realtime` in `tinfoilsh/confidential-realtime-models` using `realtime-models.tinfoil.containers.tinfoil.dev`.
  - Moved `qwen3-tts` to `tinfoilsh/confidential-realtime-models` and `realtime-models.tinfoil.containers.tinfoil.dev`.

- **Dependencies**
  - Updated CVM to 0.7.3.
  - Updated router image to `ghcr.io/tinfoilsh/confidential-model-router:0.0.71`.

<sup>Written for commit 16c9c8862eb0272746cff908a15beb32c8f4fd3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

