### PR TITLE
chore: update enclave doc-upload

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,7 +11,7 @@ models:
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - confidential-doc-upload-inf5.tinfoil.containers.tinfoil.dev
+      - confidential-doc-upload.tinfoil.containers.tinfoil.dev
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-whisper-large-v3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point the `doc-upload` model to the new enclave hostname, replacing the deprecated `-inf5` endpoint. This ensures traffic routes to the current production enclave.

<sup>Written for commit 8473b90684c9c87e4eab51f7cac4b1ee316f9719. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

