### PR TITLE
chore: move glm-5-1

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -36,7 +36,7 @@ models:
   glm-5-1:
     repo: tinfoilsh/confidential-glm5-1
     enclaves:
-      - glm-5-1-inf10.tinfoil.containers.tinfoil.dev
+      - glm-5-1.tinfoil.containers.tinfoil.dev
 
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the `glm-5-1` model configuration to use the new enclave hostname. Switched from `glm-5-1-inf10.tinfoil.containers.tinfoil.dev` to `glm-5-1.tinfoil.containers.tinfoil.dev` in `config.yml`.

<sup>Written for commit 2ad4c298eedf378f8de3616ad3cf349b730edb16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

