### PR TITLE
feat: implement circuit breaker to only route traffic to healthy endp…

### DIFF
--- a/manager/circuitbreaker.go
+++ b/manager/circuitbreaker.go
@@ -1,0 +1,97 @@
+package manager
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type cbState int32
+
+const (
+	cbClosed   cbState = iota // healthy — traffic flows normally
+	cbOpen                    // unhealthy — traffic is blocked
+	cbHalfOpen                // probing — one request allowed to test recovery
+)
+
+const (
+	cbFailureThreshold = 3                // consecutive failures before opening
+	cbCooldown         = 30 * time.Second // wait before probing after opening
+)
+
+// circuitBreaker tracks the health of a single enclave backend using the
+// standard closed → open → half-open state machine.
+//
+// All methods are safe for concurrent use.
+type circuitBreaker struct {
+	state               atomic.Int32
+	consecutiveFailures atomic.Int64
+	lastFailureNano     atomic.Int64
+}
+
+func newCircuitBreaker() *circuitBreaker {
+	return &circuitBreaker{}
+}
+
+func (cb *circuitBreaker) loadState() cbState {
+	return cbState(cb.state.Load())
+}
+
+func (cb *circuitBreaker) storeState(s cbState) {
+	cb.state.Store(int32(s))
+}
+
+func (cb *circuitBreaker) casState(old, new cbState) bool {
+	return cb.state.CompareAndSwap(int32(old), int32(new))
+}
+
+// RecordSuccess resets the circuit breaker to the closed state.
+func (cb *circuitBreaker) RecordSuccess() {
+	cb.consecutiveFailures.Store(0)
+	cb.storeState(cbClosed)
+}
+
+// RecordFailure increments the consecutive failure counter and transitions
+// to the open state once the threshold is reached.
+func (cb *circuitBreaker) RecordFailure() {
+	cb.lastFailureNano.Store(time.Now().UnixNano())
+	failures := cb.consecutiveFailures.Add(1)
+	if failures >= cbFailureThreshold {
+		cb.storeState(cbOpen)
+	}
+}
+
+// Available reports whether the enclave should receive traffic.
+//
+//   - Closed: always available.
+//   - Open: available only after the cooldown has elapsed, at which point the
+//     state transitions to half-open so exactly one probe request goes through.
+//   - Half-open: not available (a probe is already in flight).
+func (cb *circuitBreaker) Available() bool {
+	switch cb.loadState() {
+	case cbClosed:
+		return true
+	case cbOpen:
+		last := time.Unix(0, cb.lastFailureNano.Load())
+		if time.Since(last) < cbCooldown {
+			return false
+		}
+		if cb.casState(cbOpen, cbHalfOpen) {
+			return true
+		}
+		return false
+	case cbHalfOpen:
+		return false
+	default:
+		return true
+	}
+}
+
+// State returns the current state for observability.
+func (cb *circuitBreaker) State() cbState {
+	return cb.loadState()
+}
+
+// ConsecutiveFailures returns the current consecutive failure count.
+func (cb *circuitBreaker) ConsecutiveFailures() int64 {
+	return cb.consecutiveFailures.Load()
+}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -30,6 +30,7 @@ type Enclave struct {
 	predicate attestation.PredicateType
 	proxy     *httputil.ReverseProxy
 	metrics   *enclaveMetrics
+	cb        *circuitBreaker
 }
 
 type Model struct {
@@ -167,13 +168,15 @@ func (em *EnclaveManager) addEnclave(
 		return fmt.Errorf("measurement mismatch for enclave %s: %v", host, err)
 	}
 
+	cb := newCircuitBreaker()
 	model.Enclaves[host] = &Enclave{
 		host:      host,
 		predicate: verification.Measurement.Type,
 		tlsKeyFP:  verification.TLSPublicKeyFP,
 		hpkeKey:   verification.HPKEPublicKey,
-		proxy:     newProxy(host, verification.TLSPublicKeyFP, modelName, em.billingCollector),
+		proxy:     newProxy(host, verification.TLSPublicKeyFP, modelName, em.billingCollector, cb),
 		metrics:   newEnclaveMetrics(host, modelName),
+		cb:        cb,
 	}
 	model.Enclaves[host].updateOverloadConfig(model.Overload)
 	return nil
@@ -288,7 +291,10 @@ func (em *EnclaveManager) Shutdown() {
 	})
 }
 
