### PR TITLE
chore: enclave URLs in config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,12 +6,12 @@ models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:
-      - nomic-embed-text.tinfoil.containers.tinfoil.dev
+      - nomic.inf9.tinfoil.sh
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - confidential-doc-upload.tinfoil.containers.tinfoil.dev
+      - doc-upload.inf9.tinfoil.sh
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-whisper-large-v3
@@ -41,9 +41,6 @@ models:
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
-      - gpt-oss-120b-inf5.tinfoil.containers.tinfoil.dev
-      - gpt-oss-120b-inf5-2.tinfoil.containers.tinfoil.dev
-      - gpt-oss-120b-inf5-3.inf5.tinfoil.sh
       - gpt-oss-120b-0.inf9.tinfoil.sh
       - gpt-oss-120b-1.inf9.tinfoil.sh
       - gpt-oss-120b-2.inf9.tinfoil.sh


### PR DESCRIPTION
Updated enclave URLs for several models in the config file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated enclave URLs in config.yml to point models to the inf9 cluster. Removed deprecated inf5/containers hosts to avoid routing to retired infrastructure.

- **Refactors**
  - Pointed nomic-embed-text and doc-upload to inf9 domains (nomic.inf9.tinfoil.sh, doc-upload.inf9.tinfoil.sh).
  - Cleaned up gpt-oss-120b by removing old inf5/containers hosts; existing inf9 hosts remain.

<sup>Written for commit 33ce740cc5f5c190453e95059cc1f1b806dd7069. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

