### PR TITLE
chore: move kimi-k2-5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -66,7 +66,7 @@ models:
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
-      - kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev
+      - kimi-k2-5-inf11.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 4
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move `kimi-k2-5` to the new `inf11` enclave by updating its hostname in `config.yml`, routing all traffic to the new infra. No behavior or rate limit changes.

<sup>Written for commit 772a42d23797e196014ef81f43e2c9bf0e862d67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

