### PR TITLE
chore: move gemma

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -83,7 +83,6 @@ models:
   gemma4-31b:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
-      - gemma4-31b.inf9.tinfoil.sh
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
     overload:
       max_requests_waiting: 16


### PR DESCRIPTION
Removed an enclave entry for gemma4-31b.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated enclave endpoint for gemma4-31b in config.yml to route all traffic to `gemma4-31b-inf6.tinfoil.containers.tinfoil.dev`. This prevents requests from hitting the retired `gemma4-31b.inf9.tinfoil.sh` host.

<sup>Written for commit 41bf7d084d0579e130c8b43a22e1507c85907035. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

