### PR TITLE
feat: support base64 file inputs in chat and responses

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -180,12 +181,12 @@ func extractModelFromMultipart(r *http.Request) (string, []byte, error) {
 // models follow the same streaming usage behavior. If the client explicitly
 // asked for usage stats, we mark that in a header so the proxy can preserve
 // usage-only chunks instead of filtering them out.
-func ensureStreamingUsageOptions(body map[string]interface{}, headers http.Header) {
+func ensureStreamingUsageOptions(body map[string]any, headers http.Header) {
 	clientRequestedUsage := false
 
-	streamOptions, ok := body["stream_options"].(map[string]interface{})
+	streamOptions, ok := body["stream_options"].(map[string]any)
 	if !ok {
-		streamOptions = map[string]interface{}{}
+		streamOptions = map[string]any{}
 		body["stream_options"] = streamOptions
 	}
 
@@ -325,7 +326,7 @@ func main() {
 				return
 			} else if r.URL.Path == "/v1/audio/speech" {
 				// Extract model from JSON body, default to qwen3-tts
-				var body map[string]interface{}
+				var body map[string]any
 				bodyBytes, err := io.ReadAll(r.Body)
 				if err != nil {
 					jsonError(w, fmt.Sprintf("Could not read request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
@@ -357,7 +358,7 @@ func main() {
 			} else if r.URL.Path == "/v1/convert/file" {
 				modelName = "doc-upload"
 			} else { // This is an OpenAI-compatible API request
-				var body map[string]interface{}
+				var body map[string]any
 				bodyBytes, err := io.ReadAll(r.Body)
 
 				if err != nil {
@@ -388,7 +389,7 @@ func main() {
 				if _, ok := body["web_search_options"]; ok {
 					useWebsearch = true
 				} else if r.URL.Path == "/v1/responses" {
-					if tools, ok := body["tools"].([]interface{}); ok {
+					if tools, ok := body["tools"].([]any); ok {
 						useWebsearch = slices.ContainsFunc(tools, func(t any) bool {
 							m, _ := t.(map[string]any)
 							typeVal, ok := m["type"].(string)
@@ -401,13 +402,45 @@ func main() {
 					modelName = "websearch"
 				}
 
+				bodyModified := false
+				if r.URL.Path == "/v1/responses" || r.URL.Path == "/v1/chat/completions" {
+					rewritten := false
+					switch r.URL.Path {
+					case "/v1/responses":
+						rewritten, err = rewriteResponsesBase64Files(r.Context(), body, em, r.Header.Get("Authorization"))
+					case "/v1/chat/completions":
+						rewritten, err = rewriteChatCompletionsBase64Files(r.Context(), body, em, r.Header.Get("Authorization"))
+					}
+					if err != nil {
+						var inputErr *fileInputError
+						if errors.As(err, &inputErr) {
+							jsonError(w, inputErr.Message, manager.ErrTypeInvalidRequest, inputErr.StatusCode)
+							return
+						}
+
+						var conversionErr *manager.FileConversionError
+						if errors.As(err, &conversionErr) {
+							errType := manager.ErrTypeServer
+							if conversionErr.StatusCode >= 400 && conversionErr.StatusCode < 500 {
+								errType = manager.ErrTypeInvalidRequest
+							}
+							jsonError(w, conversionErr.Message, errType, conversionErr.StatusCode)
+							return
+						}
+
+						jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusBadGateway)
+						return
+					}
+					bodyModified = rewritten
+				}
+
 				// Strip any user-supplied priority to prevent circumventing rate limits
 				// or jumping ahead of other users.
 				_, hadPriority := body["priority"]
 				delete(body, "priority")
 
 				// Check rate limiting and inject lower vLLM priority if over budget
-				bodyModified := hadPriority
+				bodyModified = bodyModified || hadPriority
 				if rlCfg := em.GetRateLimitConfig(rateLimitModel); rlCfg != nil {
 					if apiKey != "" && em.RequestTracker().RecordAndCheck(apiKey, rateLimitModel, rlCfg.MaxRequestsPerMinute) {
 						body["priority"] = 1

--- a/manager/file_inputs.go
+++ b/manager/file_inputs.go
@@ -1,0 +1,192 @@
+package manager
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strings"
+	"time"
+
+	tinfoilClient "github.com/tinfoilsh/tinfoil-go/verifier/client"
+)
+
+type FileConversionError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *FileConversionError) Error() string {
+	return e.Message
+}
+
+type docUploadResponse struct {
+	Document struct {
+		MDContent string `json:"md_content"`
+	} `json:"document"`
+}
+
+func parseDocUploadMarkdown(respBody []byte) (string, error) {
+	var parsed docUploadResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", &FileConversionError{
+			StatusCode: http.StatusBadGateway,
+			Message:    "invalid document processing response",
+		}
+	}
+
+	if strings.TrimSpace(parsed.Document.MDContent) == "" {
+		return "", &FileConversionError{
+			StatusCode: http.StatusBadGateway,
+			Message:    "document processing returned empty content",
+		}
+	}
+
+	return parsed.Document.MDContent, nil
+}
+
+// ConvertFileToMarkdown sends an uploaded file to the private doc-upload enclave
+// and returns the extracted markdown content.
+func (em *EnclaveManager) ConvertFileToMarkdown(
+	ctx context.Context,
+	authHeader string,
+	filename string,
+	contentType string,
+	data []byte,
+) (string, error) {
+	model, found := em.GetModel("doc-upload")
+	if !found {
+		return "", &FileConversionError{
+			StatusCode: http.StatusBadGateway,
+			Message:    "document processing backend is not configured",
+		}
+	}
+
+	enclave := model.NextEnclave()
+	if enclave == nil {
+		return "", &FileConversionError{
+			StatusCode: http.StatusBadGateway,
+			Message:    "document processing backend is unavailable",
+		}
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	headers := make(textproto.MIMEHeader)
+	headers.Set("Content-Disposition", fmt.Sprintf(`form-data; name="files"; filename="%s"`, escapeMultipartFilename(filename)))
+	if sanitizedContentType := sanitizeMultipartContentType(contentType); sanitizedContentType != "" {
+		headers.Set("Content-Type", sanitizedContentType)
+	}
+	part, err := writer.CreatePart(headers)
+	if err != nil {
+		return "", &FileConversionError{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "failed to build document upload request",
+		}
+	}
+	if _, err := part.Write(data); err != nil {
+		return "", &FileConversionError{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "failed to build document upload request",
+		}
+	}
+	if err := writer.WriteField("to_format", "md"); err != nil {
+		return "", &FileConversionError{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "failed to build document upload request",
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return "", &FileConversionError{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "failed to finalize document upload request",
+		}
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		"https://"+enclave.host+"/v1/convert/file",
+		bytes.NewReader(body.Bytes()),
+	)
+	if err != nil {
+		return "", &FileConversionError{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "failed to create document upload request",
+		}
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", body.Len()))
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+
+	client := &http.Client{
+		Timeout: 10 * time.Minute,
+		Transport: &slowHeaderTripper{
+			base: &tinfoilClient.TLSBoundRoundTripper{
+				ExpectedPublicKey: enclave.tlsKeyFP,
+			},
+			timeout: responseHeaderTimeout,
+			onSlow:  func() {},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", &FileConversionError{
+			StatusCode: http.StatusBadGateway,
+			Message:    "document processing request failed",
+		}
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", &FileConversionError{
+			StatusCode: http.StatusBadGateway,
+			Message:    "failed to read document processing response",
+		}
+	}
+	if resp.StatusCode != http.StatusOK {
+		message := strings.TrimSpace(string(respBody))
+		if message == "" {
+			message = "document processing failed"
+		}
+		return "", &FileConversionError{
+			StatusCode: resp.StatusCode,
+			Message:    message,
+		}
+	}
+
+	return parseDocUploadMarkdown(respBody)
+}
+
+func escapeMultipartFilename(filename string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		`"`, `\"`,
+		"\r", "_",
+		"\n", "_",
+	)
+	return replacer.Replace(filename)
+}
+
+func sanitizeMultipartContentType(contentType string) string {
+	if contentType == "" || strings.ContainsAny(contentType, "\r\n") {
+		return ""
+	}
+
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return ""
+	}
+
+	return mime.FormatMediaType(mediaType, params)
+}

--- a/manager/file_inputs_test.go
+++ b/manager/file_inputs_test.go
@@ -1,0 +1,140 @@
+package manager
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestEscapeMultipartFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "plain",
+			input:    "report.pdf",
+			expected: "report.pdf",
+		},
+		{
+			name:     "quotes and backslashes",
+			input:    `folder\"quoted".pdf`,
+			expected: `folder\\\"quoted\".pdf`,
+		},
+		{
+			name:     "crlf injection",
+			input:    "evil\r\nX-Injected: yes\r\n\r\nbody.pdf",
+			expected: "evil__X-Injected: yes____body.pdf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := escapeMultipartFilename(tt.input); got != tt.expected {
+				t.Fatalf("escapeMultipartFilename(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizeMultipartContentType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "valid_with_charset",
+			input:    "application/json;charset=utf-8",
+			expected: "application/json; charset=utf-8",
+		},
+		{
+			name:     "invalid",
+			input:    "application/json; charset",
+			expected: "",
+		},
+		{
+			name:     "crlf_injection",
+			input:    "application/pdf\r\nX-Injected: yes",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeMultipartContentType(tt.input); got != tt.expected {
+				t.Fatalf("sanitizeMultipartContentType(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseDocUploadMarkdown(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		expected      string
+		expectedError string
+		expectedCode  int
+	}{
+		{
+			name:     "valid_markdown",
+			body:     `{"document":{"md_content":"# heading\nbody"}}`,
+			expected: "# heading\nbody",
+		},
+		{
+			name:          "invalid_json",
+			body:          `{`,
+			expectedError: "invalid document processing response",
+			expectedCode:  http.StatusBadGateway,
+		},
+		{
+			name:          "empty_markdown",
+			body:          `{"document":{"md_content":""}}`,
+			expectedError: "document processing returned empty content",
+			expectedCode:  http.StatusBadGateway,
+		},
+		{
+			name:          "whitespace_only_markdown",
+			body:          `{"document":{"md_content":" \n\t "}}`,
+			expectedError: "document processing returned empty content",
+			expectedCode:  http.StatusBadGateway,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDocUploadMarkdown([]byte(tt.body))
+			if tt.expectedError == "" {
+				if err != nil {
+					t.Fatalf("parseDocUploadMarkdown returned unexpected error: %v", err)
+				}
+				if got != tt.expected {
+					t.Fatalf("parseDocUploadMarkdown() = %q, want %q", got, tt.expected)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if err.Error() != tt.expectedError {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var conversionErr *FileConversionError
+			if !errors.As(err, &conversionErr) {
+				t.Fatalf("expected FileConversionError, got %T", err)
+			}
+			if conversionErr.StatusCode != tt.expectedCode {
+				t.Fatalf("expected status %d, got %d", tt.expectedCode, conversionErr.StatusCode)
+			}
+		})
+	}
+}

--- a/responses_file_inputs.go
+++ b/responses_file_inputs.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/tinfoilsh/confidential-model-router/manager"
+)
+
+type fileInputProcessor func(ctx context.Context, authHeader string, filename string, contentType string, data []byte) (string, error)
+
+type fileInputError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *fileInputError) Error() string {
+	return e.Message
+}
+
+func rewriteResponsesBase64Files(
+	ctx context.Context,
+	body map[string]any,
+	em *manager.EnclaveManager,
+	authHeader string,
+) (bool, error) {
+	return rewriteResponsesBase64FilesWithProcessor(ctx, body, authHeader, em.ConvertFileToMarkdown)
+}
+
+func rewriteResponsesBase64FilesWithProcessor(
+	ctx context.Context,
+	body map[string]any,
+	authHeader string,
+	process fileInputProcessor,
+) (bool, error) {
+	inputItems, ok := body["input"].([]any)
+	if !ok {
+		return false, nil
+	}
+
+	rewritten := false
+	for _, item := range inputItems {
+		msg, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		contentItems, ok := msg["content"].([]any)
+		if !ok {
+			continue
+		}
+
+		newContent := make([]any, 0, len(contentItems))
+		for _, rawPart := range contentItems {
+			part, ok := rawPart.(map[string]any)
+			if !ok {
+				newContent = append(newContent, rawPart)
+				continue
+			}
+
+			partType, _ := part["type"].(string)
+			if partType != "input_file" {
+				newContent = append(newContent, rawPart)
+				continue
+			}
+			decoded, err := decodeResponsesInputFilePart(part)
+			if err != nil {
+				return false, err
+			}
+			fileText, err := renderDecodedFile(ctx, authHeader, decoded, process)
+			if err != nil {
+				return false, err
+			}
+
+			newContent = append(newContent, map[string]any{
+				"type": "input_text",
+				"text": renderFileInputText(decoded.filename, fileText),
+			})
+			rewritten = true
+		}
+
+		msg["content"] = newContent
+	}
+
+	return rewritten, nil
+}
+
+func rewriteChatCompletionsBase64Files(
+	ctx context.Context,
+	body map[string]any,
+	em *manager.EnclaveManager,
+	authHeader string,
+) (bool, error) {
+	return rewriteChatCompletionsBase64FilesWithProcessor(ctx, body, authHeader, em.ConvertFileToMarkdown)
+}
+
+func rewriteChatCompletionsBase64FilesWithProcessor(
+	ctx context.Context,
+	body map[string]any,
+	authHeader string,
+	process fileInputProcessor,
+) (bool, error) {
+	messages, ok := body["messages"].([]any)
+	if !ok {
+		return false, nil
+	}
+
+	rewritten := false
+	for _, item := range messages {
+		msg, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		contentItems, ok := msg["content"].([]any)
+		if !ok {
+			continue
+		}
+
+		newContent := make([]any, 0, len(contentItems))
+		for _, rawPart := range contentItems {
+			part, ok := rawPart.(map[string]any)
+			if !ok {
+				newContent = append(newContent, rawPart)
+				continue
+			}
+
+			partType, _ := part["type"].(string)
+			if partType != "file" {
+				newContent = append(newContent, rawPart)
+				continue
+			}
+
+			decoded, err := decodeChatCompletionsFilePart(part)
+			if err != nil {
+				return false, err
+			}
+			fileText, err := renderDecodedFile(ctx, authHeader, decoded, process)
+			if err != nil {
+				return false, err
+			}
+
+			newContent = append(newContent, map[string]any{
+				"type": "text",
+				"text": renderFileInputText(decoded.filename, fileText),
+			})
+			rewritten = true
+		}
+
+		msg["content"] = newContent
+	}
+
+	return rewritten, nil
+}
+
+type decodedFileInput struct {
+	filename    string
+	contentType string
+	data        []byte
+}
+
+func decodeResponsesInputFilePart(part map[string]any) (*decodedFileInput, error) {
+	filename, _ := part["filename"].(string)
+	if _, hasFileID := part["file_id"]; hasFileID {
+		return nil, &fileInputError{
+			StatusCode: http.StatusBadRequest,
+			Message:    "Only input_file.file_data is supported on this endpoint.",
+		}
+	}
+
+	fileData, _ := part["file_data"].(string)
+	if fileData == "" {
+		return nil, &fileInputError{
+			StatusCode: http.StatusBadRequest,
+			Message:    "Missing required parameter: 'file_data' on input_file.",
+		}
+	}
+
+	return decodeFileInput(filename, fileData, "input_file.file_data")
+}
+
+func decodeChatCompletionsFilePart(part map[string]any) (*decodedFileInput, error) {
+	fileObj, _ := part["file"].(map[string]any)
+	if fileObj == nil {
+		return nil, &fileInputError{
+			StatusCode: http.StatusBadRequest,
+			Message:    "Missing required parameter: 'file' on file content part.",
+		}
+	}
+
+	filename, _ := fileObj["filename"].(string)
+	if _, hasFileID := fileObj["file_id"]; hasFileID {
+		return nil, &fileInputError{
+			StatusCode: http.StatusBadRequest,
+			Message:    "Only file.file_data is supported on this endpoint.",
+		}
+	}
+
+	fileData, _ := fileObj["file_data"].(string)
+	if fileData == "" {
+		return nil, &fileInputError{
+			StatusCode: http.StatusBadRequest,
+			Message:    "Missing required parameter: 'file.file_data'.",
+		}
+	}
+
+	return decodeFileInput(filename, fileData, "file.file_data")
+}
+
+func renderDecodedFile(
+	ctx context.Context,
+	authHeader string,
+	decoded *decodedFileInput,
+	process fileInputProcessor,
+) (string, error) {
+	if isInlineTextFile(decoded.filename, decoded.contentType, decoded.data) {
+		return string(decoded.data), nil
+	}
+
+	return process(ctx, authHeader, decoded.filename, decoded.contentType, decoded.data)
+}
+
+func decodeFileInput(filename string, fileData string, paramName string) (*decodedFileInput, error) {
+	contentType := ""
+	rawBase64 := fileData
+
+	if strings.HasPrefix(fileData, "data:") {
+		mediaType, payload, ok := strings.Cut(fileData, ",")
+		if !ok {
+			return nil, &fileInputError{
+				StatusCode: http.StatusBadRequest,
+				Message:    fmt.Sprintf("Invalid data URL in %s.", paramName),
+			}
+		}
+		if !strings.HasSuffix(mediaType, ";base64") {
+			return nil, &fileInputError{
+				StatusCode: http.StatusBadRequest,
+				Message:    fmt.Sprintf("%s must be base64-encoded.", paramName),
+			}
+		}
+		contentType = strings.TrimPrefix(strings.TrimSuffix(mediaType, ";base64"), "data:")
+		rawBase64 = payload
+	}
+
+	decoded, err := decodeBase64Payload(rawBase64)
+	if err != nil {
+		return nil, &fileInputError{
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintf("Invalid base64 payload in %s.", paramName),
+		}
+	}
+	if filename == "" {
+		filename = "uploaded-file"
+	}
+
+	return &decodedFileInput{
+		filename:    filename,
+		contentType: contentType,
+		data:        decoded,
+	}, nil
+}
+
+func decodeBase64Payload(raw string) ([]byte, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, errors.New("empty payload")
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(trimmed)
+	if err == nil {
+		return decoded, nil
+	}
+
+	decoded, rawErr := base64.RawStdEncoding.DecodeString(trimmed)
+	if rawErr == nil {
+		return decoded, nil
+	}
+
+	return nil, err
+}
+
+func renderFileInputText(filename string, markdown string) string {
+	if markdown == "" {
+		return fmt.Sprintf("[Attached file: %s]", filename)
+	}
+	return fmt.Sprintf("[Attached file: %s]\n\n%s", filename, markdown)
+}
+
+func isInlineTextFile(filename string, contentType string, data []byte) bool {
+	if !utf8.Valid(data) {
+		return false
+	}
+
+	if contentType != "" {
+		mediaType := contentType
+		if parsedMediaType, _, err := mime.ParseMediaType(contentType); err == nil {
+			mediaType = parsedMediaType
+		}
+
+		if strings.HasPrefix(mediaType, "text/") {
+			return true
+		}
+		switch mediaType {
+		case "application/json", "application/xml", "application/yaml", "application/x-yaml":
+			return true
+		}
+	}
+
+	switch strings.ToLower(filepath.Ext(filename)) {
+	case ".txt", ".md", ".json", ".xml", ".yaml", ".yml", ".csv", ".html", ".htm":
+		return true
+	}
+
+	return false
+}

--- a/responses_file_inputs_test.go
+++ b/responses_file_inputs_test.go
@@ -1,0 +1,341 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+)
+
+type rewriteRunner func(context.Context, map[string]any, string, fileInputProcessor) (bool, error)
+
+type rewriteTestCase struct {
+	name                string
+	run                 rewriteRunner
+	buildBody           func(parts ...any) map[string]any
+	buildFileDataPart   func(filename string, fileData string) any
+	buildFileIDPart     func(fileID string) any
+	buildTextPart       func(text string) any
+	contentParts        func(body map[string]any) []any
+	expectedTextType    string
+	expectedFileIDError string
+	expectedFieldName   string
+}
+
+var rewriteTestCases = []rewriteTestCase{
+	{
+		name: "responses",
+		run:  rewriteResponsesBase64FilesWithProcessor,
+		buildBody: func(parts ...any) map[string]any {
+			return map[string]any{
+				"model": "gpt-oss-120b",
+				"input": []any{
+					map[string]any{
+						"role":    "user",
+						"content": parts,
+					},
+				},
+			}
+		},
+		buildFileDataPart: func(filename string, fileData string) any {
+			return map[string]any{
+				"type":      "input_file",
+				"filename":  filename,
+				"file_data": fileData,
+			}
+		},
+		buildFileIDPart: func(fileID string) any {
+			return map[string]any{
+				"type":    "input_file",
+				"file_id": fileID,
+			}
+		},
+		buildTextPart: func(text string) any {
+			return map[string]any{
+				"type": "input_text",
+				"text": text,
+			}
+		},
+		contentParts: func(body map[string]any) []any {
+			return body["input"].([]any)[0].(map[string]any)["content"].([]any)
+		},
+		expectedTextType:    "input_text",
+		expectedFileIDError: "Only input_file.file_data is supported on this endpoint.",
+		expectedFieldName:   "input_file.file_data",
+	},
+	{
+		name: "chat_completions",
+		run:  rewriteChatCompletionsBase64FilesWithProcessor,
+		buildBody: func(parts ...any) map[string]any {
+			return map[string]any{
+				"model": "gpt-oss-120b",
+				"messages": []any{
+					map[string]any{
+						"role":    "user",
+						"content": parts,
+					},
+				},
+			}
+		},
+		buildFileDataPart: func(filename string, fileData string) any {
+			return map[string]any{
+				"type": "file",
+				"file": map[string]any{
+					"filename":  filename,
+					"file_data": fileData,
+				},
+			}
+		},
+		buildFileIDPart: func(fileID string) any {
+			return map[string]any{
+				"type": "file",
+				"file": map[string]any{
+					"file_id": fileID,
+				},
+			}
+		},
+		buildTextPart: func(text string) any {
+			return map[string]any{
+				"type": "text",
+				"text": text,
+			}
+		},
+		contentParts: func(body map[string]any) []any {
+			return body["messages"].([]any)[0].(map[string]any)["content"].([]any)
+		},
+		expectedTextType:    "text",
+		expectedFileIDError: "Only file.file_data is supported on this endpoint.",
+		expectedFieldName:   "file.file_data",
+	},
+}
+
+func TestRewriteBase64FilesWithProcessorText(t *testing.T) {
+	for _, tc := range rewriteTestCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			body := tc.buildBody(
+				tc.buildFileDataPart("notes.txt", "data:text/plain;base64,"+base64.StdEncoding.EncodeToString([]byte("hello"))),
+				tc.buildTextPart("Summarize it."),
+			)
+
+			rewritten, err := tc.run(
+				context.Background(),
+				body,
+				"Bearer test-key",
+				func(_ context.Context, _, _, _ string, _ []byte) (string, error) {
+					t.Fatal("processor should not be called for text/plain input")
+					return "", nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("rewrite failed: %v", err)
+			}
+			if !rewritten {
+				t.Fatal("expected request body to be rewritten")
+			}
+
+			content := tc.contentParts(body)
+			assertTextPart(t, content[0], tc.expectedTextType, "[Attached file: notes.txt]\n\nhello")
+			assertPartType(t, content[1], tc.expectedTextType)
+		})
+	}
+}
+
+func TestRewriteBase64FilesWithProcessorRejectsFileID(t *testing.T) {
+	for _, tc := range rewriteTestCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			body := tc.buildBody(tc.buildFileIDPart("file-123"))
+
+			_, err := tc.run(
+				context.Background(),
+				body,
+				"Bearer test-key",
+				func(_ context.Context, _, _, _ string, _ []byte) (string, error) {
+					t.Fatal("processor should not be called")
+					return "", nil
+				},
+			)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if err.Error() != tc.expectedFileIDError {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDecodeFileInputRawBase64(t *testing.T) {
+	decoded, err := decodeFileInput("report.md", base64.StdEncoding.EncodeToString([]byte("# hello")), "input_file.file_data")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if decoded.filename != "report.md" {
+		t.Fatalf("expected report.md, got %q", decoded.filename)
+	}
+	if decoded.contentType != "" {
+		t.Fatalf("expected empty content type, got %q", decoded.contentType)
+	}
+	if string(decoded.data) != "# hello" {
+		t.Fatalf("unexpected decoded payload: %q", string(decoded.data))
+	}
+}
+
+func TestRewriteBase64FilesUsesContextSpecificDecodeErrors(t *testing.T) {
+	for _, tc := range rewriteTestCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tests := []struct {
+				name          string
+				fileData      string
+				expectedError string
+			}{
+				{
+					name:          "invalid_data_url",
+					fileData:      "data:text/plain;base64",
+					expectedError: "Invalid data URL in " + tc.expectedFieldName + ".",
+				},
+				{
+					name:          "missing_base64_marker",
+					fileData:      "data:text/plain,hello",
+					expectedError: tc.expectedFieldName + " must be base64-encoded.",
+				},
+				{
+					name:          "invalid_base64_payload",
+					fileData:      "data:text/plain;base64,%%%%",
+					expectedError: "Invalid base64 payload in " + tc.expectedFieldName + ".",
+				},
+			}
+
+			for _, test := range tests {
+				test := test
+				t.Run(test.name, func(t *testing.T) {
+					body := tc.buildBody(tc.buildFileDataPart("notes.txt", test.fileData))
+
+					_, err := tc.run(
+						context.Background(),
+						body,
+						"Bearer test-key",
+						func(_ context.Context, _, _, _ string, _ []byte) (string, error) {
+							t.Fatal("processor should not be called")
+							return "", nil
+						},
+					)
+					if err == nil {
+						t.Fatal("expected an error")
+					}
+					if err.Error() != test.expectedError {
+						t.Fatalf("unexpected error: %v", err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestRewriteBase64FilesUsesProcessorForBinaryFiles(t *testing.T) {
+	for _, tc := range rewriteTestCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			body := tc.buildBody(
+				tc.buildFileDataPart("scan.pdf", "data:application/pdf;base64,"+base64.StdEncoding.EncodeToString([]byte("%PDF"))),
+			)
+
+			called := false
+			rewritten, err := tc.run(
+				context.Background(),
+				body,
+				"Bearer test-key",
+				func(_ context.Context, authHeader, filename, contentType string, data []byte) (string, error) {
+					called = true
+					if authHeader != "Bearer test-key" {
+						t.Fatalf("expected auth header to be forwarded, got %q", authHeader)
+					}
+					if filename != "scan.pdf" {
+						t.Fatalf("expected scan.pdf, got %q", filename)
+					}
+					if contentType != "application/pdf" {
+						t.Fatalf("expected application/pdf, got %q", contentType)
+					}
+					if string(data) != "%PDF" {
+						t.Fatalf("unexpected payload: %q", string(data))
+					}
+					return "converted markdown", nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("rewrite failed: %v", err)
+			}
+			if !rewritten {
+				t.Fatal("expected request body to be rewritten")
+			}
+			if !called {
+				t.Fatal("expected processor to be called for binary input")
+			}
+
+			content := tc.contentParts(body)
+			assertTextPart(t, content[0], tc.expectedTextType, "[Attached file: scan.pdf]\n\nconverted markdown")
+		})
+	}
+}
+
+func TestIsInlineTextFileHandlesContentTypeParameters(t *testing.T) {
+	tests := []struct {
+		name        string
+		filename    string
+		contentType string
+		data        []byte
+		expected    bool
+	}{
+		{
+			name:        "text_with_charset",
+			filename:    "notes.bin",
+			contentType: "text/plain; charset=utf-8",
+			data:        []byte("hello"),
+			expected:    true,
+		},
+		{
+			name:        "json_with_charset",
+			filename:    "payload.bin",
+			contentType: "application/json;charset=utf-8",
+			data:        []byte(`{"ok":true}`),
+			expected:    true,
+		},
+		{
+			name:        "pdf_with_parameters",
+			filename:    "scan.bin",
+			contentType: "application/pdf; charset=utf-8",
+			data:        []byte("%PDF"),
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInlineTextFile(tt.filename, tt.contentType, tt.data); got != tt.expected {
+				t.Fatalf("isInlineTextFile(%q, %q, %q) = %v, want %v", tt.filename, tt.contentType, string(tt.data), got, tt.expected)
+			}
+		})
+	}
+}
+
+func assertTextPart(t *testing.T, rawPart any, expectedType string, expectedText string) {
+	t.Helper()
+
+	part := rawPart.(map[string]any)
+	if got := part["type"]; got != expectedType {
+		t.Fatalf("expected %s, got %v", expectedType, got)
+	}
+	if got := part["text"]; got != expectedText {
+		t.Fatalf("unexpected rewritten text: %v", got)
+	}
+}
+
+func assertPartType(t *testing.T, rawPart any, expectedType string) {
+	t.Helper()
+
+	part := rawPart.(map[string]any)
+	if got := part["type"]; got != expectedType {
+		t.Fatalf("expected %s, got %v", expectedType, got)
+	}
+}


### PR DESCRIPTION
## Summary
- add private base64 file-input rewriting for /v1/responses using input_file.file_data
- add OpenAI-compatible chat completions support for type=file with file.file_data
- forward auth to doc-upload for binary/PDF conversion and add runbook canary smoke tests

## Testing
- go test ./...
- verified local /v1/responses requests for plain text and PDF file_data
- verified local /v1/chat/completions requests for plain text and PDF file payloads

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds base64 file input support to `/v1/responses` and OpenAI-compatible `/v1/chat/completions`. Text files are inlined; PDFs and other binaries are converted to Markdown via the private `doc-upload` backend, with stricter validation, normalized content-type handling, and clearer errors.

- **New Features**
  - Accepts base64 (and data URL) file data in both endpoints:
    - Responses: `input_file.file_data`
    - Chat Completions: `type: "file"` with `file.file_data`
  - Rewrites file parts to text content with a filename header; text stays inline, binaries go through `doc-upload` for Markdown.
  - Forwards `Authorization` to `doc-upload`; sanitizes multipart content types on upload and maps conversion failures to clear 4xx/5xx errors.
  - Hardened input checks: precise 400s for invalid data URLs/base64, safe filename escaping, and content-type normalization (strip params) when deciding inline vs conversion.
  - Adds table-driven unit tests for endpoints and helpers.

- **Migration**
  - `file_id` is not supported on these paths; use `file_data` instead (400 if used).
  - No changes needed for existing text-only requests.

<sup>Written for commit b2fd2a9f9aa7c19c93652a44b79e4fc472161600. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

