### PR TITLE
feat: allow clients to receive parallel tool calls

### DIFF
--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -115,9 +115,6 @@ func runChatStreaming(
 			return nil
 		}
 
-		// Mid-turn client tool_calls are intentionally dropped; only the
-		// final turn (no router tool calls to resolve) forwards them to
-		// the client. This preserves parity with runChatLoop.
 		routerToolCalls, clientToolCalls := splitToolCalls(ownedTools, result.toolCalls)
 		if debugEnabled {
 			toolNames := make([]string, 0, len(result.toolCalls))
@@ -132,9 +129,19 @@ func runChatStreaming(
 			return streamer.finalize(r, em, modelName, result, clientToolCalls)
 		}
 
-		messages, _ := reqBody["messages"].([]any)
-		messages = append(messages, result.assistantMessage())
+		// Execute every router-owned tool call live so its citations
+		// and progress markers flow to the client before any terminal
+		// chunks. On a non-mixed turn the outputs are also appended to
+		// the messages history so the next upstream turn can see them;
+		// on a mixed turn the router finalizes instead of looping so
+		// appending to history would be wasted work.
+		mixedTurn := len(clientToolCalls) > 0
 		tracePhase := fmt.Sprintf("chatstream.iter=%d", i)
+		var messages []any
+		if !mixedTurn {
+			messages, _ = reqBody["messages"].([]any)
+			messages = append(messages, result.assistantMessage())
+		}
 		for _, call := range routerToolCalls {
 			output := resolveStreamingRouterToolCall(
 				ctx, call, searchOpts, toolSchemas, streamer.citations,
@@ -143,11 +150,24 @@ func runChatStreaming(
 				},
 				tracePhase, tid,
 			)
-			messages = append(messages, map[string]any{
-				"role":         "tool",
-				"tool_call_id": call.id,
-				"content":      output,
-			})
+			if !mixedTurn {
+				messages = append(messages, map[string]any{
+					"role":         "tool",
+					"tool_call_id": call.id,
+					"content":      output,
+				})
+			}
+		}
+		if mixedTurn {
+			// Orphan-avoidance: looping back with an assistant
+			// tool_calls entry that has no matching role:"tool"
+			// response for the client call would either be rejected
+			// by upstream or silently swallow the client call. Finalize
+			// instead; finalize's existing logic emits the client
+			// tool_calls chunk and picks finish_reason="tool_calls" when
+			// upstream did not already set one.
+			debugLogf("toolruntime:%s chatstream.mixed_turn iterations=%d (router+client calls in one turn; finalizing)", tid, i+1)
+			return streamer.finalize(r, em, modelName, result, clientToolCalls)
 		}
 		reqBody["messages"] = messages
 	}

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -129,12 +129,6 @@ func runChatStreaming(
 			return streamer.finalize(r, em, modelName, result, clientToolCalls)
 		}
 
-		// Execute every router-owned tool call live so its citations
-		// and progress markers flow to the client before any terminal
-		// chunks. On a non-mixed turn the outputs are also appended to
-		// the messages history so the next upstream turn can see them;
-		// on a mixed turn the router finalizes instead of looping so
-		// appending to history would be wasted work.
 		mixedTurn := len(clientToolCalls) > 0
 		tracePhase := fmt.Sprintf("chatstream.iter=%d", i)
 		var messages []any
@@ -158,14 +152,8 @@ func runChatStreaming(
 				})
 			}
 		}
