### PR TITLE
chore: Update enclave for voxtral-small-24b model

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -21,7 +21,7 @@ models:
   voxtral-small-24b:
     repo: tinfoilsh/confidential-voxtral-small-24b
     enclaves:
-      - voxtral-small-24b.inf9.tinfoil.sh
+      - voxtral-small-24b.inf5.tinfoil.sh
 
   voxtral-mini-4b-realtime:
     repo: tinfoilsh/confidential-realtime-models


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update config to route the `voxtral-small-24b` model to the `inf5` enclave, matching the current deployment. Changed host from voxtral-small-24b.inf9.tinfoil.sh to voxtral-small-24b.inf5.tinfoil.sh.

<sup>Written for commit 9e79b35d9bf943791a79775158b3632f98544812. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

