### PR TITLE
chore: remove kimi-k2-thinking

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -63,11 +63,6 @@ models:
     enclaves:
       - qwen3-vl-30b.tinfoil.containers.tinfoil.dev
 
-  kimi-k2-thinking:
-    repo: tinfoilsh/confidential-kimi-k2-thinking
-    enclaves:
-      - kimi-k2-thinking.tinfoil.containers.tinfoil.dev
-
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the deprecated `kimi-k2-thinking` model from `config.yml` to clean up unused config and prevent deployments to its enclave. Any remaining references to `kimi-k2-thinking` should be updated to a supported model (e.g., `kimi-k2-5`).

<sup>Written for commit b1d1300b2ee30898235bbefcafcd7eadc17661ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

