### PR TITLE
feat: add gemma4-31b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -85,7 +85,7 @@ models:
     enclaves:
       - websearch.tinfoil.functions.tinfoil.sh
 
-  grok2:
-    repo: tinfoilsh/confidential-grok2
+  gemma4-31b:
+    repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
-      - grok-2.tinfoil.containers.tinfoil.dev
+      - gemma4-31b.tinfoil.containers.tinfoil.dev


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `gemma4-31b` to the model registry by replacing the `grok2` entry, updating the repo to `tinfoilsh/confidential-gemma4-31b` and enclave to `gemma4-31b.tinfoil.containers.tinfoil.dev`.

- **Migration**
  - Update any references from `grok2` to `gemma4-31b`.

<sup>Written for commit 28bb85950a4c55b9f05a1ed6e5331993e902ae14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

