### PR TITLE
fix: circuit breaker recovers reliably

### DIFF
--- a/manager/circuitbreaker.go
+++ b/manager/circuitbreaker.go
@@ -60,30 +60,23 @@ func (cb *circuitBreaker) RecordFailure() {
 	}
 }
 
-// Available reports whether the enclave should receive traffic.
-//
-//   - Closed: always available.
-//   - Open: available only after the cooldown has elapsed, at which point the
-//     state transitions to half-open so exactly one probe request goes through.
-//   - Half-open: not available (a probe is already in flight).
-func (cb *circuitBreaker) Available() bool {
-	switch cb.loadState() {
-	case cbClosed:
-		return true
-	case cbOpen:
-		last := time.Unix(0, cb.lastFailureNano.Load())
-		if time.Since(last) < cbCooldown {
-			return false
-		}
-		if cb.casState(cbOpen, cbHalfOpen) {
-			return true
-		}
+// Closed reports whether the circuit breaker is in the closed (healthy) state.
+func (cb *circuitBreaker) Closed() bool {
+	return cb.loadState() == cbClosed
+}
+
+// NeedProbe attempts to transition an open circuit breaker to half-open after
+// the cooldown has elapsed. Returns true if this caller won the CAS and should
+// send exactly one probe request to this enclave.
+func (cb *circuitBreaker) NeedProbe() bool {
+	if cb.loadState() != cbOpen {
 		return false
-	case cbHalfOpen:
-		return false
-	default:
-		return true
 	}
+	last := time.Unix(0, cb.lastFailureNano.Load())
+	if time.Since(last) < cbCooldown {
+		return false
+	}
+	return cb.casState(cbOpen, cbHalfOpen)
 }
 
 // State returns the current state for observability.

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"math/rand/v2"
 	"slices"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -42,7 +42,6 @@ type Model struct {
 	RateLimit         *config.RateLimitConfig  `json:"rate_limit,omitempty"`
 
 	expectedHosts int // number of configured hostnames; 0 means no backends expected
-	counter       uint64
 	mu            sync.RWMutex
 }
 
@@ -179,6 +178,7 @@ func (em *EnclaveManager) addEnclave(
 		cb:        cb,
 	}
 	model.Enclaves[host].updateOverloadConfig(model.Overload)
+	CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cbClosed))
 	return nil
 }
 
@@ -275,12 +275,10 @@ func (em *EnclaveManager) Shutdown() {
 	})
 }
 
