### PR TITLE
feat: add support for websocket proxying

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,15 @@ func sendJSON(w http.ResponseWriter, data any) {
 }
 
 func isWebSocketUpgrade(r *http.Request) bool {
-	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
+	if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		return false
+	}
+	for _, v := range strings.Split(r.Header.Get("Connection"), ",") {
+		if strings.EqualFold(strings.TrimSpace(v), "upgrade") {
+			return true
+		}
+	}
+	return false
 }
 
 func parseModelFromSubdomain(r *http.Request, domain string) (string, error) {

--- a/main.go
+++ b/main.go
@@ -95,6 +95,10 @@ func sendJSON(w http.ResponseWriter, data any) {
 	}
 }
 
+func isWebSocketUpgrade(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
+}
+
 func parseModelFromSubdomain(r *http.Request, domain string) (string, error) {
 	// Check if the request is for a subdomain and derive model from leftmost subdomain.
 	host := r.Header.Get("X-Forwarded-Host")
@@ -192,6 +196,21 @@ func main() {
 		if modelName, err = parseModelFromSubdomain(r, *domain); err != nil {
 			jsonError(w, fmt.Sprintf("Invalid request: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 			return
+		}
+
+		// WebSocket upgrade on /v1/realtime: extract model from ?model= query parameter, skip body parsing
+		if isWebSocketUpgrade(r) && r.URL.Path == "/v1/realtime" {
+			if modelName == "" {
+				modelName = r.URL.Query().Get("model")
+			}
+			if modelName == "" {
+				jsonError(w, "Missing required parameter: 'model' (use ?model=<name> query parameter for WebSocket requests).", manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+				return
+			}
+			log.WithFields(log.Fields{
+				"model": modelName,
+				"path":  r.URL.Path,
+			}).Debug("WebSocket upgrade request")
 		} else if modelName == "" { // The request does not use a subdomain. We route using specific inference routing logic.
 			if r.URL.Path == "/" {
 				http.Redirect(w, r, "https://docs.tinfoil.sh", http.StatusTemporaryRedirect)

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -92,6 +92,13 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 
 	// Add token extraction and billing via ModifyResponse
 	proxy.ModifyResponse = func(resp *http.Response) error {
+		// WebSocket/protocol upgrade: the reverse proxy will hijack both
+		// connections and copy bidirectionally after this callback returns.
+		// We must not touch the body or wrap it.
+		if resp.StatusCode == http.StatusSwitchingProtocols {
+			return nil
+		}
+
 		// Extract request details that we'll need for billing
 		req := resp.Request
 		authHeader := req.Header.Get("Authorization")

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -92,13 +92,6 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 
 	// Add token extraction and billing via ModifyResponse
 	proxy.ModifyResponse = func(resp *http.Response) error {
-		// WebSocket/protocol upgrade: the reverse proxy will hijack both
-		// connections and copy bidirectionally after this callback returns.
-		// We must not touch the body or wrap it.
-		if resp.StatusCode == http.StatusSwitchingProtocols {
-			return nil
-		}
-
 		// Extract request details that we'll need for billing
 		req := resp.Request
 		authHeader := req.Header.Get("Authorization")
@@ -121,17 +114,6 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 		requestPath := req.URL.Path
 		streaming := strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream")
 
-		// Check if client requested usage metrics in response header/trailer
-		usageMetricsRequested := req.Header.Get(UsageMetricsRequestHeader) == "true"
-		if streaming && usageMetricsRequested {
-			addTrailerHeader(resp.Header, UsageMetricsResponseHeader)
-			if wrapper, ok := req.Context().Value(usageWriterKey{}).(*usageMetricsWriter); ok {
-				wrapper.EnableTrailer()
-			}
-		}
-
-		var handlerCalled atomic.Bool
-
 		emitZeroTokenEvent := func() {
 			billingCollector.AddEvent(billing.Event{
 				Timestamp:   time.Now(),
@@ -144,6 +126,27 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				Streaming:   streaming,
 			})
 		}
+
+		// WebSocket/protocol upgrade: the reverse proxy will hijack both
+		// connections and copy bidirectionally after this callback returns.
+		// We must not touch the body or wrap it, but still emit a billing event.
+		if resp.StatusCode == http.StatusSwitchingProtocols {
+			if billingCollector != nil && apiKey != "" {
+				emitZeroTokenEvent()
+			}
+			return nil
+		}
+
+		// Check if client requested usage metrics in response header/trailer
+		usageMetricsRequested := req.Header.Get(UsageMetricsRequestHeader) == "true"
+		if streaming && usageMetricsRequested {
+			addTrailerHeader(resp.Header, UsageMetricsResponseHeader)
+			if wrapper, ok := req.Context().Value(usageWriterKey{}).(*usageMetricsWriter); ok {
+				wrapper.EnableTrailer()
+			}
+		}
+
+		var handlerCalled atomic.Bool
 
 		// Create a usage handler that will be called when usage is extracted
 		usageHandler := func(usage *tokencount.Usage) {

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -8,7 +8,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.71"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.72"
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add WebSocket proxying for `/v1/realtime` so clients can establish realtime connections and stream data reliably. Clients must include the model via subdomain or `?model=` when connecting.

- **New Features**
  - Detect protocol upgrades using both `Upgrade` and `Connection` headers.
  - On `/v1/realtime`, read `model` from query if not in subdomain; skip body parsing; log upgrade with model.
  - On 101 Switching Protocols, let the proxy pass through and emit a zero‑token billing event on upgrade.

- **Dependencies**
  - Bump `ghcr.io/tinfoilsh/confidential-model-router` image to `0.0.72`.

<sup>Written for commit f614d1eb2e2030dd4654088994a27f5d5f622e1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

