### PR TITLE
chore: move models

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -41,7 +41,7 @@ models:
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
-      - gpt-oss-120b-0.inf9.tinfoil.sh
+      - gpt-oss-120b-0.inf6.tinfoil.sh
       - gpt-oss-120b-1.inf9.tinfoil.sh
       - gpt-oss-120b-2.inf9.tinfoil.sh
     overload:
@@ -61,7 +61,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.tinfoil.containers.tinfoil.dev
+      - qwen3-vl-30b-inf9.tinfoil.containers.tinfoil.dev
 
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5
@@ -80,6 +80,7 @@ models:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
       - gemma4-31b.inf9.tinfoil.sh
+      - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1

--- a/config.yml
+++ b/config.yml
@@ -61,7 +61,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b-inf9.tinfoil.containers.tinfoil.dev
+      - qwen3-vl-30b.inf9.tinfoil.sh
 
   kimi-k2-5:
     repo: tinfoilsh/confidential-kimi-k2-5


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved model endpoints to new enclaves and added redundancy in config.yml. Switched gpt-oss-120b’s first enclave to inf6, updated qwen3-vl-30b to inf9.tinfoil.sh, and added an inf6 enclave for gemma4-31b.

<sup>Written for commit 50cc777c498406f1ab8ce1733f5b5f165d0e8001. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

