### PR TITLE
fix: add auth support for Browser WebSocket auth

### DIFF
--- a/main.go
+++ b/main.go
@@ -215,6 +215,31 @@ func main() {
 				jsonError(w, "Missing required parameter: 'model' (use ?model=<name> query parameter for WebSocket requests).", manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 				return
 			}
+
+			// Browser WebSocket auth: extract API key from Sec-WebSocket-Protocol subprotocol
+			// Browsers can't set Authorization headers, so they pass the key as:
+			//   new WebSocket(url, ["realtime", "openai-insecure-api-key.<key>"])
+			if apiKey == "" {
+				const subprotoPrefix = "openai-insecure-api-key."
+				var cleaned []string
+				for _, proto := range strings.Split(r.Header.Get("Sec-WebSocket-Protocol"), ",") {
+					proto = strings.TrimSpace(proto)
+					if strings.HasPrefix(proto, subprotoPrefix) {
+						apiKey = strings.TrimPrefix(proto, subprotoPrefix)
+					} else if proto != "" {
+						cleaned = append(cleaned, proto)
+					}
+				}
+				if apiKey != "" {
+					r.Header.Set("Authorization", "Bearer "+apiKey)
+					if len(cleaned) > 0 {
+						r.Header.Set("Sec-WebSocket-Protocol", strings.Join(cleaned, ", "))
+					} else {
+						r.Header.Del("Sec-WebSocket-Protocol")
+					}
+				}
+			}
+
 			log.WithFields(log.Fields{
 				"model": modelName,
 				"path":  r.URL.Path,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds browser-compatible WebSocket auth by accepting API keys in the subprotocol list and converting them to a standard Bearer Authorization header. This lets browser clients authenticate without custom headers and avoids handshake failures.

- **Bug Fixes**
  - Support keys sent as "openai-insecure-api-key.<key>" (e.g., with "realtime").
  - Strip the key from Sec-WebSocket-Protocol after extraction; preserve other subprotocols or remove the header if empty.
  - Only applies when the Authorization header is missing.

<sup>Written for commit 378546a3254f17f6cce1d82dc99467116fccdd17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

