### PR TITLE
chore: update domain for docling

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,7 +11,7 @@ models:
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - confidential-doc-upload.tinfoil.containers.tinfoil.sh
+      - confidential-doc-upload-inf5.tinfoil.containers.tinfoil.dev
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-whisper-large-v3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the doc-upload enclave domain to confidential-doc-upload-inf5.tinfoil.containers.tinfoil.dev to align with the new docking environment and route traffic to the INF5 dev cluster.

<sup>Written for commit 09b98085313b8815896c62b177ef7e0b6bda1dd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

