### PR TITLE
Clean up JSON parsing 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,10 @@ require (
 	github.com/sigstore/timestamp-authority/v2 v2.0.3 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/theupdateframework/go-tuf/v2 v2.4.1 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.2.0 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/transparency-dev/formats v0.0.0-20251103090025-99ec6f4410eb // indirect
 	github.com/transparency-dev/merkle v0.0.2 // indirect
 	go.mongodb.org/mongo-driver v1.17.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -321,6 +321,17 @@ github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qv
 github.com/theupdateframework/go-tuf v0.7.0/go.mod h1:uEB7WSY+7ZIugK6R1hiBMBjQftaFzn7ZCDJcp1tCUug=
 github.com/theupdateframework/go-tuf/v2 v2.4.1 h1:K6ewW064rKZCPkRo1W/CTbTtm/+IB4+coG1iNURAGCw=
 github.com/theupdateframework/go-tuf/v2 v2.4.1/go.mod h1:Nex2enPVYDFCklrnbTzl3OVwD7fgIAj0J5++z/rvCj8=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/match v1.2.0 h1:0pt8FlkOwjN2fPt4bIl4BoNxb98gGHN2ObFEDkrfZnM=
+github.com/tidwall/match v1.2.0/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tinfoilsh/tinfoil-go v0.12.4 h1:HdUDvrdlMwqMIImcvn2i86jYnjMwvnky4zqOSSvTDN4=
 github.com/tinfoilsh/tinfoil-go v0.12.4/go.mod h1:eDxG2dtCTb6VP+kLm0CTuCMzvsIFK+Np0z2qS6yt9Nc=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -22,6 +21,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 
 	"github.com/tinfoilsh/confidential-model-router/manager"
 )
