### PR TITLE
feat: update cvm-version and add healthcheck configuration

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,14 +1,20 @@
-cvm-version: 0.7.3
-cpus: 8
+cvm-version: 0.7.5
 memory: 16384
-
-shim:
-  upstream-port: 8089
-  tls-wildcard: true
+cpus: 8
 
 containers:
   - name: "proxy"
     image: "ghcr.io/tinfoilsh/confidential-model-router@sha256:bc8cb29f4711ce87035f02c2ddde7df76748b59e5f8b193638755ca8fd825dfc" # v0.0.79
+    restart: always
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8001/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 5m
+
+shim:
+  upstream-port: 8089
+  tls-wildcard: true

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,7 +10,7 @@ containers:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8001/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8089/health"]
       interval: 30s
       timeout: 5s
       start_period: 5m


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `cvm-version` to 0.7.5 and add a healthcheck plus `restart: always` for the `proxy` container to improve reliability.

- **New Features**
  - Added healthcheck: `wget --spider http://localhost:8089/health` (interval 30s, timeout 5s, start period 5m).
  - Set `restart: always` on `proxy`.

- **Dependencies**
  - Bumped `cvm-version` from 0.7.3 to 0.7.5.

<sup>Written for commit f56f080ccdc5d8d516ff868f1b68f2638d3ca604. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

