### PR TITLE
chore: remove router-1 from config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,6 @@
 routers:
   inference.tinfoil.sh:
   router.inf6.tinfoil.sh:
-  router-1.tinfoil.dev:
 
 models:
   nomic-embed-text:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove the unused router entry `router-1.tinfoil.dev` from `config.yml` to prevent traffic from targeting a retired endpoint and keep the router list current.

<sup>Written for commit 53139dfd2f837b0c555611bda3f7dac7f811b4b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