-// NextEnclave gets the next sequential enclave
+// NextEnclave returns the next enclave using round-robin, preferring enclaves
+// whose circuit breaker is not open. If all circuit breakers are open, it
+// falls back to round-robin across all enclaves (degraded service is better
+// than no service).
 func (m *Model) NextEnclave() *Enclave {
 	count := atomic.AddUint64(&m.counter, 1)
 	m.mu.RLock()
@@ -298,13 +304,21 @@ func (m *Model) NextEnclave() *Enclave {
 		return nil
 	}
 
-	// Convert map to slice for indexed access
-	enclaves := make([]*Enclave, 0, len(m.Enclaves))
+	all := make([]*Enclave, 0, len(m.Enclaves))
+	available := make([]*Enclave, 0, len(m.Enclaves))
 	for _, enclave := range m.Enclaves {
-		enclaves = append(enclaves, enclave)
+		all = append(all, enclave)
+		if enclave.cb == nil || enclave.cb.Available() {
+			available = append(available, enclave)
+		}
 	}
 
-	return enclaves[(count-1)%uint64(len(enclaves))]
+	pool := available
+	if len(pool) == 0 {
+		pool = all
+	}
+
+	return pool[(count-1)%uint64(len(pool))]
 }
 
 func (e *Enclave) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -69,4 +69,33 @@ var (
 		},
 		[]string{"model"},
 	)
+
+	// CircuitBreakerState tracks the current state of each enclave's circuit breaker (0=closed, 1=open, 2=half-open)
+	CircuitBreakerState = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "router_circuit_breaker_state",
+			Help: "Current circuit breaker state (0=closed/healthy, 1=open/unhealthy, 2=half-open/probing)",
+		},
+		[]string{"model", "enclave"},
+	)
+
+	// ProxySuccessTotal tracks successful proxy responses per enclave
+	ProxySuccessTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_proxy_success_total",
+			Help: "Total number of successful proxy responses (status < 500)",
+		},
+		[]string{"model", "enclave"},
+	)
+
+	// ProxyFailureTotal tracks failed proxy responses and transport errors per enclave.
+	// The "reason" label classifies the failure: timeout, tls_mismatch, connection_refused,
+	// connection_reset, dns_error, tls_error, canceled, transport_error, or http_<status>.
+	ProxyFailureTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_proxy_failure_total",
+			Help: "Total number of failed proxy responses (status >= 500 or transport error)",
+		},
+		[]string{"model", "enclave", "reason"},
+	)
 )

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -132,6 +132,17 @@ func (t *slowHeaderTripper) RoundTrip(req *http.Request) (*http.Response, error)
 }
 
 func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Collector, cb *circuitBreaker) *httputil.ReverseProxy {
+	recordFailure := func(reason string) {
+		cb.RecordFailure()
+		ProxyFailureTotal.WithLabelValues(modelName, host, reason).Inc()
+		CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cb.State()))
+	}
+	recordSuccess := func() {
+		cb.RecordSuccess()
+		ProxySuccessTotal.WithLabelValues(modelName, host).Inc()
+		CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cb.State()))
+	}
+
 	transport := &slowHeaderTripper{
 		base: &tinfoilClient.TLSBoundRoundTripper{
 			ExpectedPublicKey: publicKeyFP,
@@ -143,9 +154,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				"enclave": host,
 				"timeout": responseHeaderTimeout,
 			}).Warn("backend slow: response headers not received within timeout")
-			cb.RecordFailure()
-			ProxyFailureTotal.WithLabelValues(modelName, host, "slow").Inc()
-			CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cb.State()))
+			recordFailure("slow")
 		},
 	}
 	proxy := httputil.NewSingleHostReverseProxy(&url.URL{
@@ -161,9 +170,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 			"reason":  reason,
 			"error":   err.Error(),
 		}).Error("proxy error")
