### PR TITLE
chore: add overload settings for gemma4-31b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -84,3 +84,6 @@ models:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
       - gemma4-31b.inf5.tinfoil.sh
+    overload:
+      max_requests_waiting: 8
+      retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added overload controls for `gemma4-31b` to prevent queue buildup during traffic spikes. Sets `max_requests_waiting` to 8 and `retry_after_minutes` to 1 so clients back off when saturated.

<sup>Written for commit 3f00ba9dc3dc755fafc0d67a829ccb32dfdffd6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

