### PR TITLE
Add K2.6 router entry

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -71,6 +71,11 @@ models:
     rate_limit:
       max_requests_per_minute: 4
 
+  kimi-k2-6:
+    repo: tinfoilsh/confidential-kimi-k2-6
+    enclaves:
+      - kimi-k2-6.tinfoil.containers.tinfoil.dev
+
   websearch:
     repo: tinfoilsh/confidential-websearch
     enclaves:


### PR DESCRIPTION
Adds the confidential Kimi K2.6 model to the router runtime config using the updated enclave hostname.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the confidential Kimi K2.6 model to the router runtime config. The new `kimi-k2-6` entry routes to repo `tinfoilsh/confidential-kimi-k2-6` via enclave `kimi-k2-6.tinfoil.containers.tinfoil.dev`.

<sup>Written for commit 58b5e921f6da16ae423338f994df6c31a19a9e34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