-// NextEnclave returns the next enclave using round-robin, preferring enclaves
-// whose circuit breaker is not open. If all circuit breakers are open, it
-// falls back to round-robin across all enclaves (degraded service is better
-// than no service).
+// NextEnclave picks a uniformly random enclave with a closed circuit breaker.
+// If an open breaker is past its cooldown, it sends a probe to that enclave.
+// If all breakers are open, it picks a random enclave (degraded > unavailable).
 func (m *Model) NextEnclave() *Enclave {
-	count := atomic.AddUint64(&m.counter, 1)
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -289,20 +287,20 @@ func (m *Model) NextEnclave() *Enclave {
 	}
 
 	all := make([]*Enclave, 0, len(m.Enclaves))
-	available := make([]*Enclave, 0, len(m.Enclaves))
+	var closed []*Enclave
 	for _, enclave := range m.Enclaves {
 		all = append(all, enclave)
-		if enclave.cb == nil || enclave.cb.Available() {
-			available = append(available, enclave)
+		if enclave.cb == nil || enclave.cb.Closed() {
+			closed = append(closed, enclave)
+		} else if enclave.cb.NeedProbe() {
+			return enclave
 		}
 	}
 
-	pool := available
-	if len(pool) == 0 {
-		pool = all
+	if len(closed) > 0 {
+		return closed[rand.IntN(len(closed))]
 	}
-
-	return pool[(count-1)%uint64(len(pool))]
+	return all[rand.IntN(len(all))]
 }
 
 func (e *Enclave) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -169,13 +169,13 @@ func TestProxyBilling_WebsearchEmitsOnlyZeroTokenEvent(t *testing.T) {
 
 // --- Circuit breaker tests ---
 
-func TestCircuitBreaker_StartsClosedAndAvailable(t *testing.T) {
+func TestCircuitBreaker_StartsClosed(t *testing.T) {
 	cb := newCircuitBreaker()
 	if cb.State() != cbClosed {
 		t.Fatalf("expected closed, got %d", cb.State())
 	}
-	if !cb.Available() {
-		t.Fatal("expected available")
+	if !cb.Closed() {
+		t.Fatal("expected closed")
 	}
 }
 
@@ -191,8 +191,8 @@ func TestCircuitBreaker_OpensAfterThreshold(t *testing.T) {
 	if cb.State() != cbOpen {
 		t.Fatalf("expected open after %d failures, got %d", cbFailureThreshold, cb.State())
 	}
-	if cb.Available() {
-		t.Fatal("expected unavailable when open")
+	if cb.Closed() {
+		t.Fatal("expected not closed when open")
 	}
 }
 
@@ -213,23 +213,26 @@ func TestCircuitBreaker_SuccessResetsClosed(t *testing.T) {
 	}
 }
 
-func TestCircuitBreaker_HalfOpenAfterCooldown(t *testing.T) {
+func TestCircuitBreaker_NeedProbeAfterCooldown(t *testing.T) {
 	cb := newCircuitBreaker()
 	for i := 0; i < cbFailureThreshold; i++ {
 		cb.RecordFailure()
 	}
+	if cb.NeedProbe() {
+		t.Fatal("should not probe before cooldown")
+	}
 	// Simulate cooldown by backdating lastFailureNano
 	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
 
-	if !cb.Available() {
-		t.Fatal("expected available after cooldown")
+	if !cb.NeedProbe() {
+		t.Fatal("expected probe after cooldown")
 	}
 	if cb.State() != cbHalfOpen {
 		t.Fatalf("expected half-open, got %d", cb.State())
 	}
-	// Second call should return false (half-open allows only one probe)
-	if cb.Available() {
-		t.Fatal("expected unavailable while half-open")
+	// Second call should return false (only one probe allowed)
+	if cb.NeedProbe() {
+		t.Fatal("expected no second probe while half-open")
 	}
 }
 
@@ -239,7 +242,7 @@ func TestCircuitBreaker_HalfOpenToClosedOnSuccess(t *testing.T) {
 		cb.RecordFailure()
 	}
 	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
-	cb.Available() // transition to half-open
+	cb.NeedProbe() // transition to half-open
 
 	cb.RecordSuccess()
 	if cb.State() != cbClosed {
@@ -253,7 +256,7 @@ func TestCircuitBreaker_HalfOpenToOpenOnFailure(t *testing.T) {
 		cb.RecordFailure()
 	}
 	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
-	cb.Available() // transition to half-open
+	cb.NeedProbe() // transition to half-open
 
 	cb.RecordFailure()
 	if cb.State() != cbOpen {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes circuit breaker recovery by separating health checks from probe initiation and updating enclave selection to prefer healthy backends while sending exactly one probe after cooldown. Reduces accidental routing to unhealthy enclaves and speeds up recovery.

- **Bug Fixes**
  - Replaced `Available()` with `Closed()` and `NeedProbe()` to cleanly separate health checks from probe initiation; `NeedProbe()` transitions open→half-open after cooldown with a single CAS-won probe.
  - Updated `NextEnclave()` to use `math/rand/v2`: pick a random closed enclave; if an open breaker is past cooldown and `NeedProbe()` wins, return it for a single probe; if all are open, pick randomly from all (degraded > unavailable).
  - Initialize `CircuitBreakerState` to closed when adding an enclave; updated tests to match the new API and behavior.

<sup>Written for commit 266694c5c47485c32ae290a6f0e3c1a75213fb8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

