### PR TITLE
hotfix: send parsed citation url so webapp shows it correctly

### DIFF
--- a/local_testing.md
+++ b/local_testing.md
@@ -79,6 +79,7 @@ PORT=8090 \
 DOMAIN=localhost \
 INIT_CONFIG_URL="/tmp/model-router-local.yml@sha256:<sha-from-step-2>" \
 UPDATE_CONFIG_URL=/tmp/model-router-local.yml \
+USAGE_REPORTER_SECRET=test-secret \
 go run -tags toolruntime_debug .
 ```
 

--- a/toolruntime/citation_stream.go
+++ b/toolruntime/citation_stream.go
@@ -117,6 +117,7 @@ func (e *citationEmitter) drain(final bool) (string, []citationAnnotation) {
 			normalizeLinkBrackets(e.text, openIndex, endIndex)
 			contentBuilder.WriteString(string(e.text[openIndex:endIndex]))
 			if source, sourceOK := e.state.resolveSource(url); sourceOK {
+				source.url = url // Use the model's URL so the webapp can match it against the rendered markdown link
 				annotations = append(annotations, citationAnnotation{
 					startIndex: labelStart,
 					endIndex:   labelEnd,

--- a/toolruntime/citations.go
+++ b/toolruntime/citations.go
@@ -269,6 +269,7 @@ func (c *citationState) matchesFor(text string) []annotationMatch {
 		if !ok {
 			continue
 		}
+		source.url = url // Use the model's URL so the webapp can match it against the rendered markdown link
 		// Span the visible label, not the whole [label](url) expression, so
 		// downstream consumers can highlight just the link text the user sees.
 		// Convert regex byte offsets to Unicode code-point offsets so the


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Send the model-parsed citation URL in annotations so the webapp can match the rendered markdown link and display citations correctly. Also adds `USAGE_REPORTER_SECRET` to the local testing example.

<sup>Written for commit d8b175f855687373578e10ba8bee43d03fc01aba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

