### PR TITLE
feat: remove deepseek-r1-0528, add glm-5-1 in config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -33,10 +33,10 @@ models:
     enclaves:
       - llama3-3-70b.tinfoil.containers.tinfoil.dev
 
-  deepseek-r1-0528:
-    repo: tinfoilsh/confidential-deepseek-r1-0528
+  glm-5-1:
+    repo: tinfoilsh/confidential-glm5-1
     enclaves:
-      - deepseek-r1-0528.inf7.tinfoil.sh
+      - glm-5-1.tinfoil.containers.tinfoil.dev
 
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced the `deepseek-r1-0528` model with `glm-5-1` in `config.yml` to route traffic to the new deployment. Updated the repo to `tinfoilsh/confidential-glm5-1` and the enclave to `glm-5-1.tinfoil.containers.tinfoil.dev`.

- **Migration**
  - Update any references from `deepseek-r1-0528` to `glm-5-1`.
  - Verify connectivity to `glm-5-1.tinfoil.containers.tinfoil.dev`.

<sup>Written for commit cad5b181f96aa9aeebbc68556549db33b22de7a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

