### PR TITLE
chore: Add grok2 configuration to config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -84,3 +84,8 @@ models:
     repo: tinfoilsh/confidential-websearch
     enclaves:
       - websearch.tinfoil.functions.tinfoil.sh
+
+  grok2:
+    repo: tinfoilsh/confidential-grok2
+    enclaves:
+      - grok-2.tinfoil.containers.tinfoil.dev


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `grok2` model configuration to `config.yml` to enable deployment and routing through its enclave.
It references the repo `tinfoilsh/confidential-grok2` and enclave `grok-2.tinfoil.containers.tinfoil.dev`.

<sup>Written for commit d96e18227e1b535e7d7d05908c417cd66658222e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

