### PR TITLE
feat: add health endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -249,17 +249,15 @@ func main() {
 				http.Redirect(w, r, "https://docs.tinfoil.sh", http.StatusTemporaryRedirect)
 				return
 			} else if r.URL.Path == "/health" {
-				healthy, issues := em.Healthy()
-				if healthy {
-					sendJSON(w, map[string]string{"status": "ok"})
-				} else {
+				if !em.Ready() {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusServiceUnavailable)
 					json.NewEncoder(w).Encode(map[string]any{
-						"status":          "unhealthy",
-						"unhealthy_models": issues,
+						"status": "not ready",
 					})
+					return
 				}
+				sendJSON(w, map[string]any{"status": "ok", "version": version})
 				return
 			} else if r.URL.Path == "/.well-known/tinfoil-proxy" {
 				status := em.Status()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -192,30 +192,14 @@ func (em *EnclaveManager) Models() map[string]*Model {
 	return models
 }
 
-// Healthy returns true if every model that has configured hostnames also has
-// at least one verified enclave. Models with no configured hostnames are
-// excluded. It also returns the list of unhealthy model names.
-func (em *EnclaveManager) Healthy() (bool, []string) {
+// Ready returns true if the router has completed at least one successful sync
+// and is able to serve requests.
+func (em *EnclaveManager) Ready() bool {
 	em.stateMu.Lock()
-	synced := !em.lastSuccessfulUpdate.IsZero()
-	em.stateMu.Unlock()
-	if !synced {
-		return false, []string{"initial sync has not completed"}
-	}
-	var unhealthy []string
-	em.models.Range(func(key, value any) bool {
-		model := value.(*Model)
-		model.mu.RLock()
-		expected := model.expectedHosts
-		actual := len(model.Enclaves)
-		model.mu.RUnlock()
-		if expected > 0 && actual == 0 {
-			unhealthy = append(unhealthy, key.(string))
-		}
-		return true
-	})
-	return len(unhealthy) == 0, unhealthy
+	defer em.stateMu.Unlock()
+	return !em.lastSuccessfulUpdate.IsZero()
 }
+
 
 // Status returns the status of the enclave manager to be JSON encoded
 func (em *EnclaveManager) Status() map[string]any {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a `/health` endpoint that reports readiness and version, using a simpler readiness check to avoid false unhealthy states.

- **New Features**
  - `/health` returns 503 with `{"status":"not ready"}` until the initial sync completes.
  - When ready, `/health` returns `{"status":"ok","version":<version>}`.

- **Refactors**
  - Replaced `Healthy()` with `Ready()` in the manager to check only for a successful initial sync (via `lastSuccessfulUpdate`).

<sup>Written for commit cbf47e14fac42ee27ddb25881e69e0a939bd1a41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

