### PR TITLE
chore: remove qwen2.5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -75,11 +75,6 @@ models:
     rate_limit:
       max_requests_per_minute: 4
 
-  qwen2-5-05b:
-    repo: tinfoilsh/confidential-qwen2-5-05b
-    enclaves:
-      - title-model.tinfoil.functions.tinfoil.sh
-
   websearch:
     repo: tinfoilsh/confidential-websearch
     enclaves:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed `qwen2-5-05b` from `config.yml` to retire the model and prevent accidental use. This cleans up the model list and avoids misconfigurations.

<sup>Written for commit 658404eb469293a1c1ce17f8adb305bc61c12e1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