+		// Mixed turn: see the mixed-turn contract on runToolLoop.
 		if mixedTurn {
-			// Orphan-avoidance: looping back with an assistant
-			// tool_calls entry that has no matching role:"tool"
-			// response for the client call would either be rejected
-			// by upstream or silently swallow the client call. Finalize
-			// instead; finalize's existing logic emits the client
-			// tool_calls chunk and picks finish_reason="tool_calls" when
-			// upstream did not already set one.
 			debugLogf("toolruntime:%s chatstream.mixed_turn iterations=%d (router+client calls in one turn; finalizing)", tid, i+1)
 			return streamer.finalize(r, em, modelName, result, clientToolCalls)
 		}

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -59,7 +59,7 @@ func runChatStreaming(
 	stripRouterOwnedIncludes(reqBody)
 	reqBody["stream"] = true
 	reqBody["stream_options"] = map[string]any{"include_usage": true}
-	reqBody["parallel_tool_calls"] = false
+	applyParallelToolCallsPolicy(reqBody)
 	reqBody["tools"] = append(existingTools(reqBody["tools"]), chatTools(tools)...)
 	reqBody["messages"] = prependChatPrompt(prompt, reqBody["messages"])
 

--- a/toolruntime/chat_stream_finalize.go
+++ b/toolruntime/chat_stream_finalize.go
@@ -40,12 +40,10 @@ func (s *chatStreamer) finalize(
 	}
 
 	finishReason := result.finishReason
-	if finishReason == "" {
-		if len(clientToolCalls) > 0 {
-			finishReason = "tool_calls"
-		} else {
-			finishReason = "stop"
-		}
+	if len(clientToolCalls) > 0 {
+		finishReason = "tool_calls"
+	} else if finishReason == "" {
+		finishReason = "stop"
 	}
 	s.writeChunk(map[string]any{
 		"choices": []any{

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -116,6 +116,39 @@ func TestChatStreamerFinalizeEmitsFinishAndUsage(t *testing.T) {
 	}
 }
 
+func TestChatStreamerFinalizeForcesToolCallsFinishReason(t *testing.T) {
+	streamer, rec := newTestChatStreamer(t)
+	result := chatIterationResult{
+		finishReason: "stop",
+		rawToolCalls: []any{
+			map[string]any{
+				"id":   "call_1",
+				"type": "function",
+				"function": map[string]any{
+					"name":      "client_lookup",
+					"arguments": `{"id":1}`,
+				},
+			},
+		},
+	}
+	clientToolCalls := []toolCall{
+		{id: "call_1", name: "client_lookup", arguments: map[string]any{"id": float64(1)}},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	if err := streamer.finalize(req, nil, "gpt-oss-120b", result, clientToolCalls); err != nil {
+		t.Fatalf("finalize returned error: %v", err)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"finish_reason":"tool_calls"`) {
+		t.Fatalf("expected finish_reason tool_calls, got %s", body)
+	}
+	if strings.Contains(body, `"finish_reason":"stop"`) {
+		t.Fatalf("unexpected stop finish_reason when tool_calls are present, got %s", body)
+	}
+}
+
 func TestChatStreamerEmitContentDeltaForwardsAnnotations(t *testing.T) {
 	streamer, rec := newTestChatStreamer(t)
 	streamer.citations.sources = []citationSource{
@@ -317,6 +350,43 @@ func TestChatToolCallBuilderAssemblesFragments(t *testing.T) {
 	fn, _ := rawMap["function"].(map[string]any)
 	if fn["arguments"].(string) != `{"query":"go"}` {
 		t.Fatalf("unexpected raw arguments: %#v", fn["arguments"])
+	}
+}
+
+func TestRawToolCallsFromParsedMatchesClientCallsWithoutIDs(t *testing.T) {
+	raw := []any{
+		map[string]any{
+			"id":   "",
+			"type": "function",
+			"function": map[string]any{
+				"name":      "search",
+				"arguments": `{"query":"go"}`,
+			},
+		},
+		map[string]any{
+			"id":   "",
+			"type": "function",
+			"function": map[string]any{
+				"name":      "client_lookup",
+				"arguments": `{"id":1}`,
+			},
+		},
+	}
+	parsed := []toolCall{
+		{name: "client_lookup", arguments: map[string]any{"id": float64(1)}},
+	}
+
+	filtered := rawToolCallsFromParsed(parsed, raw)
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 filtered raw tool call, got %#v", filtered)
+	}
+	call, _ := filtered[0].(map[string]any)
+	function, _ := call["function"].(map[string]any)
+	if got := function["name"]; got != "client_lookup" {
+		t.Fatalf("expected client_lookup raw tool call, got %#v", got)
+	}
+	if got := call["index"]; got != 0 {
+		t.Fatalf("expected reindexed client tool call at 0, got %#v", got)
 	}
 }
 

--- a/toolruntime/chat_stream_toolcalls.go
+++ b/toolruntime/chat_stream_toolcalls.go
@@ -114,14 +114,11 @@ func (b *chatToolCallBuilder) raw() []any {
 // tool_calls list. The `id`, `type`, and `function` fields are preserved
 // byte-for-byte from what upstream produced.
 func rawToolCallsFromParsed(parsed []toolCall, raw []any) []any {
-	allowed := make(map[string]struct{}, len(parsed))
-	for _, call := range parsed {
-		allowed[call.id] = struct{}{}
-	}
 	filtered := make([]any, 0, len(parsed))
+	next := 0
 	for _, item := range raw {
 		source, _ := item.(map[string]any)
-		if _, ok := allowed[stringValue(source["id"])]; !ok {
+		if source == nil || next >= len(parsed) || !rawToolCallMatchesParsed(source, parsed[next]) {
 			continue
 		}
 		reindexed := map[string]any{
@@ -131,6 +128,21 @@ func rawToolCallsFromParsed(parsed []toolCall, raw []any) []any {
 			"function": source["function"],
 		}
 		filtered = append(filtered, reindexed)
+		next++
 	}
 	return filtered
+}
+
+func rawToolCallMatchesParsed(source map[string]any, call toolCall) bool {
+	if source == nil {
+		return false
+	}
+	function, _ := source["function"].(map[string]any)
+	if function == nil || stringValue(function["name"]) != call.name {
+		return false
+	}
+	if call.id != "" && stringValue(source["id"]) != call.id {
+		return false
+	}
+	return true
 }

--- a/toolruntime/citations.go
+++ b/toolruntime/citations.go
@@ -480,10 +480,10 @@ func formatStructuredToolOutput(name string, raw any, citations *citationState) 
 		return ""
 	}
 
-	switch name {
-	case "search":
+	switch {
+	case isRouterSearchToolName(name):
 		return formatSearchToolOutput(content["results"], citations)
-	case "fetch":
+	case isRouterFetchToolName(name):
 		if formatted := formatFetchToolOutput(content["pages"], citations); formatted != "" {
 			return formatted
 		}
@@ -753,8 +753,8 @@ func buildWebSearchCallOutputItems(records []toolCallRecord, includeActionSource
 	events := make([]any, 0, len(records))
 	for _, record := range records {
 		status := statusForRecord(record)
-		switch record.name {
-		case "search":
+		switch {
+		case isRouterSearchToolName(record.name):
 			action := map[string]any{"type": "search"}
 			if query := stringValue(record.arguments["query"]); query != "" {
 				action["query"] = query
@@ -765,7 +765,7 @@ func buildWebSearchCallOutputItems(records []toolCallRecord, includeActionSource
 				}
 			}
 			events = append(events, webSearchCallEvent("ws_"+uuid.NewString(), status, record.errorReason, action))
-		case "fetch":
+		case isRouterFetchToolName(record.name):
 			for _, url := range fetchArgumentURLs(record.arguments) {
 				action := map[string]any{"type": "open_page", "url": url}
 				events = append(events, webSearchCallEvent("ws_"+uuid.NewString(), status, record.errorReason, action))

--- a/toolruntime/events.go
+++ b/toolruntime/events.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 )
 
-
 // Tinfoil-event marker constants. The router emits opt-in progress
 // markers for router-owned tool calls (web search, fetch) by wrapping a
 // JSON payload in `<tinfoil-event>...</tinfoil-event>` tags carried
@@ -185,14 +184,14 @@ func tinfoilEventMarkersForRecords(records []toolCallRecord) string {
 		builder.WriteString(tinfoilEventMarker(id, s, action, reason, sources))
 	}
 	for _, record := range records {
-		switch record.name {
-		case "search":
+		switch {
+		case isRouterSearchToolName(record.name):
 			action := map[string]any{"type": "search"}
 			if query := stringValue(record.arguments["query"]); query != "" {
 				action["query"] = query
 			}
 			writePair(action, status(record), record.errorReason, record.resultSources)
-		case "fetch":
+		case isRouterFetchToolName(record.name):
 			urls := fetchArgumentURLs(record.arguments)
 			if len(urls) == 0 {
 				continue

--- a/toolruntime/options.go
+++ b/toolruntime/options.go
@@ -474,18 +474,11 @@ func normalizePublishedDate(raw any) string {
 	return ""
 }
 
-// applyParallelToolCallsPolicy sets parallel_tool_calls on the upstream
-// request so the model is free to fan out client-owned tool calls.
-// Router-owned tools (web search, fetch) are still dispatched serially
-// inside runToolLoop to keep citation numbering and streaming event
-// order deterministic, and mixed turns (router + client tool calls in
-// one assistant response) are detected on every surface and finalized
-// without replaying the assistant turn to the model, so client calls
-// are never orphaned or silently dropped.
-//
-// If the caller explicitly set parallel_tool_calls on the incoming
-// request, honor their choice. Otherwise default to true so callers
-// that expect parallel fan-out on their own tools get it.
+// applyParallelToolCallsPolicy defaults parallel_tool_calls to true so
+// the model can fan out client-owned tool calls. Router-owned tools are
+// still dispatched serially inside runToolLoop to keep citation numbering
+// and streaming event order deterministic. A caller-provided value is
+// honored unchanged.
 func applyParallelToolCallsPolicy(reqBody map[string]any) {
 	if _, ok := reqBody["parallel_tool_calls"]; ok {
 		return

--- a/toolruntime/options.go
+++ b/toolruntime/options.go
@@ -496,10 +496,10 @@ func applyParallelToolCallsPolicy(reqBody map[string]any) {
 // applyWebSearchOptionsToToolCall dispatches to the per-tool merge helper so
 // options forwarded from OpenAI's request shape end up on the MCP tool call.
 func applyWebSearchOptionsToToolCall(toolName string, arguments map[string]any, opts webSearchOptions) {
-	switch toolName {
-	case "search":
+	switch {
+	case isRouterSearchToolName(toolName):
 		opts.applyToSearchArgs(arguments)
-	case "fetch":
+	case isRouterFetchToolName(toolName):
 		opts.applyToFetchArgs(arguments)
 	}
 }

--- a/toolruntime/options.go
+++ b/toolruntime/options.go
@@ -474,6 +474,24 @@ func normalizePublishedDate(raw any) string {
 	return ""
 }
 
+// applyParallelToolCallsPolicy sets parallel_tool_calls on the upstream
+// request so client-owned tools can fan out. Router-owned tools (web
+// search, fetch) are still executed serially inside the tool-loop
+// dispatch regardless of the upstream flag, which keeps citation
+// numbering and streaming event ordering deterministic. The upstream
+// flag is a model-side hint for what it is allowed to emit, not an
+// execution requirement the router must honor.
+//
+// If the caller explicitly set parallel_tool_calls on the incoming
+// request, honor their choice. Otherwise default to true so callers
+// that expect parallel fan-out on their own tools get it.
+func applyParallelToolCallsPolicy(reqBody map[string]any) {
+	if _, ok := reqBody["parallel_tool_calls"]; ok {
+		return
+	}
+	reqBody["parallel_tool_calls"] = true
+}
+
 // applyWebSearchOptionsToToolCall dispatches to the per-tool merge helper so
 // options forwarded from OpenAI's request shape end up on the MCP tool call.
 func applyWebSearchOptionsToToolCall(toolName string, arguments map[string]any, opts webSearchOptions) {

--- a/toolruntime/options.go
+++ b/toolruntime/options.go
@@ -475,12 +475,13 @@ func normalizePublishedDate(raw any) string {
 }
 
 // applyParallelToolCallsPolicy sets parallel_tool_calls on the upstream
-// request so client-owned tools can fan out. Router-owned tools (web
-// search, fetch) are still executed serially inside the tool-loop
-// dispatch regardless of the upstream flag, which keeps citation
-// numbering and streaming event ordering deterministic. The upstream
-// flag is a model-side hint for what it is allowed to emit, not an
-// execution requirement the router must honor.
+// request so the model is free to fan out client-owned tool calls.
+// Router-owned tools (web search, fetch) are still dispatched serially
+// inside runToolLoop to keep citation numbering and streaming event
+// order deterministic, and mixed turns (router + client tool calls in
+// one assistant response) are detected on every surface and finalized
+// without replaying the assistant turn to the model, so client calls
+// are never orphaned or silently dropped.
 //
 // If the caller explicitly set parallel_tool_calls on the incoming
 // request, honor their choice. Otherwise default to true so callers

--- a/toolruntime/prompt.go
+++ b/toolruntime/prompt.go
@@ -33,7 +33,7 @@ func buildRouterPrompt() *mcp.GetPromptResult {
 			{
 				Role: "system",
 				Content: &mcp.TextContent{
-					Text: "You may use the search and fetch tools when current web information would improve the answer. Use search first to discover sources, then fetch specific URLs only when you need deeper detail. " + citationInstructions + " " + toolOutputWarning + " " + toolEconomyInstructions,
+					Text: fmt.Sprintf("You may use the %s and %s tools when current web information would improve the answer. Use %s first to discover sources, then %s specific URLs only when you need deeper detail. %s %s %s", routerSearchToolName, routerFetchToolName, routerSearchToolName, routerFetchToolName, citationInstructions, toolOutputWarning, toolEconomyInstructions),
 				},
 			},
 		},

--- a/toolruntime/registry_dispatch_test.go
+++ b/toolruntime/registry_dispatch_test.go
@@ -44,7 +44,7 @@ func TestExecuteRouterToolCallDispatchesToCorrectProfile(t *testing.T) {
 	}{
 		{
 			name:     "search routes to websearch server",
-			callName: "search",
+			callName: routerSearchToolName,
 			wantSub:  "websearch:search",
 		},
 		{

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -53,7 +53,7 @@ func runResponsesStreaming(
 	delete(base, "prompt_injection_check_options")
 	stripRouterOwnedIncludes(base)
 	base["stream"] = true
-	base["parallel_tool_calls"] = false
+	applyParallelToolCallsPolicy(base)
 	base["tools"] = replaceResponsesWebSearchTools(base["tools"], responseTools(tools))
 	base["input"] = prependResponsesPrompt(prompt, base["input"])
 

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -96,13 +96,6 @@ func runResponsesStreaming(
 			return streamer.finalize(r, em, modelName, result)
 		}
 
-		// Execute every router-owned tool call so its citations and
-		// web_search_call progress events are surfaced to the client
-		// before any terminal events. On a non-mixed turn the outputs
-		// are also appended to accumulatedInput so the next upstream
-		// turn can see them; on a mixed turn the streamer finalizes
-		// instead of looping so the function_call_output wrappers are
-		// skipped.
 		mixedTurn := len(clientToolCalls) > 0
 		var toolOutputs []any
 		if !mixedTurn {
@@ -124,15 +117,8 @@ func runResponsesStreaming(
 				})
 			}
 		}
+		// Mixed turn: see the mixed-turn contract on runToolLoop.
 		if mixedTurn {
-			// Orphan-avoidance: appending the client function_calls to
-			// accumulatedInput without matching function_call_output
-			// items violates the Responses API contract and upstream
-			// either rejects the next turn or silently drops the client
-			// call. finalize emits response.completed with the resolved
-			// web_search_call items (prepended by
-			// attachResponsesCitations) alongside the client
-			// function_calls already forwarded live.
 			return streamer.finalize(r, em, modelName, result)
 		}
 

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -91,12 +91,23 @@ func runResponsesStreaming(
 			return nil
 		}
 
-		routerToolCalls, _ := splitToolCalls(ownedTools, result.toolCalls)
+		routerToolCalls, clientToolCalls := splitToolCalls(ownedTools, result.toolCalls)
 		if len(routerToolCalls) == 0 {
 			return streamer.finalize(r, em, modelName, result)
 		}
 
-		toolOutputs := make([]any, 0, len(routerToolCalls))
+		// Execute every router-owned tool call so its citations and
+		// web_search_call progress events are surfaced to the client
+		// before any terminal events. On a non-mixed turn the outputs
+		// are also appended to accumulatedInput so the next upstream
+		// turn can see them; on a mixed turn the streamer finalizes
+		// instead of looping so the function_call_output wrappers are
+		// skipped.
+		mixedTurn := len(clientToolCalls) > 0
+		var toolOutputs []any
+		if !mixedTurn {
+			toolOutputs = make([]any, 0, len(routerToolCalls))
+		}
 		for _, call := range routerToolCalls {
 			output := resolveStreamingRouterToolCall(
 				ctx, call, searchOpts, toolSchemas, streamer.citations,
@@ -105,11 +116,24 @@ func runResponsesStreaming(
 				},
 				"", "",
 			)
-			toolOutputs = append(toolOutputs, map[string]any{
-				"type":    "function_call_output",
-				"call_id": call.id,
-				"output":  output,
-			})
+			if !mixedTurn {
+				toolOutputs = append(toolOutputs, map[string]any{
+					"type":    "function_call_output",
+					"call_id": call.id,
+					"output":  output,
+				})
+			}
+		}
+		if mixedTurn {
+			// Orphan-avoidance: appending the client function_calls to
+			// accumulatedInput without matching function_call_output
+			// items violates the Responses API contract and upstream
+			// either rejects the next turn or silently drops the client
+			// call. finalize emits response.completed with the resolved
+			// web_search_call items (prepended by
+			// attachResponsesCitations) alongside the client
+			// function_calls already forwarded live.
+			return streamer.finalize(r, em, modelName, result)
 		}
 
 		accumulatedInput = append(accumulatedInput, normalizeResponsesOutputItems(result.outputItems)...)

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -259,6 +259,7 @@ func (s *responsesStreamer) runIteration(
 	defer body.Close()
 
 	s.resetPerIterationState()
+	s.functionCallArguments = map[int]*strings.Builder{}
 	return s.pumpUpstream(newSSEReader(body), isFirst)
 }
 

--- a/toolruntime/responses_stream_test.go
+++ b/toolruntime/responses_stream_test.go
@@ -16,7 +16,8 @@ import (
 // newTestResponsesStreamer builds a responsesStreamer backed by an
 // httptest recorder, pre-marked as having written headers so tests can
 // exercise event emission without driving a real upstream request.
-// The router-owned tools are pre-seeded with `search` and `fetch` so
+// The router-owned tools are pre-seeded with `router_search` and
+// `router_fetch` so
 // tests exercising tool-call interception see the production-time
 // classification without having to wire up the full Handle() flow.
 func newTestResponsesStreamer(t *testing.T) (*responsesStreamer, *httptest.ResponseRecorder) {
@@ -39,8 +40,8 @@ func newTestResponsesStreamer(t *testing.T) (*responsesStreamer, *httptest.Respo
 		outputIndexMap:        map[int]int{},
 		suppressedItems:       map[int]struct{}{},
 		ownedTools: map[string]struct{}{
-			"search": {},
-			"fetch":  {},
+			routerSearchToolName: {},
+			routerFetchToolName:  {},
 		},
 	}
 	return streamer, rec
@@ -55,8 +56,8 @@ func TestResponsesStreamerPumpForwardsTextAndCapturesToolCalls(t *testing.T) {
 		"event: response.output_text.delta\n" + `data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_1","content_index":0,"delta":"world"}`,
 		"event: response.output_text.done\n" + `data: {"type":"response.output_text.done","output_index":0,"item_id":"msg_1","content_index":0,"text":"hello world"}`,
 		"event: response.output_item.done\n" + `data: {"type":"response.output_item.done","output_index":0,"item":{"id":"msg_1","type":"message"}}`,
-		"event: response.output_item.added\n" + `data: {"type":"response.output_item.added","output_index":1,"item":{"id":"fc_1","type":"function_call","name":"search","call_id":"call_1","arguments":"{\"query\":\"go\"}"}}`,
-		"event: response.output_item.done\n" + `data: {"type":"response.output_item.done","output_index":1,"item":{"id":"fc_1","type":"function_call","name":"search","call_id":"call_1","arguments":"{\"query\":\"go\"}"}}`,
+		"event: response.output_item.added\n" + `data: {"type":"response.output_item.added","output_index":1,"item":{"id":"fc_1","type":"function_call","name":"` + routerSearchToolName + `","call_id":"call_1","arguments":"{\"query\":\"go\"}"}}`,
+		"event: response.output_item.done\n" + `data: {"type":"response.output_item.done","output_index":1,"item":{"id":"fc_1","type":"function_call","name":"` + routerSearchToolName + `","call_id":"call_1","arguments":"{\"query\":\"go\"}"}}`,
 		"event: response.completed\n" + `data: {"type":"response.completed","response":{"id":"resp_upstream","usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}}}`,
 	}
 	upstream := strings.Join(frames, "\n\n") + "\n\n"
@@ -69,8 +70,8 @@ func TestResponsesStreamerPumpForwardsTextAndCapturesToolCalls(t *testing.T) {
 	if streamer.responseID != "resp_upstream" {
 		t.Fatalf("expected upstream id captured, got %q", streamer.responseID)
 	}
-	if len(result.toolCalls) != 1 || result.toolCalls[0].name != "search" {
-		t.Fatalf("expected search tool call, got %#v", result.toolCalls)
+	if len(result.toolCalls) != 1 || result.toolCalls[0].name != routerSearchToolName {
+		t.Fatalf("expected %s tool call, got %#v", routerSearchToolName, result.toolCalls)
 	}
 	if got := result.toolCalls[0].arguments["query"]; got != "go" {
 		t.Fatalf("expected arguments to parse, got %#v", got)
@@ -481,11 +482,11 @@ func TestResponsesStreamerAnnotationIndexMonotonic(t *testing.T) {
 func TestResponsesStreamerFunctionCallArgumentsReassembly(t *testing.T) {
 	streamer, _ := newTestResponsesStreamer(t)
 	frames := []string{
-		"event: response.output_item.added\n" + `data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","name":"search","call_id":"call_1","arguments":""}}`,
+		"event: response.output_item.added\n" + `data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","name":"` + routerSearchToolName + `","call_id":"call_1","arguments":""}}`,
 		"event: response.function_call_arguments.delta\n" + `data: {"type":"response.function_call_arguments.delta","output_index":0,"delta":"{\"query\":\""}`,
 		"event: response.function_call_arguments.delta\n" + `data: {"type":"response.function_call_arguments.delta","output_index":0,"delta":"go\"}"}`,
 		"event: response.function_call_arguments.done\n" + `data: {"type":"response.function_call_arguments.done","output_index":0}`,
-		"event: response.output_item.done\n" + `data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","name":"search","call_id":"call_1","arguments":""}}`,
+		"event: response.output_item.done\n" + `data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","name":"` + routerSearchToolName + `","call_id":"call_1","arguments":""}}`,
 		"event: response.completed\n" + `data: {"type":"response.completed","response":{"id":"resp_upstream"}}`,
 	}
 	upstream := strings.Join(frames, "\n\n") + "\n\n"
@@ -513,11 +514,11 @@ func TestResponsesStreamerFunctionCallArgumentsReassembly(t *testing.T) {
 func TestResponsesStreamerRouterOwnedArgsSplicedBackIntoItem(t *testing.T) {
 	streamer, _ := newTestResponsesStreamer(t)
 	frames := []string{
-		"event: response.output_item.added\n" + `data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","name":"search","call_id":"call_1","arguments":""}}`,
+		"event: response.output_item.added\n" + `data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","name":"` + routerSearchToolName + `","call_id":"call_1","arguments":""}}`,
 		"event: response.function_call_arguments.delta\n" + `data: {"type":"response.function_call_arguments.delta","output_index":0,"delta":"{\"query\":"}`,
 		"event: response.function_call_arguments.delta\n" + `data: {"type":"response.function_call_arguments.delta","output_index":0,"delta":"\"go\"}"}`,
 		"event: response.function_call_arguments.done\n" + `data: {"type":"response.function_call_arguments.done","output_index":0}`,
-		"event: response.output_item.done\n" + `data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","name":"search","call_id":"call_1","arguments":""}}`,
+		"event: response.output_item.done\n" + `data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","name":"` + routerSearchToolName + `","call_id":"call_1","arguments":""}}`,
 		"event: response.completed\n" + `data: {"type":"response.completed","response":{"id":"resp_upstream"}}`,
 	}
 	upstream := strings.Join(frames, "\n\n") + "\n\n"
@@ -615,7 +616,7 @@ func TestResponsesStreamerPumpAbortsOnClientDisconnect(t *testing.T) {
 		suppressedItems:       map[int]struct{}{},
 		responseID:            "resp_test",
 		createdAt:             1,
-		ownedTools:            map[string]struct{}{"search": {}},
+		ownedTools:            map[string]struct{}{routerSearchToolName: {}},
 	}
 
 	frames := []string{
@@ -703,15 +704,15 @@ func TestResponsesStreamerTwoIterationStitching(t *testing.T) {
 	// tool. pump captures it, suppresses it from the wire, and the
 	// outer driver would run it and re-pump.
 	turn0 := responsesIterationTurn("resp_upstream", []any{
-		map[string]any{"id": "fc_1", "type": "function_call", "name": "search", "call_id": "call_a", "arguments": `{"query":"go"}`},
+		map[string]any{"id": "fc_1", "type": "function_call", "name": routerSearchToolName, "call_id": "call_a", "arguments": `{"query":"go"}`},
 	})
 	streamer.resetPerIterationState()
 	result0, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(turn0)), true)
 	if err != nil {
 		t.Fatalf("iter0 pump err: %v", err)
 	}
-	if len(result0.toolCalls) != 1 || result0.toolCalls[0].name != "search" {
-		t.Fatalf("iter0 expected 1 search tool call, got %+v", result0.toolCalls)
+	if len(result0.toolCalls) != 1 || result0.toolCalls[0].name != routerSearchToolName {
+		t.Fatalf("iter0 expected 1 %s tool call, got %+v", routerSearchToolName, result0.toolCalls)
 	}
 
 	// Iteration 1: upstream emits the final assistant message.
@@ -756,10 +757,10 @@ func TestResponsesStreamerThreeIterationStitching(t *testing.T) {
 
 	turns := []string{
 		responsesIterationTurn("resp_upstream", []any{
-			map[string]any{"id": "fc_1", "type": "function_call", "name": "search", "call_id": "call_a", "arguments": `{"query":"q1"}`},
+			map[string]any{"id": "fc_1", "type": "function_call", "name": routerSearchToolName, "call_id": "call_a", "arguments": `{"query":"q1"}`},
 		}),
 		responsesIterationTurn("resp_upstream", []any{
-			map[string]any{"id": "fc_2", "type": "function_call", "name": "search", "call_id": "call_b", "arguments": `{"query":"q2"}`},
+			map[string]any{"id": "fc_2", "type": "function_call", "name": routerSearchToolName, "call_id": "call_b", "arguments": `{"query":"q2"}`},
 		}),
 		responsesIterationTurn("resp_upstream", []any{
 			map[string]any{"id": "msg_final", "type": "message", "text": "answer"},
@@ -843,7 +844,7 @@ func TestResponsesStreamerSequenceNumberMonotonicAcrossIterations(t *testing.T) 
 
 	turns := []string{
 		responsesIterationTurn("resp_upstream", []any{
-			map[string]any{"id": "fc_1", "type": "function_call", "name": "search", "call_id": "call_a", "arguments": `{"query":"q1"}`},
+			map[string]any{"id": "fc_1", "type": "function_call", "name": routerSearchToolName, "call_id": "call_a", "arguments": `{"query":"q1"}`},
 		}),
 		responsesIterationTurn("resp_upstream", []any{
 			map[string]any{"id": "msg_final", "type": "message", "text": "answer"},

--- a/toolruntime/router_tool_names.go
+++ b/toolruntime/router_tool_names.go
@@ -1,0 +1,59 @@
+package toolruntime
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+const (
+	routerSearchToolName = "router_search"
+	routerFetchToolName  = "router_fetch"
+
+	mcpSearchToolName = "search"
+	mcpFetchToolName  = "fetch"
+
+	webSearchProfileName = "web_search"
+)
+
+func outwardRouterToolName(profileName, toolName string) string {
+	if profileName != webSearchProfileName {
+		return toolName
+	}
+	switch toolName {
+	case mcpSearchToolName:
+		return routerSearchToolName
+	case mcpFetchToolName:
+		return routerFetchToolName
+	default:
+		return toolName
+	}
+}
+
+func outwardRouterTool(profileName string, tool *mcp.Tool) *mcp.Tool {
+	if tool == nil {
+		return nil
+	}
+	outwardName := outwardRouterToolName(profileName, tool.Name)
+	if outwardName == tool.Name {
+		return tool
+	}
+	cloned := *tool
+	cloned.Name = outwardName
+	return &cloned
+}
+
+func dispatchRouterToolName(toolName string) string {
+	switch toolName {
+	case routerSearchToolName:
+		return mcpSearchToolName
+	case routerFetchToolName:
+		return mcpFetchToolName
+	default:
+		return toolName
+	}
+}
+
+func isRouterSearchToolName(toolName string) bool {
+	return dispatchRouterToolName(toolName) == mcpSearchToolName
+}
+
+func isRouterFetchToolName(toolName string) bool {
+	return dispatchRouterToolName(toolName) == mcpFetchToolName
+}

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -220,7 +220,7 @@ func executeRouterToolCall(
 		return output
 	}
 	tstart := time.Now()
-	output, err := callTool(ctx, session, call.name, call.arguments, citations)
+	output, err := callTool(ctx, session, registry.dispatchName(call.name), call.arguments, citations)
 	record := toolCallRecord{
 		name:      call.name,
 		arguments: call.arguments,
@@ -336,8 +336,6 @@ func postJSON(ctx context.Context, em *manager.EnclaveManager, modelName, path s
 		statusCode: resp.StatusCode,
 	}, nil
 }
-
-
 
 func isStream(body map[string]any) bool {
 	stream, _ := body["stream"].(bool)

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -20,18 +20,18 @@ func TestReplaceResponsesWebSearchTools(t *testing.T) {
 		map[string]any{"type": "web_search"},
 		map[string]any{"type": "function", "name": "other"},
 	}, []any{
-		map[string]any{"type": "function", "name": "search"},
-		map[string]any{"type": "function", "name": "fetch"},
+		map[string]any{"type": "function", "name": routerSearchToolName},
+		map[string]any{"type": "function", "name": routerFetchToolName},
 	})
 
 	if len(replaced) != 3 {
 		t.Fatalf("expected 3 tools, got %d", len(replaced))
 	}
-	if replaced[0].(map[string]any)["name"] != "search" {
-		t.Fatalf("expected first replacement tool to be search, got %#v", replaced[0])
+	if replaced[0].(map[string]any)["name"] != routerSearchToolName {
+		t.Fatalf("expected first replacement tool to be %s, got %#v", routerSearchToolName, replaced[0])
 	}
-	if replaced[1].(map[string]any)["name"] != "fetch" {
-		t.Fatalf("expected second replacement tool to be fetch, got %#v", replaced[1])
+	if replaced[1].(map[string]any)["name"] != routerFetchToolName {
+		t.Fatalf("expected second replacement tool to be %s, got %#v", routerFetchToolName, replaced[1])
 	}
 }
 
@@ -41,8 +41,8 @@ func TestReplaceResponsesWebSearchToolsDedupes(t *testing.T) {
 		map[string]any{"type": "function", "name": "other"},
 		map[string]any{"type": "web_search"},
 	}, []any{
-		map[string]any{"type": "function", "name": "search"},
-		map[string]any{"type": "function", "name": "fetch"},
+		map[string]any{"type": "function", "name": routerSearchToolName},
+		map[string]any{"type": "function", "name": routerFetchToolName},
 	})
 
 	counts := map[string]int{}
@@ -52,11 +52,11 @@ func TestReplaceResponsesWebSearchToolsDedupes(t *testing.T) {
 			counts[name]++
 		}
 	}
-	if counts["search"] != 1 {
-		t.Fatalf("expected search injected exactly once, got %d", counts["search"])
+	if counts[routerSearchToolName] != 1 {
+		t.Fatalf("expected %s injected exactly once, got %d", routerSearchToolName, counts[routerSearchToolName])
 	}
-	if counts["fetch"] != 1 {
-		t.Fatalf("expected fetch injected exactly once, got %d", counts["fetch"])
+	if counts[routerFetchToolName] != 1 {
+		t.Fatalf("expected %s injected exactly once, got %d", routerFetchToolName, counts[routerFetchToolName])
 	}
 	if counts["other"] != 1 {
 		t.Fatalf("expected other tool preserved exactly once, got %d", counts["other"])
@@ -91,12 +91,12 @@ func TestParseResponsesToolCalls(t *testing.T) {
 
 func TestSplitToolCalls(t *testing.T) {
 	routerCalls, clientCalls := splitToolCalls(map[string]struct{}{
-		"search": {},
-		"fetch":  {},
+		routerSearchToolName: {},
+		routerFetchToolName:  {},
 	}, []toolCall{
-		{id: "call_1", name: "search"},
+		{id: "call_1", name: routerSearchToolName},
 		{id: "call_2", name: "client_lookup"},
-		{id: "call_3", name: "fetch"},
+		{id: "call_3", name: routerFetchToolName},
 	})
 
 	if len(routerCalls) != 2 {
@@ -525,7 +525,7 @@ func TestForcedFinalResponsesRequestStripsToolSelection(t *testing.T) {
 	reqBody := map[string]any{
 		"input":       []map[string]any{{"type": "message", "role": "user", "content": "hi"}},
 		"tools":       []any{map[string]any{"type": "function"}},
-		"tool_choice": map[string]any{"type": "function", "function": map[string]any{"name": "search"}},
+		"tool_choice": map[string]any{"type": "function", "function": map[string]any{"name": routerSearchToolName}},
 	}
 	finalBody := forcedFinalResponsesRequest(reqBody)
 	for _, field := range []string{"tools", "tool_choice"} {

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -832,3 +832,65 @@ func TestStripRouterOwnedIncludesFiltersActionSources(t *testing.T) {
 		t.Fatal("stripRouterOwnedIncludes must not invent an include key")
 	}
 }
+
+// TestChatAdapterStripRouterToolCallsPreservesUnparseableEntries pins that
+// a raw tool_calls entry which fails the map[string]any assertion is kept
+// rather than silently dropped. The entry can't be inspected, so it can't
+// be attributed to the router; preserving it matches the defensive shape
+// the responses adapter uses for output items it can't classify.
+func TestChatAdapterStripRouterToolCallsPreservesUnparseableEntries(t *testing.T) {
+	response := &upstreamJSONResponse{
+		body: map[string]any{
+			"choices": []any{
+				map[string]any{
+					"message": map[string]any{
+						"role": "assistant",
+						"tool_calls": []any{
+							"unparseable-entry",
+							map[string]any{
+								"id":   "call_router",
+								"type": "function",
+								"function": map[string]any{
+									"name":      routerSearchToolName,
+									"arguments": "{}",
+								},
+							},
+							map[string]any{
+								"id":   "call_client",
+								"type": "function",
+								"function": map[string]any{
+									"name":      "client_tool",
+									"arguments": "{}",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		header: make(http.Header),
+	}
+
+	adapter := newChatLoopAdapter(map[string]any{}, nil, nil, map[string]struct{}{routerSearchToolName: {}}, "m", http.Header{})
+	adapter.stripRouterToolCallsFromResponse(response)
+
+	choice := response.body["choices"].([]any)[0].(map[string]any)
+	message := choice["message"].(map[string]any)
+	calls, _ := message["tool_calls"].([]any)
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 tool_calls after strip (unparseable + client), got %d: %#v", len(calls), calls)
+	}
+	if got, _ := calls[0].(string); got != "unparseable-entry" {
+		t.Fatalf("expected unparseable entry preserved as first call, got %#v", calls[0])
+	}
+	clientCall, _ := calls[1].(map[string]any)
+	if clientCall == nil {
+		t.Fatalf("expected client tool call preserved as second entry, got %#v", calls[1])
+	}
+	if fn, _ := clientCall["function"].(map[string]any); fn == nil || stringValue(fn["name"]) != "client_tool" {
+		t.Fatalf("expected client_tool to survive strip, got %#v", clientCall)
+	}
+	if stringValue(choice["finish_reason"]) != "tool_calls" {
+		t.Fatalf("expected finish_reason normalized to tool_calls, got %#v", choice["finish_reason"])
+	}
+}

--- a/toolruntime/session_registry.go
+++ b/toolruntime/session_registry.go
@@ -28,6 +28,12 @@ type sessionRegistry struct {
 	// byTool maps tool name -> servicing session. Sealed after build().
 	byTool map[string]*mcp.ClientSession
 
+	// dispatchByTool maps the model-facing tool name -> underlying MCP
+	// tool name. Most tools keep the same name on both sides; router-owned
+	// web-search tools are intentionally aliased so they do not collide
+	// with generic client tool names such as "search" or "fetch".
+	dispatchByTool map[string]string
+
 	// owned is the union of router-owned tool names across all sessions.
 	owned map[string]struct{}
 
@@ -57,8 +63,9 @@ func buildSessionRegistry(
 	}
 
 	r := &sessionRegistry{
-		byTool: make(map[string]*mcp.ClientSession),
-		owned:  make(map[string]struct{}),
+		byTool:         make(map[string]*mcp.ClientSession),
+		dispatchByTool: make(map[string]string),
+		owned:          make(map[string]struct{}),
 	}
 
 	for _, profile := range profiles {
@@ -75,7 +82,8 @@ func buildSessionRegistry(
 		}
 
 		for _, tool := range toolsResult.Tools {
-			if existing, clash := r.byTool[tool.Name]; clash {
+			outwardName := outwardRouterToolName(profile.Name, tool.Name)
+			if existing, clash := r.byTool[outwardName]; clash {
 				// We deliberately fail LOUD on overlapping tool names
 				// rather than silently routing to whichever session
 				// registered last. Namespacing would mask a genuine
@@ -86,11 +94,12 @@ func buildSessionRegistry(
 				r.CloseAll()
 				return nil, fmt.Errorf(
 					"tool name %q advertised by multiple profiles; rename or disable one",
-					tool.Name,
+					outwardName,
 				)
 			}
-			r.byTool[tool.Name] = session
-			r.owned[tool.Name] = struct{}{}
+			r.byTool[outwardName] = session
+			r.dispatchByTool[outwardName] = tool.Name
+			r.owned[outwardName] = struct{}{}
 		}
 
 		r.entries = append(r.entries, sessionEntry{
@@ -98,7 +107,9 @@ func buildSessionRegistry(
 			session: session,
 			tools:   toolsResult.Tools,
 		})
-		r.tools = append(r.tools, toolsResult.Tools...)
+		for _, tool := range toolsResult.Tools {
+			r.tools = append(r.tools, outwardRouterTool(profile.Name, tool))
+		}
 	}
 
 	return r, nil
@@ -116,6 +127,16 @@ func (r *sessionRegistry) sessionFor(toolName string) (*mcp.ClientSession, bool)
 	}
 	s, ok := r.byTool[toolName]
 	return s, ok
+}
+
+func (r *sessionRegistry) dispatchName(toolName string) string {
+	if r == nil {
+		return dispatchRouterToolName(toolName)
+	}
+	if name, ok := r.dispatchByTool[toolName]; ok {
+		return name
+	}
+	return dispatchRouterToolName(toolName)
 }
 
 // ownedTools returns the union of router-owned tool names across every

--- a/toolruntime/session_registry_test.go
+++ b/toolruntime/session_registry_test.go
@@ -94,7 +94,7 @@ func TestSessionRegistryRoutesTwoProfilesToSeparateSessions(t *testing.T) {
 		t.Fatalf("buildSessionRegistry: %v", err)
 	}
 
-	for _, name := range []string{"search", "fetch"} {
+	for _, name := range []string{routerSearchToolName, routerFetchToolName} {
 		got, ok := r.sessionFor(name)
 		if !ok {
 			t.Fatalf("sessionFor(%q) missing", name)
@@ -108,13 +108,19 @@ func TestSessionRegistryRoutesTwoProfilesToSeparateSessions(t *testing.T) {
 	}
 
 	owned := r.ownedTools()
-	for _, want := range []string{"search", "fetch", "fake_tool"} {
+	for _, want := range []string{routerSearchToolName, routerFetchToolName, "fake_tool"} {
 		if _, ok := owned[want]; !ok {
 			t.Errorf("ownedTools missing %q; got %v", want, owned)
 		}
 	}
 	if len(owned) != 3 {
 		t.Errorf("ownedTools size = %d, want 3", len(owned))
+	}
+	toolNames := ownedToolNames(r.allTools())
+	for _, want := range []string{routerSearchToolName, routerFetchToolName, "fake_tool"} {
+		if _, ok := toolNames[want]; !ok {
+			t.Errorf("allTools missing %q; got %v", want, toolNames)
+		}
 	}
 
 	names := r.profileNames()

--- a/toolruntime/tinfoil_events_stream_test.go
+++ b/toolruntime/tinfoil_events_stream_test.go
@@ -26,7 +26,7 @@ func newTestResponsesStreamerForSpecEvents(t *testing.T) (*responsesStreamer, *h
 		emitters:              map[itemContentKey]*citationEmitter{},
 		annotationCounts:      map[itemContentKey]int{},
 		functionCallArguments: map[int]*strings.Builder{},
-		ownedTools:            map[string]struct{}{"search": {}, "fetch": {}},
+		ownedTools:            map[string]struct{}{routerSearchToolName: {}, routerFetchToolName: {}},
 		responseID:            "resp_test",
 		upstreamIDCaptured:    true,
 		createdAt:             1700000000,

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -338,6 +338,7 @@ func (a *chatLoopAdapter) stripRouterToolCallsFromResponse(response *upstreamJSO
 	for _, raw := range rawCalls {
 		call, _ := raw.(map[string]any)
 		if call == nil {
+			filtered = append(filtered, raw)
 			continue
 		}
 		fn, _ := call["function"].(map[string]any)

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -221,7 +221,7 @@ func (a *chatLoopAdapter) buildInitialRequest() map[string]any {
 	delete(reqBody, "prompt_injection_check_options")
 	stripRouterOwnedIncludes(reqBody)
 	reqBody["stream"] = false
-	reqBody["parallel_tool_calls"] = false
+	applyParallelToolCallsPolicy(reqBody)
 	reqBody["tools"] = append(existingTools(reqBody["tools"]), chatTools(a.tools)...)
 	reqBody["messages"] = prependChatPrompt(a.prompt, reqBody["messages"])
 
@@ -339,7 +339,7 @@ func (a *responsesLoopAdapter) attachCitations(body map[string]any, citations *c
 func (a *responsesLoopAdapter) buildInitialRequest() map[string]any {
 	base := cloneJSONMap(a.body)
 	base["stream"] = false
-	base["parallel_tool_calls"] = false
+	applyParallelToolCallsPolicy(base)
 	delete(base, "stream_options")
 	delete(base, "pii_check_options")
 	delete(base, "prompt_injection_check_options")

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -46,22 +46,16 @@ type toolLoopAdapter interface {
 	// surface-specific state (Chat: assistant message; Responses: raw
 	// output items) that applyToolOutputs will fold back into the next
 	// request body. hasClientToolCalls reports whether the same turn
-	// also carried client-owned tool calls, which signals the driver to
-	// finalize rather than continue looping so client calls are not
-	// orphaned in history or silently dropped. elapsed is the upstream
-	// call's wall time.
+	// also carried client-owned tool calls; see the mixed-turn contract
+	// in runToolLoop. elapsed is the upstream call's wall time.
 	onUpstreamResponse(response *upstreamJSONResponse, iteration int, elapsed time.Duration) (routerToolCalls []toolCall, hasClientToolCalls bool, state any)
 
 	applyToolOutputs(reqBody map[string]any, state any, outputs []toolOutput) map[string]any
 
-	// stripRouterToolCallsFromResponse removes the router-owned tool
-	// call items from the response body on a mixed-turn finalize so the
-	// caller sees only the client-owned tool calls that still need a
-	// response. The router's work is surfaced separately via
-	// attachCitations (tinfoil-event markers on Chat, web_search_call
-	// output items on Responses). Non-mixed turns never call this
-	// helper because applyToolOutputs feeds the same router outputs
-	// back into the next upstream request instead.
+	// stripRouterToolCallsFromResponse removes router-owned tool calls
+	// from a mixed-turn response so the caller sees only the client-owned
+	// calls that still need a response. Router work is surfaced via
+	// attachCitations instead.
 	stripRouterToolCallsFromResponse(response *upstreamJSONResponse)
 
 	// forcedFinalRequest builds the forced-final-answer request body used
@@ -96,6 +90,15 @@ type toolOutput struct {
 // "no router tool calls this turn -> finalize and return" contract, the
 // executeRouterToolCall dispatch, and the iteration-budget / forced-final
 // fallback with its usage-accumulation comment.
+//
+// Mixed-turn contract: when an assistant turn emits both router-owned
+// and client-owned tool calls, the router resolves its own calls and
+// then finalizes instead of replaying. Replaying would send back an
+// assistant message whose client tool_calls have no matching
+// role:"tool" / function_call_output entries; upstream then either
+// rejects the request or drops the client call. On finalize the
+// caller sees the client tool_calls verbatim and the router's work
+// surfaced via attachCitations.
 func runToolLoop(
 	ctx context.Context,
 	em *manager.EnclaveManager,
@@ -152,17 +155,8 @@ func runToolLoop(
 			})
 		}
 
-		// Mixed turn: the model emitted both router-owned and
-		// client-owned tool calls on the same assistant turn. The
-		// router has now resolved its own calls; looping back to the
-		// model would orphan the client calls (Chat leaves an
-		// assistant tool_calls entry with no matching tool output;
-		// Responses leaves a function_call with no matching
-		// function_call_output) and either the upstream rejects the
-		// next request or silently swallows the client call. Finalize
-		// instead so the caller receives the unresolved client tool
-		// calls verbatim alongside the resolved router work surfaced
-		// as citations / web_search_call items.
+		// Mixed turn: finalize instead of replaying so the client's
+		// tool calls are not orphaned in the next request's history.
 		if hasClientToolCalls {
 			if traceID := adapter.traceID(); traceID != "" {
 				debugLogf("toolruntime:%s %s mixed_turn iterations=%d (router+client calls in one turn; finalizing without replay)", traceID, adapter.tracePhase(i), i+1)
@@ -304,16 +298,10 @@ func (a *chatLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, ite
 	return routerToolCalls, len(clientToolCalls) > 0, message
 }
 
-// stripRouterToolCallsFromResponse rewrites the assistant message on a
-// mixed-turn response so only the client-owned tool_calls remain. The
-// router-owned tool outputs are already threaded into citationState
-// via executeRouterToolCall; attachChatCitations surfaces them on the
-// message's annotations and, for eventsEnabled callers, as
-// tinfoil-event markers in the assistant content. finish_reason is
-// normalized to "tool_calls" to match the message shape the caller
-// now sees (tool_calls present, no prose); SDKs that gate on it will
-// collect tool outputs and re-post instead of treating the response
-// as final.
+// stripRouterToolCallsFromResponse keeps only the client-owned
+// tool_calls on the assistant message and normalizes finish_reason to
+// "tool_calls" so SDKs that gate on it collect tool outputs and
+// re-post instead of treating the response as final.
 func (a *chatLoopAdapter) stripRouterToolCallsFromResponse(response *upstreamJSONResponse) {
 	if response == nil || response.body == nil {
 		return
@@ -447,13 +435,9 @@ func (a *responsesLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse
 	return routerToolCalls, len(clientToolCalls) > 0, outputItems
 }
 
-// stripRouterToolCallsFromResponse removes router-owned function_call
-// items from the response's output array on a mixed-turn finalize so
-// the caller sees only the client-owned function_calls that need a
-// response. Router-owned work is surfaced via the synthesized
-// web_search_call items attachResponsesCitations prepends to the same
-// output array, which is the shape OpenAI's Responses API documents
-// for router-executed tools.
+// stripRouterToolCallsFromResponse drops router-owned function_call
+// items from the output array; attachResponsesCitations prepends the
+// matching web_search_call items that replace them.
 func (a *responsesLoopAdapter) stripRouterToolCallsFromResponse(response *upstreamJSONResponse) {
 	if response == nil || response.body == nil {
 		return

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -45,10 +45,24 @@ type toolLoopAdapter interface {
 	// onUpstreamResponse extracts router-owned tool calls plus any
 	// surface-specific state (Chat: assistant message; Responses: raw
 	// output items) that applyToolOutputs will fold back into the next
-	// request body. elapsed is the upstream call's wall time.
-	onUpstreamResponse(response *upstreamJSONResponse, iteration int, elapsed time.Duration) (routerToolCalls []toolCall, state any)
+	// request body. hasClientToolCalls reports whether the same turn
+	// also carried client-owned tool calls, which signals the driver to
+	// finalize rather than continue looping so client calls are not
+	// orphaned in history or silently dropped. elapsed is the upstream
+	// call's wall time.
+	onUpstreamResponse(response *upstreamJSONResponse, iteration int, elapsed time.Duration) (routerToolCalls []toolCall, hasClientToolCalls bool, state any)
 
 	applyToolOutputs(reqBody map[string]any, state any, outputs []toolOutput) map[string]any
+
+	// stripRouterToolCallsFromResponse removes the router-owned tool
+	// call items from the response body on a mixed-turn finalize so the
+	// caller sees only the client-owned tool calls that still need a
+	// response. The router's work is surfaced separately via
+	// attachCitations (tinfoil-event markers on Chat, web_search_call
+	// output items on Responses). Non-mixed turns never call this
+	// helper because applyToolOutputs feeds the same router outputs
+	// back into the next upstream request instead.
+	stripRouterToolCallsFromResponse(response *upstreamJSONResponse)
 
 	// forcedFinalRequest builds the forced-final-answer request body used
 	// when the iteration budget is exhausted without the model settling.
@@ -118,7 +132,7 @@ func runToolLoop(
 		}
 		usageTotals.Add(response)
 
-		routerToolCalls, state := adapter.onUpstreamResponse(response, i, time.Since(start))
+		routerToolCalls, hasClientToolCalls, state := adapter.onUpstreamResponse(response, i, time.Since(start))
 		if len(routerToolCalls) == 0 {
 			if traceID := adapter.traceID(); traceID != "" {
 				debugLogf("toolruntime:%s %s done iterations=%d (no router tool calls this turn)", traceID, adapter.tracePhase(i), i+1)
@@ -137,6 +151,28 @@ func runToolLoop(
 				output: output,
 			})
 		}
+
+		// Mixed turn: the model emitted both router-owned and
+		// client-owned tool calls on the same assistant turn. The
+		// router has now resolved its own calls; looping back to the
+		// model would orphan the client calls (Chat leaves an
+		// assistant tool_calls entry with no matching tool output;
+		// Responses leaves a function_call with no matching
+		// function_call_output) and either the upstream rejects the
+		// next request or silently swallows the client call. Finalize
+		// instead so the caller receives the unresolved client tool
+		// calls verbatim alongside the resolved router work surfaced
+		// as citations / web_search_call items.
+		if hasClientToolCalls {
+			if traceID := adapter.traceID(); traceID != "" {
+				debugLogf("toolruntime:%s %s mixed_turn iterations=%d (router+client calls in one turn; finalizing without replay)", traceID, adapter.tracePhase(i), i+1)
+			}
+			adapter.stripRouterToolCallsFromResponse(response)
+			adapter.applyUsage(response, usageTotals.Usage())
+			adapter.attachCitations(response.body, &citations, eventsEnabled)
+			return response, nil
+		}
+
 		reqBody = adapter.applyToolOutputs(reqBody, state, outputs)
 	}
 
@@ -244,7 +280,7 @@ func (a *chatLoopAdapter) preIteration(reqBody map[string]any, iteration int) {
 	}
 }
 
-func (a *chatLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, iteration int, elapsed time.Duration) ([]toolCall, any) {
+func (a *chatLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, iteration int, elapsed time.Duration) ([]toolCall, bool, any) {
 	message, toolCalls := parseChatToolCalls(response.body)
 	routerToolCalls, clientToolCalls := splitToolCalls(a.ownedTools, toolCalls)
 	if debugEnabled {
@@ -265,7 +301,60 @@ func (a *chatLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, ite
 		debugLogf("toolruntime:%s chat.iter=%d upstream.response elapsed=%s finish=%q total_tool_calls=%d router_tool_calls=%d client_tool_calls=%d tool_names=%v content=%q",
 			a.tid, iteration, elapsed, finishReason, len(toolCalls), len(routerToolCalls), len(clientToolCalls), toolNames, debugPreview(content, 240))
 	}
-	return routerToolCalls, message
+	return routerToolCalls, len(clientToolCalls) > 0, message
+}
+
+// stripRouterToolCallsFromResponse rewrites the assistant message on a
+// mixed-turn response so only the client-owned tool_calls remain. The
+// router-owned tool outputs are already threaded into citationState
+// via executeRouterToolCall; attachChatCitations surfaces them on the
+// message's annotations and, for eventsEnabled callers, as
+// tinfoil-event markers in the assistant content. finish_reason is
+// normalized to "tool_calls" to match the message shape the caller
+// now sees (tool_calls present, no prose); SDKs that gate on it will
+// collect tool outputs and re-post instead of treating the response
+// as final.
+func (a *chatLoopAdapter) stripRouterToolCallsFromResponse(response *upstreamJSONResponse) {
+	if response == nil || response.body == nil {
+		return
+	}
+	choices, _ := response.body["choices"].([]any)
+	if len(choices) == 0 {
+		return
+	}
+	choice, _ := choices[0].(map[string]any)
+	if choice == nil {
+		return
+	}
+	message, _ := choice["message"].(map[string]any)
+	if message == nil {
+		return
+	}
+	rawCalls, _ := message["tool_calls"].([]any)
+	if len(rawCalls) == 0 {
+		return
+	}
+	filtered := make([]any, 0, len(rawCalls))
+	for _, raw := range rawCalls {
+		call, _ := raw.(map[string]any)
+		if call == nil {
+			continue
+		}
+		fn, _ := call["function"].(map[string]any)
+		name := ""
+		if fn != nil {
+			name = stringValue(fn["name"])
+		}
+		if _, ok := a.ownedTools[name]; ok {
+			continue
+		}
+		filtered = append(filtered, raw)
+	}
+	message["tool_calls"] = filtered
+	if len(filtered) == 0 {
+		delete(message, "tool_calls")
+	}
+	choice["finish_reason"] = "tool_calls"
 }
 
 func (a *chatLoopAdapter) applyToolOutputs(reqBody map[string]any, state any, outputs []toolOutput) map[string]any {
@@ -351,10 +440,43 @@ func (a *responsesLoopAdapter) buildInitialRequest() map[string]any {
 	return base
 }
 
-func (a *responsesLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, _ int, _ time.Duration) ([]toolCall, any) {
-	routerToolCalls, _ := splitToolCalls(a.ownedTools, parseResponsesToolCalls(response.body))
+func (a *responsesLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, _ int, _ time.Duration) ([]toolCall, bool, any) {
+	routerToolCalls, clientToolCalls := splitToolCalls(a.ownedTools, parseResponsesToolCalls(response.body))
 	outputItems, _ := response.body["output"].([]any)
-	return routerToolCalls, outputItems
+	return routerToolCalls, len(clientToolCalls) > 0, outputItems
+}
+
+// stripRouterToolCallsFromResponse removes router-owned function_call
+// items from the response's output array on a mixed-turn finalize so
+// the caller sees only the client-owned function_calls that need a
+// response. Router-owned work is surfaced via the synthesized
+// web_search_call items attachResponsesCitations prepends to the same
+// output array, which is the shape OpenAI's Responses API documents
+// for router-executed tools.
+func (a *responsesLoopAdapter) stripRouterToolCallsFromResponse(response *upstreamJSONResponse) {
+	if response == nil || response.body == nil {
+		return
+	}
+	outputItems, _ := response.body["output"].([]any)
+	if len(outputItems) == 0 {
+		return
+	}
+	filtered := make([]any, 0, len(outputItems))
+	for _, rawItem := range outputItems {
+		item, _ := rawItem.(map[string]any)
+		if item == nil {
+			filtered = append(filtered, rawItem)
+			continue
+		}
+		itemType := stringValue(item["type"])
+		if itemType == "function_call" || itemType == "mcp_call" {
+			if _, ok := a.ownedTools[stringValue(item["name"])]; ok {
+				continue
+			}
+		}
+		filtered = append(filtered, rawItem)
+	}
+	response.body["output"] = filtered
 }
 
 func (a *responsesLoopAdapter) applyToolOutputs(_ map[string]any, state any, outputs []toolOutput) map[string]any {

--- a/toolruntime/tool_progress.go
+++ b/toolruntime/tool_progress.go
@@ -74,14 +74,15 @@ func executeToolWithProgress(
 	if !ok {
 		return "", fmt.Errorf("no MCP session registered for tool %q", call.name)
 	}
-	switch call.name {
-	case "search":
+	dispatchName := registry.dispatchName(call.name)
+	switch {
+	case isRouterSearchToolName(call.name):
 		id := "ws_" + uuid.NewString()
 		action := map[string]any{"type": "search", "query": stringValue(call.arguments["query"])}
 		handle := emitter.open(id, action)
 		emitter.phase(handle, "response.web_search_call.in_progress")
 		emitter.phase(handle, "response.web_search_call.searching")
-		output, err := callTool(ctx, session, call.name, call.arguments, citations)
+		output, err := callTool(ctx, session, dispatchName, call.arguments, citations)
 		if err != nil {
 			emitter.close(handle, action, failureStatusFor(err), publicToolErrorReason(call.name, err), nil)
 			return "", err
@@ -90,10 +91,10 @@ func executeToolWithProgress(
 		emitter.phase(handle, "response.web_search_call.completed")
 		emitter.close(handle, action, "completed", "", sources)
 		return output, nil
-	case "fetch":
+	case isRouterFetchToolName(call.name):
 		urls := fetchArgumentURLs(call.arguments)
 		if len(urls) == 0 {
-			return callTool(ctx, session, call.name, call.arguments, citations)
+			return callTool(ctx, session, dispatchName, call.arguments, citations)
 		}
 		handles := make([]toolProgressHandle, len(urls))
 		actions := make([]map[string]any, len(urls))
@@ -103,7 +104,7 @@ func executeToolWithProgress(
 			handles[i] = emitter.open(id, actions[i])
 			emitter.phase(handles[i], "response.web_search_call.in_progress")
 		}
-		output, err := callTool(ctx, session, call.name, call.arguments, citations)
+		output, err := callTool(ctx, session, dispatchName, call.arguments, citations)
 		if err != nil {
 			reason := publicToolErrorReason(call.name, err)
 			status := failureStatusFor(err)
@@ -118,7 +119,7 @@ func executeToolWithProgress(
 		}
 		return output, nil
 	default:
-		return callTool(ctx, session, call.name, call.arguments, citations)
+		return callTool(ctx, session, dispatchName, call.arguments, citations)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables parallel tool calls by default and supports mixed router+client tool turns without orphaning client requests. Router web tools are now namespaced to avoid name clashes.

- **New Features**
  - Default `parallel_tool_calls: true` for chat and responses in streaming and non‑streaming paths (caller override respected).
  - Mixed turns: resolve router calls, surface citations/events, then finalize with the client `tool_calls` intact; `finish_reason` is forced to `tool_calls`, and any unrecognizable `tool_calls` entries are preserved during router-call stripping.
  - Router-owned web tools are exposed as `router_search` and `router_fetch`, executed serially and internally dispatched to MCP `search`/`fetch` for deterministic citations and event order.

- **Migration**
  - To opt out, set `parallel_tool_calls: false`. If you target router tools in `tool_choice` or schemas, use `router_search` and `router_fetch`.

<sup>Written for commit 00cf7b76becf834b63d29514b7005d8ccb0a5511. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