@@ -282,19 +283,18 @@ func main() {
 				return
 			} else if r.URL.Path == "/v1/audio/speech" {
 				// Extract model from JSON body, default to qwen3-tts
-				var body map[string]interface{}
 				bodyBytes, err := io.ReadAll(r.Body)
 				if err != nil {
 					jsonError(w, fmt.Sprintf("Could not read request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
 				r.Body.Close()
-				if err := json.Unmarshal(bodyBytes, &body); err != nil {
-					jsonError(w, fmt.Sprintf("Invalid request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+				if !gjson.ValidBytes(bodyBytes) {
+					jsonError(w, "Invalid request body: invalid JSON.", manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
-				if m, ok := body["model"].(string); ok && m != "" {
-					modelName = m
+				if r := gjson.GetBytes(bodyBytes, "model"); r.Type == gjson.String && r.String() != "" {
+					modelName = r.String()
 				} else {
 					modelName = "qwen3-tts"
 				}
@@ -314,44 +314,40 @@ func main() {
 			} else if r.URL.Path == "/v1/convert/file" {
 				modelName = "doc-upload"
 			} else { // This is an OpenAI-compatible API request
-				var body map[string]interface{}
 				bodyBytes, err := io.ReadAll(r.Body)
-
 				if err != nil {
 					jsonError(w, fmt.Sprintf("Could not read request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
-				if err := json.Unmarshal(bodyBytes, &body); err != nil {
-					jsonError(w, fmt.Sprintf("Invalid request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+				if !gjson.ValidBytes(bodyBytes) {
+					jsonError(w, "Invalid request body: invalid JSON.", manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
 
 				// Extract model name from request body
-				modelInterface, ok := body["model"]
-				if !ok {
+				modelResult := gjson.GetBytes(bodyBytes, "model")
+				if !modelResult.Exists() {
 					jsonError(w, "Missing required parameter: 'model'.", manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
-				modelName, ok = modelInterface.(string)
-				if !ok {
+				if modelResult.Type != gjson.String {
 					jsonError(w, "Invalid parameter: 'model' must be a string.", manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
+				modelName = modelResult.String()
 
 				// Check if request uses web search — route to websearch enclave.
 				// The original model name is preserved in the request body so the
 				// websearch service knows which model to use for inference.
-				useWebsearch := false
-				if _, ok := body["web_search_options"]; ok {
-					useWebsearch = true
-				} else if r.URL.Path == "/v1/responses" {
-					if tools, ok := body["tools"].([]interface{}); ok {
-						useWebsearch = slices.ContainsFunc(tools, func(t any) bool {
-							m, _ := t.(map[string]any)
-							typeVal, ok := m["type"].(string)
-							return ok && typeVal == "web_search"
-						})
-					}
+				useWebsearch := gjson.GetBytes(bodyBytes, "web_search_options").Exists()
+				if !useWebsearch && r.URL.Path == "/v1/responses" {
+					gjson.GetBytes(bodyBytes, "tools").ForEach(func(_, tool gjson.Result) bool {
+						if tool.Get("type").String() == "web_search" {
+							useWebsearch = true
+							return false
+						}
+						return true
+					})
 				}
 				rateLimitModel := modelName
 				if useWebsearch {
@@ -360,14 +356,15 @@ func main() {
 
 				// Strip any user-supplied priority to prevent circumventing rate limits
 				// or jumping ahead of other users.
-				_, hadPriority := body["priority"]
-				delete(body, "priority")
+				bodyModified := gjson.GetBytes(bodyBytes, "priority").Exists()
+				if bodyModified {
+					bodyBytes, _ = sjson.DeleteBytes(bodyBytes, "priority")
+				}
 
 				// Check rate limiting and inject lower vLLM priority if over budget
-				bodyModified := hadPriority
 				if rlCfg := em.GetRateLimitConfig(rateLimitModel); rlCfg != nil {
 					if apiKey != "" && em.RequestTracker().RecordAndCheck(apiKey, rateLimitModel, rlCfg.MaxRequestsPerMinute) {
-						body["priority"] = 1
+						bodyBytes, _ = sjson.SetBytes(bodyBytes, "priority", 1)
 						bodyModified = true
 						manager.RateLimitDemotionsTotal.WithLabelValues(rateLimitModel).Inc()
 						log.WithFields(log.Fields{
@@ -377,24 +374,13 @@ func main() {
 				}
 
 				// If streaming request, ensure continuous_usage_stats is enabled
-				if stream, ok := body["stream"].(bool); ok && stream {
+				if gjson.GetBytes(bodyBytes, "stream").Type == gjson.True {
 					// Check if client requested usage stats before we modify anything
-					clientRequestedUsage := false
-					if streamOptions, ok := body["stream_options"].(map[string]interface{}); ok {
-						// Check for OpenAI-style include_usage
-						if includeUsage, ok := streamOptions["include_usage"].(bool); ok && includeUsage {
-							clientRequestedUsage = true
-						}
-						// Check for vLLM-style continuous_usage_stats
-						if continuousUsage, ok := streamOptions["continuous_usage_stats"].(bool); ok && continuousUsage {
-							clientRequestedUsage = true
-						}
-						streamOptions["continuous_usage_stats"] = true
-					} else {
-						body["stream_options"] = map[string]interface{}{
-							"continuous_usage_stats": true,
-						}
-					}
+					clientRequestedUsage := gjson.GetBytes(bodyBytes, "stream_options.include_usage").Type == gjson.True ||
+						gjson.GetBytes(bodyBytes, "stream_options.continuous_usage_stats").Type == gjson.True
+
+					bodyBytes, _ = sjson.SetBytes(bodyBytes, "stream_options.continuous_usage_stats", true)
+					bodyModified = true
 
 					// Set internal header to indicate if client requested usage
 					// This header will be used by the proxy to decide whether to filter usage-only chunks
@@ -402,27 +388,10 @@ func main() {
 						r.Header.Set("X-Tinfoil-Client-Requested-Usage", "true")
 					}
 
-					// Re-encode the modified body
-					newBodyBytes, err := json.Marshal(body)
-					if err != nil {
-						jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusInternalServerError)
-						return
-					}
-					bodyBytes = newBodyBytes
-					// Update Content-Length header to match new body size
-					r.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
-					r.ContentLength = int64(len(bodyBytes))
 					log.Debugf("Modified streaming request body to include continuous_usage_stats, client requested usage: %v", clientRequestedUsage)
 				}
 
-				// Re-encode body if rate limiting modified it (non-streaming path)
 				if bodyModified {
-					newBodyBytes, err := json.Marshal(body)
-					if err != nil {
-						jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusInternalServerError)
-						return
-					}
-					bodyBytes = newBodyBytes
 					r.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
 					r.ContentLength = int64(len(bodyBytes))
 				}

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -213,9 +213,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 			resp.Body.Close()
 
 			// Extract usage from JSON
-			var jsonResp struct {
-				Usage *tokencount.Usage `json:"usage"`
-			}
+			var jsonResp tokencount.OpenAIResponse
 			if err := json.Unmarshal(bodyBytes, &jsonResp); err == nil && jsonResp.Usage != nil {
 				jsonResp.Usage.Normalize()
 				// Call usage handler for billing

--- a/tokencount/extractor.go
+++ b/tokencount/extractor.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+
+	"github.com/tidwall/gjson"
 )
 
 // Usage represents token usage information from inference responses.
@@ -185,43 +187,35 @@ func (s *StreamingTokenExtractor) processStream() {
 		if strings.HasPrefix(line, "data: ") {
 			data := strings.TrimPrefix(line, "data: ")
 			if data != "[DONE]" {
-				// Try to parse the chunk
-				var chunk map[string]interface{}
-				if err := json.Unmarshal([]byte(data), &chunk); err == nil {
-					// Check for usage in the chunk (Chat Completions API)
-					// or nested under "response" (Responses API streaming)
-					usageData, ok := chunk["usage"]
-					if (!ok || usageData == nil) {
-						if respObj, rOk := chunk["response"].(map[string]interface{}); rOk {
-							usageData, ok = respObj["usage"]
+				// Check for usage in the chunk (Chat Completions API)
+				// or nested under "response" (Responses API streaming)
+				usageResult := gjson.Get(data, "usage")
+				if !usageResult.Exists() || usageResult.Type == gjson.Null {
+					usageResult = gjson.Get(data, "response.usage")
+				}
+				if usageResult.Exists() && usageResult.Type != gjson.Null {
+					var usage Usage
+					if err := json.Unmarshal([]byte(usageResult.Raw), &usage); err == nil {
+						usage.Normalize()
+						// Update usage data (continuous stats may send incremental updates)
+						if usage.PromptTokens > 0 {
+							s.usage.PromptTokens = usage.PromptTokens
+						}
+						if usage.CompletionTokens > 0 {
+							s.usage.CompletionTokens = usage.CompletionTokens
+						}
+						if usage.TotalTokens > 0 {
+							s.usage.TotalTokens = usage.TotalTokens
 						}
 					}
-					if ok && usageData != nil {
-						usageBytes, _ := json.Marshal(usageData)
-						var usage Usage
-						if err := json.Unmarshal(usageBytes, &usage); err == nil {
-							usage.Normalize()
-							// Update usage data (continuous stats may send incremental updates)
-							if usage.PromptTokens > 0 {
-								s.usage.PromptTokens = usage.PromptTokens
-							}
-							if usage.CompletionTokens > 0 {
-								s.usage.CompletionTokens = usage.CompletionTokens
-							}
-							if usage.TotalTokens > 0 {
-								s.usage.TotalTokens = usage.TotalTokens
-							}
-						}
 
-						// Check if this is a usage-only chunk that should be filtered
-						if !s.clientRequestedUsage {
-							// Check if choices array exists and is empty
-							if choices, hasChoices := chunk["choices"].([]interface{}); hasChoices && len(choices) == 0 {
-								// This is a usage-only chunk with empty choices array
-								// Filter it out since client didn't request usage
-								shouldWrite = false
-								lastLineWasFiltered = true
-							}
+					// Check if this is a usage-only chunk that should be filtered
+					if !s.clientRequestedUsage {
+						// Check if choices array exists and is empty
+						choices := gjson.Get(data, "choices")
+						if choices.Exists() && choices.IsArray() && len(choices.Array()) == 0 {
+							shouldWrite = false
+							lastLineWasFiltered = true
 						}
 					}
 				}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replace map-based JSON handling with `gjson`/`sjson` for safer parsing and faster mutations, and simplify usage extraction in streaming and non‑streaming paths. This improves robustness, reduces allocations, and standardizes billing usage handling.

- **Refactors**
  - Validate JSON bodies with `gjson.ValidBytes`; return clear errors on invalid JSON.
  - Extract `model` via `gjson` (default `qwen3-tts` for `/v1/audio/speech`); ensure it’s a string.
  - Detect web search via `web_search_options` or `tools[*].type == "web_search"`.
  - Remove user `priority` with `sjson.DeleteBytes`; set `priority: 1` when rate-limited; update Content-Length when body changes.
  - For streaming, always set `stream_options.continuous_usage_stats = true`; set `X-Tinfoil-Client-Requested-Usage` if requested.
  - Use `gjson` in streaming to update running token usage and filter usage-only chunks when not requested.
  - Reuse `tokencount.OpenAIResponse` in proxy to read `usage`; normalize and forward to billing.

- **Dependencies**
  - Add `github.com/tidwall/gjson`, `github.com/tidwall/sjson`, `github.com/tidwall/match`, `github.com/tidwall/pretty`.

<sup>Written for commit 7078d5860eb9e3a951e88230a81ec0768bc91df1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

