### PR TITLE
chore: move kimi-k2-5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -66,7 +66,7 @@ models:
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
-      - kimi-k2-5-inf11.tinfoil.containers.tinfoil.dev
+      - kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 4
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated `config.yml` to move the `kimi-k2-5` model from `kimi-k2-5-inf11.tinfoil.containers.tinfoil.dev` to `kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev`. Routing now targets the new enclave; no rate limit changes.

<sup>Written for commit 9504314e481774fec8bf172c187204fe1ffa7c1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

