### PR TITLE
chore: remove router-1.tinfoil.dev

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,6 @@
 routers:
   inference.tinfoil.sh:
   router.inf6.tinfoil.sh:
-  router-1.tinfoil.dev:
 
 models:
   nomic-embed-text:


### PR DESCRIPTION
Removed router-1.tinfoil.dev from the configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed router-1.tinfoil.dev from the routers list in config.yml to clean up an unused routing entry.

<sup>Written for commit 75138d93e20c48183b220a65d4549e4bd2c2a0fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

