### PR TITLE
chore: new enclave configurations to config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -44,6 +44,9 @@ models:
       - gpt-oss-120b-inf5.tinfoil.containers.tinfoil.dev
       - gpt-oss-120b-inf5-2.tinfoil.containers.tinfoil.dev
       - gpt-oss-120b-inf5-3.inf5.tinfoil.sh
+      - gpt-oss-120b-0.inf9.tinfoil.sh
+      - gpt-oss-120b-1.inf9.tinfoil.sh
+      - gpt-oss-120b-2.inf9.tinfoil.sh
     overload:
       max_requests_waiting: 8
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added three inf9 enclave endpoints to the gpt-oss-120b model targets in config.yml to expand capacity and improve failover. Requests can now route to inf9 instances alongside existing inf5 endpoints.

<sup>Written for commit 4033b671897c45489f9a2f980a320cd006957906. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

