### PR TITLE
chore: Update enclave hostname in config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -83,7 +83,7 @@ models:
   gemma4-31b:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
-      - gemma4-31b.inf5.tinfoil.sh
+      - gemma4-31b.inf9.tinfoil.sh
     overload:
       max_requests_waiting: 8
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the `gemma4-31b` enclave hostname in `config.yml` from `gemma4-31b.inf5.tinfoil.sh` to `gemma4-31b.inf9.tinfoil.sh` to route traffic to the new enclave.

<sup>Written for commit a9dc079197327b644723ec826d1ac1abcf516d86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

