### PR TITLE
chore: move gemma

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -88,4 +88,4 @@ models:
   gemma4-31b:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
-      - gemma4-31b.tinfoil.containers.tinfoil.dev
+      - gemma4-31b-1.inf5.tinfoil.sh


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point the `gemma4-31b` model to the new enclave host to complete the infra move. Update config to use `gemma4-31b-1.inf5.tinfoil.sh` instead of `gemma4-31b.tinfoil.containers.tinfoil.dev`.

<sup>Written for commit afc63407043200ee4230566ff9b778e4bc4b7bbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

