### PR TITLE
chore: move glm-5-1 and kimi-k2-5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -36,7 +36,7 @@ models:
   glm-5-1:
     repo: tinfoilsh/confidential-glm5-1
     enclaves:
-      - glm-5-1.tinfoil.containers.tinfoil.dev
+      - glm-5-1-inf10.tinfoil.containers.tinfoil.dev
 
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
@@ -66,7 +66,7 @@ models:
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
-      - kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev
+      - kimi-k2-5-inf11.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 4
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update enclave targets to move `glm-5-1` to `glm-5-1-inf10.tinfoil.containers.tinfoil.dev` and `kimi-k2-5` to `kimi-k2-5-inf11.tinfoil.containers.tinfoil.dev`, routing traffic to the new infra. No functional changes.

<sup>Written for commit 764db55967f2491d4319278beb4ba04e2eff514a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

