### PR TITLE
chore: update websearch enclave url

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -78,7 +78,7 @@ models:
   websearch:
     repo: tinfoilsh/confidential-websearch
     enclaves:
-      - websearch.tinfoil.functions.tinfoil.sh
+      - websearch.tinfoil.sh
 
   gemma4-31b:
     repo: tinfoilsh/confidential-gemma4-31b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the `websearch` enclave URL in `config.yml` from `websearch.tinfoil.functions.tinfoil.sh` to `websearch.tinfoil.sh` to point to the new endpoint.

<sup>Written for commit 3867be4c5ef96ff846ac92be5950b2e3c17bca91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