-		cb.RecordFailure()
-		ProxyFailureTotal.WithLabelValues(modelName, host, reason).Inc()
-		CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cb.State()))
+		recordFailure(reason)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)
 		json.NewEncoder(w).Encode(map[string]any{
@@ -177,13 +184,10 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 	// Add token extraction and billing via ModifyResponse
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		if resp.StatusCode >= 500 {
-			cb.RecordFailure()
-			ProxyFailureTotal.WithLabelValues(modelName, host, httpFailureReason(resp.StatusCode)).Inc()
+			recordFailure(httpFailureReason(resp.StatusCode))
 		} else {
-			cb.RecordSuccess()
-			ProxySuccessTotal.WithLabelValues(modelName, host).Inc()
+			recordSuccess()
 		}
-		CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cb.State()))
 
 		// Extract request details that we'll need for billing
 		req := resp.Request

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -2,8 +2,12 @@ package manager
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/textproto"
@@ -12,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -21,6 +26,12 @@ import (
 )
 
 const (
+	// responseHeaderTimeout is the maximum time to wait for the backend to
+	// start responding (send response headers). This catches hanging backends
+	// without affecting long-running streaming responses, since the timeout
+	// only applies before the first byte is received.
+	responseHeaderTimeout = 60 * time.Second
+
 	// UsageMetricsRequestHeader is the request header clients set to request usage metrics
 	UsageMetricsRequestHeader = "X-Tinfoil-Request-Usage-Metrics"
 	// UsageMetricsResponseHeader is the response header (or trailer) containing usage metrics
@@ -30,6 +41,42 @@ const (
 	// websearchModel is charged per-request in addition to per-token.
 	websearchModel = "websearch"
 )
+
+// classifyProxyError maps a transport-level error to a bounded set of reason
+// labels for Prometheus. The raw error message is logged but not exposed as a
+// label to avoid unbounded cardinality.
+func classifyProxyError(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
+	}
+	if errors.Is(err, tinfoilClient.ErrCertMismatch) {
+		return "tls_mismatch"
+	}
+	if errors.Is(err, tinfoilClient.ErrNoTLS) || errors.Is(err, tinfoilClient.ErrNoValidCertificate) {
+		return "tls_error"
+	}
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		if errors.Is(netErr.Err, syscall.ECONNREFUSED) {
+			return "connection_refused"
+		}
+		if errors.Is(netErr.Err, syscall.ECONNRESET) {
+			return "connection_reset"
+		}
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return "dns_error"
+	}
+	return "transport_error"
+}
+
+func httpFailureReason(statusCode int) string {
+	return fmt.Sprintf("http_%d", statusCode)
+}
 
 // OpenAI-compatible error type strings returned in API error responses.
 const (
@@ -67,19 +114,56 @@ func (b *billingCloser) Close() error {
 	return err
 }
 
-func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Collector) *httputil.ReverseProxy {
-	httpClient := &http.Client{
-		Transport: &tinfoilClient.TLSBoundRoundTripper{
+// slowHeaderTripper wraps an http.RoundTripper and passively detects when a
+// backend takes longer than the configured timeout to send response headers.
+// Unlike a hard timeout, the request is never killed — the onSlow callback is
+// invoked for circuit breaker / metrics bookkeeping while the request continues.
+type slowHeaderTripper struct {
+	base    http.RoundTripper
+	timeout time.Duration
+	onSlow  func()
+}
+
+func (t *slowHeaderTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	timer := time.AfterFunc(t.timeout, t.onSlow)
+	resp, err := t.base.RoundTrip(req)
+	timer.Stop()
+	return resp, err
+}
+
+func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Collector, cb *circuitBreaker) *httputil.ReverseProxy {
+	transport := &slowHeaderTripper{
+		base: &tinfoilClient.TLSBoundRoundTripper{
 			ExpectedPublicKey: publicKeyFP,
+		},
+		timeout: responseHeaderTimeout,
+		onSlow: func() {
+			log.WithFields(log.Fields{
+				"model":   modelName,
+				"enclave": host,
+				"timeout": responseHeaderTimeout,
+			}).Warn("backend slow: response headers not received within timeout")
+			cb.RecordFailure()
+			ProxyFailureTotal.WithLabelValues(modelName, host, "slow").Inc()
+			CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cb.State()))
 		},
 	}
 	proxy := httputil.NewSingleHostReverseProxy(&url.URL{
 		Scheme: "https",
 		Host:   host,
 	})
-	proxy.Transport = httpClient.Transport
+	proxy.Transport = transport
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		log.Errorf("proxy error: %v", err)
+		reason := classifyProxyError(err)
+		log.WithFields(log.Fields{
+			"model":   modelName,
+			"enclave": host,
+			"reason":  reason,
+			"error":   err.Error(),
+		}).Error("proxy error")
+		cb.RecordFailure()
+		ProxyFailureTotal.WithLabelValues(modelName, host, reason).Inc()
+		CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cb.State()))
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)
 		json.NewEncoder(w).Encode(map[string]any{
@@ -92,6 +176,15 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 
 	// Add token extraction and billing via ModifyResponse
 	proxy.ModifyResponse = func(resp *http.Response) error {
+		if resp.StatusCode >= 500 {
+			cb.RecordFailure()
+			ProxyFailureTotal.WithLabelValues(modelName, host, httpFailureReason(resp.StatusCode)).Inc()
+		} else {
+			cb.RecordSuccess()
+			ProxySuccessTotal.WithLabelValues(modelName, host).Inc()
+		}
+		CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cb.State()))
+
 		// Extract request details that we'll need for billing
 		req := resp.Request
 		authHeader := req.Header.Get("Authorization")

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -313,12 +313,12 @@ func TestSlowHeaderTripper_FastResponse_NoCallback(t *testing.T) {
 }
 
 func TestSlowHeaderTripper_SlowResponse_CallbackFired(t *testing.T) {
-	var called atomic.Bool
+	called := make(chan struct{}, 1)
 	tripper := &slowHeaderTripper{
 		base:    http.DefaultTransport,
 		timeout: 50 * time.Millisecond,
 		onSlow: func() {
-			called.Store(true)
+			called <- struct{}{}
 		},
 	}
 
@@ -335,7 +335,9 @@ func TestSlowHeaderTripper_SlowResponse_CallbackFired(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	if !called.Load() {
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
 		t.Fatal("onSlow should be called for slow responses")
 	}
 }

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/tinfoilsh/confidential-model-router/billing"
 )
@@ -19,7 +21,7 @@ func setupTestProxyWithModel(t *testing.T, handler http.Handler, modelName strin
 	collector := billing.NewCollector("")
 	t.Cleanup(collector.Stop)
 
-	proxy := newProxy(backendURL.Host, "", modelName, collector)
+	proxy := newProxy(backendURL.Host, "", modelName, collector, newCircuitBreaker())
 	proxy.Director = func(req *http.Request) {
 		req.URL.Scheme = backendURL.Scheme
 		req.URL.Host = backendURL.Host
@@ -162,5 +164,205 @@ func TestProxyBilling_WebsearchEmitsOnlyZeroTokenEvent(t *testing.T) {
 	}
 	if events[0].Model != websearchModel {
 		t.Errorf("expected event model %q, got %q", websearchModel, events[0].Model)
+	}
+}
+
+// --- Circuit breaker tests ---
+
+func TestCircuitBreaker_StartsClosedAndAvailable(t *testing.T) {
+	cb := newCircuitBreaker()
+	if cb.State() != cbClosed {
+		t.Fatalf("expected closed, got %d", cb.State())
+	}
+	if !cb.Available() {
+		t.Fatal("expected available")
+	}
+}
+
+func TestCircuitBreaker_OpensAfterThreshold(t *testing.T) {
+	cb := newCircuitBreaker()
+	for i := 0; i < cbFailureThreshold-1; i++ {
+		cb.RecordFailure()
+		if cb.State() != cbClosed {
+			t.Fatalf("expected closed after %d failures, got %d", i+1, cb.State())
+		}
+	}
+	cb.RecordFailure()
+	if cb.State() != cbOpen {
+		t.Fatalf("expected open after %d failures, got %d", cbFailureThreshold, cb.State())
+	}
+	if cb.Available() {
+		t.Fatal("expected unavailable when open")
+	}
+}
+
+func TestCircuitBreaker_SuccessResetsClosed(t *testing.T) {
+	cb := newCircuitBreaker()
+	for i := 0; i < cbFailureThreshold; i++ {
+		cb.RecordFailure()
+	}
+	if cb.State() != cbOpen {
+		t.Fatal("expected open")
+	}
+	cb.RecordSuccess()
+	if cb.State() != cbClosed {
+		t.Fatalf("expected closed after success, got %d", cb.State())
+	}
+	if cb.ConsecutiveFailures() != 0 {
+		t.Fatalf("expected 0 failures after success, got %d", cb.ConsecutiveFailures())
+	}
+}
+
+func TestCircuitBreaker_HalfOpenAfterCooldown(t *testing.T) {
+	cb := newCircuitBreaker()
+	for i := 0; i < cbFailureThreshold; i++ {
+		cb.RecordFailure()
+	}
+	// Simulate cooldown by backdating lastFailureNano
+	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
+
+	if !cb.Available() {
+		t.Fatal("expected available after cooldown")
+	}
+	if cb.State() != cbHalfOpen {
+		t.Fatalf("expected half-open, got %d", cb.State())
+	}
+	// Second call should return false (half-open allows only one probe)
+	if cb.Available() {
+		t.Fatal("expected unavailable while half-open")
+	}
+}
+
+func TestCircuitBreaker_HalfOpenToClosedOnSuccess(t *testing.T) {
+	cb := newCircuitBreaker()
+	for i := 0; i < cbFailureThreshold; i++ {
+		cb.RecordFailure()
+	}
+	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
+	cb.Available() // transition to half-open
+
+	cb.RecordSuccess()
+	if cb.State() != cbClosed {
+		t.Fatalf("expected closed after half-open success, got %d", cb.State())
+	}
+}
+
+func TestCircuitBreaker_HalfOpenToOpenOnFailure(t *testing.T) {
+	cb := newCircuitBreaker()
+	for i := 0; i < cbFailureThreshold; i++ {
+		cb.RecordFailure()
+	}
+	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
+	cb.Available() // transition to half-open
+
+	cb.RecordFailure()
+	if cb.State() != cbOpen {
+		t.Fatalf("expected open after half-open failure, got %d", cb.State())
+	}
+}
+
+func TestCircuitBreaker_SuccessResetsFailureCount(t *testing.T) {
+	cb := newCircuitBreaker()
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.ConsecutiveFailures() != 2 {
+		t.Fatalf("expected 2 failures, got %d", cb.ConsecutiveFailures())
+	}
+	cb.RecordSuccess()
+	if cb.ConsecutiveFailures() != 0 {
+		t.Fatalf("expected 0 failures after success, got %d", cb.ConsecutiveFailures())
+	}
+	// Verify it takes full threshold again to trip
+	for i := 0; i < cbFailureThreshold; i++ {
+		cb.RecordFailure()
+	}
+	if cb.State() != cbOpen {
+		t.Fatal("expected open after fresh threshold failures")
+	}
+}
+
+// --- Slow header tripper tests ---
+
+func TestSlowHeaderTripper_FastResponse_NoCallback(t *testing.T) {
+	var called atomic.Bool
+	tripper := &slowHeaderTripper{
+		base:    http.DefaultTransport,
+		timeout: 100 * time.Millisecond,
+		onSlow: func() {
+			called.Store(true)
+		},
+	}
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	req, _ := http.NewRequest("GET", backend.URL, nil)
+	resp, err := tripper.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	// Give a bit of time to ensure callback wasn't called
+	time.Sleep(150 * time.Millisecond)
+	if called.Load() {
+		t.Fatal("onSlow should not be called for fast responses")
+	}
+}
+
+func TestSlowHeaderTripper_SlowResponse_CallbackFired(t *testing.T) {
+	var called atomic.Bool
+	tripper := &slowHeaderTripper{
+		base:    http.DefaultTransport,
+		timeout: 50 * time.Millisecond,
+		onSlow: func() {
+			called.Store(true)
+		},
+	}
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	req, _ := http.NewRequest("GET", backend.URL, nil)
+	resp, err := tripper.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	if !called.Load() {
+		t.Fatal("onSlow should be called for slow responses")
+	}
+}
+
+func TestSlowHeaderTripper_SlowResponse_RequestNotKilled(t *testing.T) {
+	tripper := &slowHeaderTripper{
+		base:    http.DefaultTransport,
+		timeout: 50 * time.Millisecond,
+		onSlow:  func() {},
+	}
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer backend.Close()
+
+	req, _ := http.NewRequest("GET", backend.URL, nil)
+	resp, err := tripper.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("request was killed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
…oints

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-enclave circuit breaker and routes traffic only to healthy backends. Improves observability with Prometheus metrics and bounded failure reasons, including slow-header detection.

- **New Features**
  - Circuit breaker (closed/open/half-open): opens after 3 consecutive failures; 30s cooldown; allows a single probe in half-open. Slow header (>60s to first byte) counts as a failure without canceling the request; success resets it.
  - Router uses round-robin but prefers enclaves with available breakers; falls back to all enclaves if none are healthy.
  - Proxy updates the breaker on transport errors and 5xx; classifies failure reasons: timeout, slow, canceled, tls_mismatch, tls_error, connection_refused, connection_reset, dns_error, transport_error, http_<status>.
  - Prometheus metrics:
    - router_circuit_breaker_state{model,enclave}
    - router_proxy_success_total{model,enclave}
    - router_proxy_failure_total{model,enclave,reason}
  - Tests cover circuit-breaker transitions and slow-header detection.

<sup>Written for commit c925180ab083645b9713c4bc6c6e93dbc33b1dbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

