### PR TITLE
chore: bump container

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -8,7 +8,7 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.72"
+    image: "ghcr.io/tinfoilsh/confidential-model-router:0.0.74"
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the `proxy` container image in `tinfoil-config.yml` from `ghcr.io/tinfoilsh/confidential-model-router:0.0.72` to `ghcr.io/tinfoilsh/confidential-model-router:0.0.74` to align with the latest router release.

<sup>Written for commit 183817b3bc53eea0b0f62a064635e2d3257b5fd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

