### PR TITLE
Revert "chore: update enclave doc-upload"

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,7 +11,7 @@ models:
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - confidential-doc-upload.tinfoil.containers.tinfoil.dev
+      - confidential-doc-upload-inf5.tinfoil.containers.tinfoil.dev
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-whisper-large-v3


### PR DESCRIPTION
Reverts tinfoilsh/confidential-model-router#243

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the doc-upload enclave host to the previous endpoint to restore the expected deployment target.
Switches config.yml to use confidential-doc-upload-inf5.tinfoil.containers.tinfoil.dev instead of confidential-doc-upload.tinfoil.containers.tinfoil.dev.

<sup>Written for commit 6b6bad92c5889700c467188889539bf3c86c24f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

