### PR TITLE
Attach per-call sources to tinfoil-event markers in chat completions

### DIFF
--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -520,11 +520,11 @@ func (s *chatStreamer) executeTool(ctx context.Context, registry *sessionRegistr
 // `delta.content` of a chat.completion.chunk frame. When the caller did
 // not opt into the marker stream, this is a no-op so strict SDKs see a
 // pristine spec-conformant stream.
-func (s *chatStreamer) emitTinfoilEventMarker(id, status string, action map[string]any, reason string) {
+func (s *chatStreamer) emitTinfoilEventMarker(id, status string, action map[string]any, reason string, sources []toolCallSource) {
 	if !s.eventsEnabled {
 		return
 	}
-	marker := tinfoilEventMarker(id, status, action, reason)
+	marker := tinfoilEventMarker(id, status, action, reason, sources)
 	s.writeChunk(map[string]any{
 		"choices": []any{
 			map[string]any{

--- a/toolruntime/citations.go
+++ b/toolruntime/citations.go
@@ -26,11 +26,27 @@ type citationSource struct {
 // carries the tool-side error message when the call failed so terminal
 // web_search_call items can honestly report status:"failed" instead of
 // silently claiming completion on a request that never returned results.
+//
+// resultSources carries the ordered {url, title} pairs this specific call
+// produced (search results, fetched pages) so terminal tinfoil-event
+// markers can attribute sources to the exact search call that surfaced
+// them. resultURLs is the same list in URL-only form kept for the
+// Responses API `action.sources` shape.
 type toolCallRecord struct {
-	name        string
-	arguments   map[string]any
-	resultURLs  []string
-	errorReason string
+	name          string
+	arguments     map[string]any
+	resultURLs    []string
+	resultSources []toolCallSource
+	errorReason   string
+}
+
+// toolCallSource is a single {url, title} pair produced by a router tool
+// call (a search hit or a fetched page). Titles are best-effort: a
+// missing or empty title is surfaced as an empty string so clients can
+// fall back to displaying the bare URL.
+type toolCallSource struct {
+	url   string
+	title string
 }
 
 type citationState struct {
@@ -120,6 +136,52 @@ func extractToolOutputURLs(output string) []string {
 		urls = append(urls, url)
 	}
 	return urls
+}
+
+// extractToolOutputSources pulls the `{Source, URL}` pairs the router
+// embeds into each numbered result block so terminal tinfoil-event
+// markers can attribute sources to the specific search call that
+// produced them. Each block is formatted as:
+//
+//	Source: <title>
+//	URL: <url>
+//
+// with the `Source:` line optional. Duplicate URLs are dropped so a
+// single call never lists the same hit twice. Titles are best-effort;
+// a missing `Source:` line yields an empty title.
+func extractToolOutputSources(output string) []toolCallSource {
+	if output == "" {
+		return nil
+	}
+	lines := strings.Split(output, "\n")
+	sources := make([]toolCallSource, 0)
+	seen := make(map[string]struct{})
+	var pendingTitle string
+	for _, line := range lines {
+		trimmed := strings.TrimRight(line, "\r")
+		if strings.HasPrefix(trimmed, "Source:") {
+			pendingTitle = strings.TrimSpace(strings.TrimPrefix(trimmed, "Source:"))
+			continue
+		}
+		if strings.HasPrefix(trimmed, "URL:") {
+			url := strings.TrimSpace(strings.TrimPrefix(trimmed, "URL:"))
+			if url == "" {
+				pendingTitle = ""
+				continue
+			}
+			if _, dup := seen[url]; dup {
+				pendingTitle = ""
+				continue
+			}
+			seen[url] = struct{}{}
+			sources = append(sources, toolCallSource{url: url, title: pendingTitle})
+			pendingTitle = ""
+		}
+	}
+	if len(sources) == 0 {
+		return nil
+	}
+	return sources
 }
 
 // toActionSources wraps a list of URLs in the OpenAI-spec shape

--- a/toolruntime/events.go
+++ b/toolruntime/events.go
@@ -108,7 +108,13 @@ func tinfoilEventsEnabled(h http.Header) bool {
 // padded with `\n` on both sides. The pad is part of the strip-regex
 // contract used by the tinfoil-events parsers in the webapp and iOS
 // apps and must not be changed without co-updating those parsers.
-func tinfoilEventMarker(id, status string, action map[string]any, reason string) string {
+//
+// When sources is non-empty the marker payload gains a top-level
+// `sources` array of `{url, title}` objects so clients can attribute
+// the citations produced by this specific tool call (e.g. one search
+// among several in a multi-step turn) rather than having to merge all
+// sources into one bucket per turn. Older clients ignore unknown keys.
+func tinfoilEventMarker(id, status string, action map[string]any, reason string, sources []toolCallSource) string {
 	payload := map[string]any{
 		"type":    tinfoilEventPayloadType,
 		"item_id": id,
@@ -117,6 +123,9 @@ func tinfoilEventMarker(id, status string, action map[string]any, reason string)
 	}
 	if reason != "" {
 		payload["error"] = map[string]any{"code": reason}
+	}
+	if encoded := encodeMarkerSources(sources); len(encoded) > 0 {
+		payload["sources"] = encoded
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -127,6 +136,31 @@ func tinfoilEventMarker(id, status string, action map[string]any, reason string)
 		data = []byte(`{"type":"` + tinfoilEventPayloadType + `"}`)
 	}
 	return "\n" + tinfoilEventOpenTag + string(data) + tinfoilEventCloseTag + "\n"
+}
+
+// encodeMarkerSources maps toolCallSource into the plain-map shape used
+// on the wire. Entries with an empty URL are dropped because a source
+// without a target is not usable by a client. Titles are kept as-is,
+// including empty strings, so clients can choose to fall back to the
+// hostname rather than guess.
+func encodeMarkerSources(sources []toolCallSource) []map[string]any {
+	if len(sources) == 0 {
+		return nil
+	}
+	encoded := make([]map[string]any, 0, len(sources))
+	for _, source := range sources {
+		if source.url == "" {
+			continue
+		}
+		encoded = append(encoded, map[string]any{
+			"url":   source.url,
+			"title": source.title,
+		})
+	}
+	if len(encoded) == 0 {
+		return nil
+	}
+	return encoded
 }
 
 // tinfoilEventMarkersForRecords renders a sequence of in_progress then
@@ -145,10 +179,10 @@ func tinfoilEventMarkersForRecords(records []toolCallRecord) string {
 	}
 	var builder strings.Builder
 	status := func(record toolCallRecord) string { return statusForRecord(record) }
-	writePair := func(action map[string]any, s, reason string) {
+	writePair := func(action map[string]any, s, reason string, sources []toolCallSource) {
 		id := "ws_" + uuid.NewString()
-		builder.WriteString(tinfoilEventMarker(id, "in_progress", action, ""))
-		builder.WriteString(tinfoilEventMarker(id, s, action, reason))
+		builder.WriteString(tinfoilEventMarker(id, "in_progress", action, "", nil))
+		builder.WriteString(tinfoilEventMarker(id, s, action, reason, sources))
 	}
 	for _, record := range records {
 		switch record.name {
@@ -157,7 +191,7 @@ func tinfoilEventMarkersForRecords(records []toolCallRecord) string {
 			if query := stringValue(record.arguments["query"]); query != "" {
 				action["query"] = query
 			}
-			writePair(action, status(record), record.errorReason)
+			writePair(action, status(record), record.errorReason, record.resultSources)
 		case "fetch":
 			urls := fetchArgumentURLs(record.arguments)
 			if len(urls) == 0 {
@@ -165,7 +199,7 @@ func tinfoilEventMarkersForRecords(records []toolCallRecord) string {
 			}
 			for _, url := range urls {
 				action := map[string]any{"type": "open_page", "url": url}
-				writePair(action, status(record), record.errorReason)
+				writePair(action, status(record), record.errorReason, nil)
 			}
 		}
 	}

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -233,6 +233,7 @@ func executeRouterToolCall(
 		record.errorReason = publicToolErrorReason(call.name, err)
 	} else {
 		record.resultURLs = extractToolOutputURLs(output)
+		record.resultSources = extractToolOutputSources(output)
 		if traceID != "" {
 			debugLogf("toolruntime:%s %s tool.result name=%s elapsed=%s output_len=%d urls=%v preview=%q",
 				traceID, tracePhase, call.name, time.Since(tstart), len(output), record.resultURLs, debugPreview(output, 400))

--- a/toolruntime/tinfoil_events_stream_test.go
+++ b/toolruntime/tinfoil_events_stream_test.go
@@ -43,7 +43,7 @@ func TestChatStreamerEmitTinfoilEventMarkerWritesDeltaWhenEnabled(t *testing.T) 
 	streamer, rec := newTestChatStreamer(t)
 	streamer.eventsEnabled = true
 
-	streamer.emitTinfoilEventMarker("ws_1", "in_progress", map[string]any{"type": "search", "query": "q"}, "")
+	streamer.emitTinfoilEventMarker("ws_1", "in_progress", map[string]any{"type": "search", "query": "q"}, "", nil)
 
 	body := rec.Body.String()
 	// Pull exactly one `data:` frame, decode it, and assert the
@@ -88,10 +88,42 @@ func TestChatStreamerEmitTinfoilEventMarkerIsNoOpWhenDisabled(t *testing.T) {
 	streamer, rec := newTestChatStreamer(t)
 	streamer.eventsEnabled = false
 
-	streamer.emitTinfoilEventMarker("ws_1", "in_progress", map[string]any{"type": "search"}, "")
+	streamer.emitTinfoilEventMarker("ws_1", "in_progress", map[string]any{"type": "search"}, "", nil)
 
 	if body := rec.Body.String(); body != "" {
 		t.Fatalf("expected empty stream when events are disabled, got %q", body)
+	}
+}
+
+// TestChatStreamerEmitsSourcesOnTerminalMarker pins that when the
+// terminal marker carries a non-empty sources list, the wire payload
+// includes them in the order provided so opt-in clients can attribute
+// citations to the specific search call that produced them.
+func TestChatStreamerEmitsSourcesOnTerminalMarker(t *testing.T) {
+	streamer, rec := newTestChatStreamer(t)
+	streamer.eventsEnabled = true
+
+	sources := []toolCallSource{
+		{url: "https://first.example", title: "First"},
+		{url: "https://second.example", title: "Second"},
+	}
+	streamer.emitTinfoilEventMarker("ws_1", "completed", map[string]any{"type": "search", "query": "q"}, "", sources)
+
+	frame := firstSSEDataFrame(t, rec.Body.String())
+	var chunk map[string]any
+	if err := json.Unmarshal([]byte(frame), &chunk); err != nil {
+		t.Fatalf("chat stream frame must be valid JSON: %v (%q)", err, frame)
+	}
+	delta := chunk["choices"].([]any)[0].(map[string]any)["delta"].(map[string]any)
+	content := delta["content"].(string)
+	if !strings.Contains(content, `"https://first.example"`) {
+		t.Fatalf("terminal marker missing first source url: %q", content)
+	}
+	if !strings.Contains(content, `"First"`) {
+		t.Fatalf("terminal marker missing first source title: %q", content)
+	}
+	if !strings.Contains(content, `"https://second.example"`) {
+		t.Fatalf("terminal marker missing second source url: %q", content)
 	}
 }
 

--- a/toolruntime/tinfoil_events_test.go
+++ b/toolruntime/tinfoil_events_test.go
@@ -45,7 +45,7 @@ func TestTinfoilEventsEnabledHeaderParsing(t *testing.T) {
 // callers depend on (id, status, action) plus the tinfoil-specific
 // reason when present.
 func TestTinfoilEventMarkerShape(t *testing.T) {
-	marker := tinfoilEventMarker("ws_1", "in_progress", map[string]any{"type": "search", "query": "q"}, "")
+	marker := tinfoilEventMarker("ws_1", "in_progress", map[string]any{"type": "search", "query": "q"}, "", nil)
 	if !strings.HasPrefix(marker, "\n"+tinfoilEventOpenTag) {
 		t.Fatalf("marker must start on its own line with %q: got %q", tinfoilEventOpenTag, marker)
 	}
@@ -81,7 +81,7 @@ func TestTinfoilEventMarkerShape(t *testing.T) {
 // surface safety-block text or upstream error context without the field
 // polluting every success marker.
 func TestTinfoilEventMarkerIncludesReason(t *testing.T) {
-	marker := tinfoilEventMarker("ws_1", "blocked", map[string]any{"type": "search"}, "safety policy rejected this query")
+	marker := tinfoilEventMarker("ws_1", "blocked", map[string]any{"type": "search"}, "safety policy rejected this query", nil)
 	payload := strings.TrimSuffix(strings.TrimPrefix(marker, "\n"+tinfoilEventOpenTag), tinfoilEventCloseTag+"\n")
 	var decoded map[string]any
 	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
@@ -116,6 +116,119 @@ func TestTinfoilEventMarkersForRecordsMapsSearch(t *testing.T) {
 	}
 	if !strings.Contains(combined, `"status":"completed"`) {
 		t.Fatalf("missing completed marker: %q", combined)
+	}
+}
+
+// TestExtractToolOutputSourcesPairsSourceAndURL pins that the
+// formatted search tool output is parsed into the correct ordered
+// {url, title} list so terminal markers can attribute citations to
+// the call that produced them. URLs missing a `Source:` line yield an
+// empty title; duplicate URLs are dropped.
+func TestExtractToolOutputSourcesPairsSourceAndURL(t *testing.T) {
+	output := strings.Join([]string{
+		"Source: First Hit",
+		"URL: https://one.example",
+		"snippet one",
+		"",
+		"URL: https://no-title.example",
+		"snippet two",
+		"",
+		"Source: Third Hit",
+		"URL: https://one.example",
+		"duplicate url should be ignored",
+	}, "\n")
+
+	sources := extractToolOutputSources(output)
+	if len(sources) != 2 {
+		t.Fatalf("expected 2 unique sources, got %d: %#v", len(sources), sources)
+	}
+	if sources[0].url != "https://one.example" || sources[0].title != "First Hit" {
+		t.Fatalf("first source mismatch: %#v", sources[0])
+	}
+	if sources[1].url != "https://no-title.example" || sources[1].title != "" {
+		t.Fatalf("second source mismatch: %#v", sources[1])
+	}
+}
+
+// TestTinfoilEventMarkerEmbedsSources pins that the optional sources
+// list surfaces on the marker JSON as a `sources` array of
+// `{url, title}` objects only on the terminal marker. Opt-in clients
+// use this to attribute citations to the specific search call that
+// produced them when a single turn runs multiple searches.
+func TestTinfoilEventMarkerEmbedsSources(t *testing.T) {
+	sources := []toolCallSource{
+		{url: "https://one.example", title: "One"},
+		{url: "https://two.example", title: "Two"},
+	}
+	marker := tinfoilEventMarker("ws_1", "completed", map[string]any{"type": "search", "query": "q"}, "", sources)
+	payload := strings.TrimSuffix(strings.TrimPrefix(marker, "\n"+tinfoilEventOpenTag), tinfoilEventCloseTag+"\n")
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+		t.Fatalf("payload must be valid JSON: %v (payload=%q)", err, payload)
+	}
+	rawSources, ok := decoded["sources"].([]any)
+	if !ok {
+		t.Fatalf("payload.sources missing or wrong type: %#v", decoded["sources"])
+	}
+	if got := len(rawSources); got != 2 {
+		t.Fatalf("expected 2 sources, got %d: %#v", got, rawSources)
+	}
+	first, _ := rawSources[0].(map[string]any)
+	if first["url"] != "https://one.example" || first["title"] != "One" {
+		t.Fatalf("first source did not round-trip: %#v", first)
+	}
+}
+
+// TestTinfoilEventMarkerOmitsSourcesWhenEmpty pins that the `sources`
+// field is absent from the payload when no sources are supplied so the
+// happy-path marker bytes stay minimal and existing snapshots continue
+// to round-trip.
+func TestTinfoilEventMarkerOmitsSourcesWhenEmpty(t *testing.T) {
+	marker := tinfoilEventMarker("ws_1", "completed", map[string]any{"type": "search"}, "", nil)
+	payload := strings.TrimSuffix(strings.TrimPrefix(marker, "\n"+tinfoilEventOpenTag), tinfoilEventCloseTag+"\n")
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+		t.Fatalf("payload must be valid JSON: %v (payload=%q)", err, payload)
+	}
+	if _, present := decoded["sources"]; present {
+		t.Fatalf("payload.sources must be omitted when no sources supplied, got %#v", decoded)
+	}
+}
+
+// TestTinfoilEventMarkersForRecordsAttachesSources pins that the
+// non-streaming bulk-marker emitter puts record.resultSources onto the
+// terminal marker of a search record (and not onto the in_progress
+// marker), so the non-streaming chat path matches the streaming one.
+func TestTinfoilEventMarkersForRecordsAttachesSources(t *testing.T) {
+	records := []toolCallRecord{
+		{
+			name:      "search",
+			arguments: map[string]any{"query": "q"},
+			resultSources: []toolCallSource{
+				{url: "https://one.example", title: "One"},
+			},
+		},
+	}
+	combined := tinfoilEventMarkersForRecords(records)
+	// Split into individual marker payloads and confirm only the
+	// completed marker carries sources.
+	matches := tinfoilEventMarkerPattern.FindAllStringSubmatch(combined, -1)
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 markers (in_progress + completed), got %d", len(matches))
+	}
+	for _, match := range matches {
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(match[1]), &decoded); err != nil {
+			t.Fatalf("marker payload must be valid JSON: %v (%q)", err, match[1])
+		}
+		status, _ := decoded["status"].(string)
+		_, hasSources := decoded["sources"]
+		if status == "in_progress" && hasSources {
+			t.Fatalf("in_progress marker must not carry sources: %q", match[1])
+		}
+		if status == "completed" && !hasSources {
+			t.Fatalf("completed marker must carry sources: %q", match[1])
+		}
 	}
 }
 

--- a/toolruntime/tool_progress.go
+++ b/toolruntime/tool_progress.go
@@ -36,7 +36,11 @@ type toolProgressEmitter interface {
 	// close emits the terminal progress frame for the call. status
 	// is one of "completed" / "failed" / "blocked"; reason is the
 	// opaque router error code surfaced to clients on non-success.
-	close(handle toolProgressHandle, action map[string]any, status, reason string)
+	// sources carries the ordered {url, title} pairs this specific
+	// call produced so clients can attribute citations to the search
+	// that surfaced them. May be nil on non-search calls or error
+	// terminations where no sources are available.
+	close(handle toolProgressHandle, action map[string]any, status, reason string, sources []toolCallSource)
 }
 
 // toolProgressHandle is the opaque per-call handle returned by
@@ -79,11 +83,12 @@ func executeToolWithProgress(
 		emitter.phase(handle, "response.web_search_call.searching")
 		output, err := callTool(ctx, session, call.name, call.arguments, citations)
 		if err != nil {
-			emitter.close(handle, action, failureStatusFor(err), publicToolErrorReason(call.name, err))
+			emitter.close(handle, action, failureStatusFor(err), publicToolErrorReason(call.name, err), nil)
 			return "", err
 		}
+		sources := extractToolOutputSources(output)
 		emitter.phase(handle, "response.web_search_call.completed")
-		emitter.close(handle, action, "completed", "")
+		emitter.close(handle, action, "completed", "", sources)
 		return output, nil
 	case "fetch":
 		urls := fetchArgumentURLs(call.arguments)
@@ -103,13 +108,13 @@ func executeToolWithProgress(
 			reason := publicToolErrorReason(call.name, err)
 			status := failureStatusFor(err)
 			for i := range urls {
-				emitter.close(handles[i], actions[i], status, reason)
+				emitter.close(handles[i], actions[i], status, reason, nil)
 			}
 			return "", err
 		}
 		for i := range urls {
 			emitter.phase(handles[i], "response.web_search_call.completed")
-			emitter.close(handles[i], actions[i], "completed", "")
+			emitter.close(handles[i], actions[i], "completed", "", nil)
 		}
 		return output, nil
 	default:
@@ -130,14 +135,14 @@ type chatToolProgressEmitter struct {
 }
 
 func (c *chatToolProgressEmitter) open(id string, action map[string]any) toolProgressHandle {
-	c.streamer.emitTinfoilEventMarker(id, "in_progress", action, "")
+	c.streamer.emitTinfoilEventMarker(id, "in_progress", action, "", nil)
 	return toolProgressHandle{id: id}
 }
 
 func (c *chatToolProgressEmitter) phase(toolProgressHandle, string) {}
 
-func (c *chatToolProgressEmitter) close(handle toolProgressHandle, action map[string]any, status, reason string) {
-	c.streamer.emitTinfoilEventMarker(handle.id, status, action, reason)
+func (c *chatToolProgressEmitter) close(handle toolProgressHandle, action map[string]any, status, reason string, sources []toolCallSource) {
+	c.streamer.emitTinfoilEventMarker(handle.id, status, action, reason, sources)
 }
 
 // responsesToolProgressEmitter surfaces router-owned tool progress on
@@ -158,7 +163,7 @@ func (r *responsesToolProgressEmitter) phase(handle toolProgressHandle, phase st
 	r.streamer.emitWebSearchCallPhase(phase, handle.id, handle.outputIndex)
 }
 
-func (r *responsesToolProgressEmitter) close(handle toolProgressHandle, action map[string]any, status, reason string) {
+func (r *responsesToolProgressEmitter) close(handle toolProgressHandle, action map[string]any, status, reason string, _ []toolCallSource) {
 	r.streamer.closeWebSearchCallItem(handle.id, handle.outputIndex, action, status, reason)
 }
 
@@ -208,6 +213,7 @@ func resolveStreamingRouterToolCall(
 		record.errorReason = publicToolErrorReason(call.name, err)
 	} else {
 		record.resultURLs = extractToolOutputURLs(output)
+		record.resultSources = extractToolOutputSources(output)
 		if traceID != "" {
 			debugLogf("toolruntime:%s %s tool.result name=%s elapsed=%s output_len=%d urls=%v preview=%q",
 				traceID, tracePhase, call.name, time.Since(tstart), len(output), record.resultURLs, debugPreview(output, 400))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Attach per-call sources to tinfoil-event markers so clients can attribute citations to the exact search call in a turn. Works for both streaming and non-streaming paths and stays backward compatible.

- **New Features**
  - Add a `sources` array to terminal tinfoil-event markers with ordered `{url, title}` entries for `search` calls; in_progress markers unchanged.
  - Parse `{Source:, URL:}` pairs from router tool output, dedupe by URL, and allow empty titles; expose as both `resultSources` and URL-only `resultURLs`.
  - Thread sources through runtime: `emitTinfoilEventMarker(...)` and `toolProgressEmitter.close(...)` now accept `sources`; non-streaming marker emitter attaches them to the terminal marker only; `fetch` calls unchanged.
  - Expand tests to cover source extraction, marker embedding, streaming shape, and non-streaming parity.

<sup>Written for commit e9c34ad08675431c8866fb5865a68a463e44c4c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

