### PR TITLE
Update enclave for voxtral-small-24b model

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -21,7 +21,7 @@ models:
   voxtral-small-24b:
     repo: tinfoilsh/confidential-voxtral-small-24b
     enclaves:
-      - voxtral-small-24b.inf5.tinfoil.sh
+      - voxtral-small-24b.inf9.tinfoil.sh
 
   voxtral-mini-4b-realtime:
     repo: tinfoilsh/confidential-realtime-models


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point `voxtral-small-24b` to the `voxtral-small-24b.inf9.tinfoil.sh` enclave, replacing `voxtral-small-24b.inf5.tinfoil.sh`. This routes all requests to the new deployment.

<sup>Written for commit fc718acc77580d885f0dc4d3f3fd5e14ac9fdb3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

