### PR TITLE
chore: update doc-upload

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,7 +11,7 @@ models:
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - confidential-doc-upload-inf5.tinfoil.containers.tinfoil.dev
+      - confidential-doc-upload.tinfoil.containers.tinfoil.dev
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-whisper-large-v3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point `doc-upload` to the new enclave host confidential-doc-upload.tinfoil.containers.tinfoil.dev. Replaces the deprecated '-inf5' host so deployments target the correct enclave.

<sup>Written for commit 777f184c779735d88b57e9f99e280bdb575821cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

