### PR TITLE
chore: add gpt-oss instances

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,6 +42,8 @@ models:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
       - gpt-oss-120b-inf5.tinfoil.containers.tinfoil.dev
+      - gpt-oss-120b-inf5-2.tinfoil.containers.tinfoil.dev
+      - gpt-oss-120b-inf5-3.inf5.tinfoil.sh
     overload:
       max_requests_waiting: 8
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added two new `gpt-oss-120b` enclave endpoints in `config.yml` to increase inference capacity and improve availability.

<sup>Written for commit 9a3bfcece0a82ace3278517d3c9c4e49ae6285d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

