### PR TITLE
chore: move kimi-k2-5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -66,7 +66,7 @@ models:
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
-      - kimi-k2-5-inf11.tinfoil.containers.tinfoil.dev
+      - kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 4
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `config.yml` to move the `kimi-k2-5` model from `kimi-k2-5-inf11.tinfoil.containers.tinfoil.dev` to `kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev`. Routes traffic to the new enclave; rate limits unchanged.

<sup>Written for commit 19610edb215d514226536fb8e283548923e30f60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

