### PR TITLE
chore: Update enclave URLs in config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -31,7 +31,7 @@ models:
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
     enclaves:
-      - llama3-3-70b.inf9.tinfoil.sh
+      - llama3-3-70b.tinfoil.containers.tinfoil.dev
 
   deepseek-r1-0528:
     repo: tinfoilsh/confidential-deepseek-r1-0528
@@ -61,7 +61,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.inf9.tinfoil.sh
+      - qwen3-vl-30b.tinfoil.containers.tinfoil.dev
 
   kimi-k2-thinking:
     repo: tinfoilsh/confidential-kimi-k2-thinking


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pointed the llama3-3-70b and qwen3-vl-30b enclave endpoints from *.inf9.tinfoil.sh to *.tinfoil.containers.tinfoil.dev in config.yml. Ensures requests route to the new containers environment.

<sup>Written for commit 89463d77b49cf781ebdf201afbeead58fb36f9ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

