### PR TITLE
chore: add replica kimi 2.5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -67,6 +67,7 @@ models:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
       - kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev
+      - kimi-k2-5-inf11.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 4
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a new inference replica for the Kimi 2.5 model to improve availability and throughput. `config.yml` now includes enclave `kimi-k2-5-inf11.tinfoil.containers.tinfoil.dev` for `tinfoilsh/confidential-kimi-k2-5`.

<sup>Written for commit 0427aed82446b67a7e489d37fda1ab53eaa27d9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

