### PR TITLE
chore: remove enclave entry for kimi-k2-5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -68,7 +68,6 @@ models:
     repo: tinfoilsh/confidential-kimi-k2-5
     enclaves:
       - kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev
-      - kimi-k2-5-inf11.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 4
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the `kimi-k2-5-inf11.tinfoil.containers.tinfoil.dev` enclave from the `kimi-k2-5` model config to reflect decommissioning.
This prevents routing traffic to an inactive enclave and keeps the config accurate.

<sup>Written for commit 754c9c4e888a374226f575f541acff3ccef11bd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

