### PR TITLE
feat: add cached prompt token metrics for kimi-k2-6

### DIFF
--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -40,6 +40,9 @@ const (
 	maxUsageMetricsBodyBytes = int64(10 << 20)
 	// websearchModel is charged per-request in addition to per-token.
 	websearchModel = "websearch"
+	// prompt token detail fields are only exposed in usage metrics for models
+	// that explicitly opt in, to avoid surprising existing consumers.
+	promptTokenDetailsMetricsModel = "kimi-k2-6"
 )
 
 // classifyProxyError maps a transport-level error to a bounded set of reason
@@ -251,6 +254,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 			if usage == nil {
 				return
 			}
+			usage.ExposePromptTokenDetails = modelName == promptTokenDetailsMetricsModel
 
 			// For streaming responses, set usage on wrapper for trailer
 			// (non-streaming sets header directly in the buffering block below)
@@ -367,9 +371,20 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 
 // formatUsage formats token usage for the response header
 func formatUsage(usage *tokencount.Usage) string {
-	return "prompt=" + strconv.Itoa(usage.PromptTokens) +
+	formatted := "prompt=" + strconv.Itoa(usage.PromptTokens) +
 		",completion=" + strconv.Itoa(usage.CompletionTokens) +
 		",total=" + strconv.Itoa(usage.TotalTokens)
+
+	if usage.ExposePromptTokenDetails {
+		cachedPromptTokens, ok := usage.CachedPromptTokens()
+		if ok {
+			uncachedPromptTokens := max(0, usage.PromptTokens-cachedPromptTokens)
+			formatted += ",cached_prompt_tokens=" + strconv.Itoa(cachedPromptTokens) +
+				",uncached_prompt_tokens=" + strconv.Itoa(uncachedPromptTokens)
+		}
+	}
+
+	return formatted
 }
 
 func addTrailerHeader(h http.Header, name string) {

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -1,10 +1,13 @@
 package manager
 
 import (
+	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -164,6 +167,156 @@ func TestProxyBilling_WebsearchEmitsOnlyZeroTokenEvent(t *testing.T) {
 	}
 	if events[0].Model != websearchModel {
 		t.Errorf("expected event model %q, got %q", websearchModel, events[0].Model)
+	}
+}
+
+func TestProxyUsageMetrics_NonStreamingIncludesCachedPromptBreakdown(t *testing.T) {
+	proxy, collector := setupTestProxyWithModel(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"choices":[],"usage":{"prompt_tokens":69,"completion_tokens":20,"total_tokens":89,"prompt_tokens_details":{"cached_tokens":64}}}`))
+	}), promptTokenDetailsMetricsModel)
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer test-key-1234567890")
+	req.Header.Set(UsageMetricsRequestHeader, "true")
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+	ctx := context.WithValue(req.Context(), usageWriterKey{}, wrapper)
+
+	proxy.ServeHTTP(wrapper, req.WithContext(ctx))
+
+	got := rec.Header().Get(UsageMetricsResponseHeader)
+	want := "prompt=69,completion=20,total=89,cached_prompt_tokens=64,uncached_prompt_tokens=5"
+	if got != want {
+		t.Fatalf("usage header = %q, want %q", got, want)
+	}
+
+	events := collector.GetEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 billing event, got %d", len(events))
+	}
+	if events[0].PromptTokens != 69 {
+		t.Fatalf("prompt_tokens billed = %d, want 69", events[0].PromptTokens)
+	}
+	if events[0].CompletionTokens != 20 {
+		t.Fatalf("completion_tokens billed = %d, want 20", events[0].CompletionTokens)
+	}
+	if events[0].TotalTokens != 89 {
+		t.Fatalf("total_tokens billed = %d, want 89", events[0].TotalTokens)
+	}
+}
+
+func TestProxyUsageMetrics_StreamingIncludesCachedPromptBreakdown(t *testing.T) {
+	proxy, collector := setupTestProxyWithModel(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"index\":0}],\"usage\":{\"prompt_tokens\":69,\"completion_tokens\":1,\"total_tokens\":70}}\n\n")
+		io.WriteString(w, "data: {\"id\":\"chatcmpl-1\",\"choices\":[],\"usage\":{\"prompt_tokens\":69,\"completion_tokens\":20,\"total_tokens\":89,\"prompt_tokens_details\":{\"cached_tokens\":64}}}\n\n")
+		io.WriteString(w, "data: [DONE]\n\n")
+	}), promptTokenDetailsMetricsModel)
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{"stream":true}`))
+	req.Header.Set("Authorization", "Bearer test-key-1234567890")
+	req.Header.Set(UsageMetricsRequestHeader, "true")
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+	ctx := context.WithValue(req.Context(), usageWriterKey{}, wrapper)
+
+	proxy.ServeHTTP(wrapper, req.WithContext(ctx))
+	if wrapper.TrailerEnabled() {
+		wrapper.WriteTrailer()
+	}
+
+	got := rec.Header().Get(UsageMetricsResponseHeader)
+	want := "prompt=69,completion=20,total=89,cached_prompt_tokens=64,uncached_prompt_tokens=5"
+	if got != want {
+		t.Fatalf("usage trailer = %q, want %q", got, want)
+	}
+
+	body := rec.Body.String()
+	if strings.Contains(body, "\"choices\":[]") {
+		t.Fatal("usage-only chunk should be filtered when client did not explicitly request usage chunks")
+	}
+
+	events := collector.GetEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 billing event, got %d", len(events))
+	}
+	if events[0].PromptTokens != 69 {
+		t.Fatalf("prompt_tokens billed = %d, want 69", events[0].PromptTokens)
+	}
+	if events[0].CompletionTokens != 20 {
+		t.Fatalf("completion_tokens billed = %d, want 20", events[0].CompletionTokens)
+	}
+	if events[0].TotalTokens != 89 {
+		t.Fatalf("total_tokens billed = %d, want 89", events[0].TotalTokens)
+	}
+}
+
+func TestProxyUsageMetrics_StreamingResponsesAPIIncludesCachedPromptBreakdown(t *testing.T) {
+	proxy, collector := setupTestProxyWithModel(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "event: response.created\n")
+		io.WriteString(w, "data: {\"response\":{\"id\":\"resp_1\",\"status\":\"in_progress\",\"usage\":null},\"type\":\"response.created\"}\n\n")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, "data: {\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":69,\"input_tokens_details\":{\"cached_tokens\":64},\"output_tokens\":20,\"total_tokens\":89}},\"type\":\"response.completed\"}\n\n")
+	}), promptTokenDetailsMetricsModel)
+
+	req := httptest.NewRequest("POST", "/v1/responses", strings.NewReader(`{"stream":true}`))
+	req.Header.Set("Authorization", "Bearer test-key-1234567890")
+	req.Header.Set(UsageMetricsRequestHeader, "true")
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+	ctx := context.WithValue(req.Context(), usageWriterKey{}, wrapper)
+
+	proxy.ServeHTTP(wrapper, req.WithContext(ctx))
+	if wrapper.TrailerEnabled() {
+		wrapper.WriteTrailer()
+	}
+
+	got := rec.Header().Get(UsageMetricsResponseHeader)
+	want := "prompt=69,completion=20,total=89,cached_prompt_tokens=64,uncached_prompt_tokens=5"
+	if got != want {
+		t.Fatalf("usage trailer = %q, want %q", got, want)
+	}
+
+	events := collector.GetEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 billing event, got %d", len(events))
+	}
+	if events[0].PromptTokens != 69 {
+		t.Fatalf("prompt_tokens billed = %d, want 69", events[0].PromptTokens)
+	}
+	if events[0].CompletionTokens != 20 {
+		t.Fatalf("completion_tokens billed = %d, want 20", events[0].CompletionTokens)
+	}
+	if events[0].TotalTokens != 89 {
+		t.Fatalf("total_tokens billed = %d, want 89", events[0].TotalTokens)
+	}
+}
+
+func TestProxyUsageMetrics_NonKimiModelKeepsLegacyUsageFormat(t *testing.T) {
+	proxy, _ := setupTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"choices":[],"usage":{"prompt_tokens":69,"completion_tokens":20,"total_tokens":89,"prompt_tokens_details":{"cached_tokens":64}}}`))
+	}))
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer test-key-1234567890")
+	req.Header.Set(UsageMetricsRequestHeader, "true")
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+	ctx := context.WithValue(req.Context(), usageWriterKey{}, wrapper)
+
+	proxy.ServeHTTP(wrapper, req.WithContext(ctx))
+
+	got := rec.Header().Get(UsageMetricsResponseHeader)
+	want := "prompt=69,completion=20,total=89"
+	if got != want {
+		t.Fatalf("usage header = %q, want %q", got, want)
 	}
 }
 

--- a/manager/usage_writer_test.go
+++ b/manager/usage_writer_test.go
@@ -72,6 +72,27 @@ func TestUsageMetricsWriter_FormatUsage(t *testing.T) {
 			expected: "prompt=128000,completion=4096,total=132096",
 		},
 		{
+			name: "includes cached prompt token details when present",
+			usage: &tokencount.Usage{
+				PromptTokens:             69,
+				CompletionTokens:         20,
+				TotalTokens:              89,
+				PromptTokensDetails:      &tokencount.PromptTokensDetails{CachedTokens: 64},
+				ExposePromptTokenDetails: true,
+			},
+			expected: "prompt=69,completion=20,total=89,cached_prompt_tokens=64,uncached_prompt_tokens=5",
+		},
+		{
+			name: "keeps legacy format when prompt token details are not exposed",
+			usage: &tokencount.Usage{
+				PromptTokens:        69,
+				CompletionTokens:    20,
+				TotalTokens:         89,
+				PromptTokensDetails: &tokencount.PromptTokensDetails{CachedTokens: 64},
+			},
+			expected: "prompt=69,completion=20,total=89",
+		},
+		{
 			name:     "nil usage",
 			usage:    nil,
 			expected: "",

--- a/tokencount/extractor.go
+++ b/tokencount/extractor.go
@@ -15,11 +15,19 @@ import (
 // Supports both Chat Completions (prompt_tokens/completion_tokens) and
 // Responses API (input_tokens/output_tokens) field names.
 type Usage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
-	InputTokens      int `json:"input_tokens"`
-	OutputTokens     int `json:"output_tokens"`
+	PromptTokens        int                  `json:"prompt_tokens"`
+	CompletionTokens    int                  `json:"completion_tokens"`
+	TotalTokens         int                  `json:"total_tokens"`
+	InputTokens         int                  `json:"input_tokens"`
+	OutputTokens        int                  `json:"output_tokens"`
+	PromptTokensDetails *PromptTokensDetails `json:"prompt_tokens_details,omitempty"`
+	InputTokensDetails  *PromptTokensDetails `json:"input_tokens_details,omitempty"`
+
+	ExposePromptTokenDetails bool `json:"-"`
+}
+
+type PromptTokensDetails struct {
+	CachedTokens int `json:"cached_tokens"`
 }
 
 // Normalize maps Responses API fields (input_tokens/output_tokens) into
@@ -32,6 +40,18 @@ func (u *Usage) Normalize() {
 	if u.CompletionTokens == 0 && u.OutputTokens > 0 {
 		u.CompletionTokens = u.OutputTokens
 	}
+	if u.PromptTokensDetails == nil && u.InputTokensDetails != nil {
+		u.PromptTokensDetails = u.InputTokensDetails
+	}
+}
+
+func (u *Usage) CachedPromptTokens() (int, bool) {
+	if u == nil || u.PromptTokensDetails == nil {
+		return 0, false
+	}
+
+	cached := min(u.PromptTokens, max(0, u.PromptTokensDetails.CachedTokens))
+	return cached, true
 }
 
 // OpenAIResponse represents a standard OpenAI-compatible response
@@ -191,7 +211,7 @@ func (s *StreamingTokenExtractor) processStream() {
 					// Check for usage in the chunk (Chat Completions API)
 					// or nested under "response" (Responses API streaming)
 					usageData, ok := chunk["usage"]
-					if (!ok || usageData == nil) {
+					if !ok || usageData == nil {
 						if respObj, rOk := chunk["response"].(map[string]interface{}); rOk {
 							usageData, ok = respObj["usage"]
 						}
@@ -210,6 +230,9 @@ func (s *StreamingTokenExtractor) processStream() {
 							}
 							if usage.TotalTokens > 0 {
 								s.usage.TotalTokens = usage.TotalTokens
+							}
+							if usage.PromptTokensDetails != nil {
+								s.usage.PromptTokensDetails = usage.PromptTokensDetails
 							}
 						}
 


### PR DESCRIPTION
## Summary
- add cached prompt token parsing for chat and responses usage payloads
- expose cached and uncached prompt token metrics only for kimi-k2-6 usage headers and trailers
- keep billing and control-plane reporting on total prompt tokens only

## Testing
- go test ./...
- verified locally against kimi-k2-6 through the router for non-streaming headers and streaming trailers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose cached and uncached prompt token metrics in usage headers/trailers for `kimi-k2-6`. No changes to billing or control-plane reporting.

- **New Features**
  - Add `cached_prompt_tokens` and `uncached_prompt_tokens` to usage header/trailer when model is `kimi-k2-6`.
  - Parse `prompt_tokens_details.cached_tokens` and `input_tokens_details.cached_tokens`, normalized to prompt tokens.
  - Support Chat Completions and Responses, streaming and non-streaming; usage-only chunks remain filtered unless explicitly requested.
  - Non-`kimi-k2-6` models keep the legacy usage format (`prompt`, `completion`, `total` only).

<sup>Written for commit 89d5e8b8ffc9cf6cae13a686c0aafd7e722cd868. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

