### PR TITLE
Jules/reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ proxy
 proxyctl
 ext.yml
 tuf-repo-cdn.sigstore.dev.json
+router

--- a/main.go
+++ b/main.go
@@ -248,6 +248,19 @@ func main() {
 			if r.URL.Path == "/" {
 				http.Redirect(w, r, "https://docs.tinfoil.sh", http.StatusTemporaryRedirect)
 				return
+			} else if r.URL.Path == "/health" {
+				healthy, issues := em.Healthy()
+				if healthy {
+					sendJSON(w, map[string]string{"status": "ok"})
+				} else {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusServiceUnavailable)
+					json.NewEncoder(w).Encode(map[string]any{
+						"status":          "unhealthy",
+						"unhealthy_models": issues,
+					})
+				}
+				return
 			} else if r.URL.Path == "/.well-known/tinfoil-proxy" {
 				status := em.Status()
 				status["version"] = version

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -40,8 +40,9 @@ type Model struct {
 	Overload          *config.OverloadConfig   `json:"overload,omitempty"`
 	RateLimit         *config.RateLimitConfig  `json:"rate_limit,omitempty"`
 
-	counter uint64
-	mu      sync.RWMutex
+	expectedHosts int // number of configured hostnames; 0 means no backends expected
+	counter       uint64
+	mu            sync.RWMutex
 }
 
 type EnclaveManager struct {
@@ -186,6 +187,28 @@ func (em *EnclaveManager) Models() map[string]*Model {
 		return true
 	})
 	return models
+}
+
+// Healthy returns true if every model that has configured hostnames also has
+// at least one verified enclave. Models with no configured hostnames are
+// excluded. It also returns the list of unhealthy model names.
+func (em *EnclaveManager) Healthy() (bool, []string) {
+	if em.lastSuccessfulUpdate.IsZero() {
+		return false, []string{"initial sync has not completed"}
+	}
+	var unhealthy []string
+	em.models.Range(func(key, value any) bool {
+		model := value.(*Model)
+		model.mu.RLock()
+		expected := model.expectedHosts
+		actual := len(model.Enclaves)
+		model.mu.RUnlock()
+		if expected > 0 && actual == 0 {
+			unhealthy = append(unhealthy, key.(string))
+		}
+		return true
+	})
+	return len(unhealthy) == 0, unhealthy
 }
 
 // Status returns the status of the enclave manager to be JSON encoded
@@ -379,6 +402,7 @@ func (em *EnclaveManager) addModel(modelName string, modelConfig config.Model) {
 		Enclaves:          make(map[string]*Enclave),
 		Overload:          modelConfig.Overload,
 		RateLimit:         modelConfig.RateLimit,
+		expectedHosts:     len(modelConfig.Hostnames),
 	})
 }
 
@@ -474,6 +498,7 @@ func (em *EnclaveManager) sync() error {
 
 			log.Tracef("Updating config for model %s", modelName)
 			model.mu.Lock()
+			model.expectedHosts = len(configModel.Hostnames)
 			model.Overload = configModel.Overload
 			model.RateLimit = configModel.RateLimit
 			for _, enclave := range model.Enclaves {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a `/health` HTTP endpoint that reports service health based on configured models and verified enclaves. This enables external probes to detect when the proxy is ready or degraded.

- **New Features**
  - Exposes `GET /health`: returns 200 with {"status":"ok"} when healthy.
  - Returns 503 with JSON on failure: {"status":"unhealthy","unhealthy_models":[...]} or "initial sync has not completed".
  - Health rules: only models with configured hostnames are checked; each must have at least one verified enclave. The manager tracks expected hosts from config and updates them during sync.

<sup>Written for commit b6505ee93515dfe8af7e1b3e915e0b9551a82335. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

