### PR TITLE
fix: increase Gemma max_requests_waiting to 16

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -80,5 +80,5 @@ models:
     enclaves:
       - gemma4-31b.inf9.tinfoil.sh
     overload:
-      max_requests_waiting: 8
+      max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increases queue capacity for the Gemma 31B enclave by raising `overload.max_requests_waiting` from 8 to 16 to better absorb traffic spikes. `retry_after_minutes` stays at 1.

<sup>Written for commit 59b32884a12a34c2a257699ac471438b887ebee2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

