### PR TITLE
chore: update enclave hostname for gemma4-31b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -83,4 +83,4 @@ models:
   gemma4-31b:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
-      - gemma4-31b-1.inf5.tinfoil.sh
+      - gemma4-31b.inf5.tinfoil.sh


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update enclave hostname for `gemma4-31b` in config to point to gemma4-31b.inf5.tinfoil.sh instead of the outdated gemma4-31b-1.inf5.tinfoil.sh, ensuring requests route to the correct enclave.

<sup>Written for commit e80dcd8c826cdb25b07f84b3cb704b7ce9690d13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

