### PR TITLE
router: prefer non-overloaded enclaves, retry on overload

### DIFF
--- a/main.go
+++ b/main.go
@@ -551,9 +551,10 @@ func main() {
 			return
 		}
 
-		// Retry with a different enclave if the first pick turns out to be
-		// overloaded at dispatch time, so one backed-up sibling doesn't cascade
-		// into a 429 when others are healthy.
+		// Try up to N picks (N = number of configured enclaves). Each pick
+		// that turns out overloaded goes into skip, so NextEnclave will prefer
+		// a sibling on the next iteration. Bounded so a single backed-up
+		// enclave doesn't cascade into a 429 when others are healthy.
 		var (
 			enclave    *manager.Enclave
 			overloaded bool
@@ -561,16 +562,19 @@ func main() {
 			waiting    float64
 			skip       = map[string]bool{}
 		)
-		for retry := 0; ; retry++ {
+		for range model.EnclaveCount() {
 			enclave = model.NextEnclave(skip)
 			if enclave == nil {
-				jsonError(w, manager.ErrMsgOverloaded, manager.ErrTypeServer, http.StatusServiceUnavailable)
-				return
+				break
 			}
-			if overloaded, retryAfter, waiting = enclave.ShouldReject(); !overloaded || retry+1 >= len(model.Enclaves) {
+			if overloaded, retryAfter, waiting = enclave.ShouldReject(); !overloaded {
 				break
 			}
 			skip[enclave.String()] = true
+		}
+		if enclave == nil {
+			jsonError(w, manager.ErrMsgOverloaded, manager.ErrTypeServer, http.StatusServiceUnavailable)
+			return
 		}
 
 		if overloaded {

--- a/main.go
+++ b/main.go
@@ -551,13 +551,29 @@ func main() {
 			return
 		}
 
-		enclave := model.NextEnclave()
-		if enclave == nil {
-			jsonError(w, manager.ErrMsgOverloaded, manager.ErrTypeServer, http.StatusServiceUnavailable)
-			return
+		// Retry with a different enclave if the first pick turns out to be
+		// overloaded at dispatch time, so one backed-up sibling doesn't cascade
+		// into a 429 when others are healthy.
+		var (
+			enclave    *manager.Enclave
+			overloaded bool
+			retryAfter time.Duration
+			waiting    float64
+			skip       = map[string]bool{}
+		)
+		for retry := 0; ; retry++ {
+			enclave = model.NextEnclave(skip)
+			if enclave == nil {
+				jsonError(w, manager.ErrMsgOverloaded, manager.ErrTypeServer, http.StatusServiceUnavailable)
+				return
+			}
+			if overloaded, retryAfter, waiting = enclave.ShouldReject(); !overloaded || retry+1 >= len(model.Enclaves) {
+				break
+			}
+			skip[enclave.String()] = true
 		}
 
-		if overloaded, retryAfter, waiting := enclave.ShouldReject(); overloaded {
+		if overloaded {
 			secs := int(retryAfter.Seconds())
 			if secs <= 0 {
 				secs = 60

--- a/manager/file_inputs.go
+++ b/manager/file_inputs.go
@@ -67,7 +67,7 @@ func (em *EnclaveManager) ConvertFileToMarkdown(
 		}
 	}
 
-	enclave := model.NextEnclave()
+	enclave := model.NextEnclave(nil)
 	if enclave == nil {
 		return "", &FileConversionError{
 			StatusCode: http.StatusBadGateway,

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -17,7 +17,7 @@ func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *ht
 		return "", nil, fmt.Errorf("model %s not found", modelName)
 	}
 
-	enclave := model.NextEnclave()
+	enclave := model.NextEnclave(nil)
 	if enclave == nil {
 		return "", nil, fmt.Errorf("model %s has no available enclave", modelName)
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -294,32 +294,43 @@ func (em *EnclaveManager) Shutdown() {
 	})
 }
 
-// NextEnclave picks a uniformly random enclave with a closed circuit breaker.
-// If an open breaker is past its cooldown, it sends a probe to that enclave.
-// If all breakers are open, it picks a random enclave (degraded > unavailable).
-func (m *Model) NextEnclave() *Enclave {
+// NextEnclave picks a uniformly random enclave with a closed circuit breaker,
+// preferring those that are not currently overloaded and not in skip. If an
+// open breaker is past its cooldown, it sends a probe to that enclave. Falls
+// back to any closed enclave, then any enclave (degraded > unavailable).
+func (m *Model) NextEnclave(skip map[string]bool) *Enclave {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if len(m.Enclaves) == 0 {
-		return nil
-	}
-
 	all := make([]*Enclave, 0, len(m.Enclaves))
-	var closed []*Enclave
+	var closed, preferred []*Enclave
 	for _, enclave := range m.Enclaves {
 		all = append(all, enclave)
-		if enclave.cb == nil || enclave.cb.Closed() {
-			closed = append(closed, enclave)
-		} else if enclave.cb.NeedProbe() {
-			return enclave
+		if enclave.cb != nil && !enclave.cb.Closed() {
+			if enclave.cb.NeedProbe() {
+				return enclave
+			}
+			continue
+		}
+		closed = append(closed, enclave)
+		if !skip[enclave.host] && !enclave.isOverloaded() {
+			preferred = append(preferred, enclave)
 		}
 	}
 
-	if len(closed) > 0 {
+	switch {
+	case len(preferred) > 0:
+		return preferred[rand.IntN(len(preferred))]
+	case len(closed) > 0:
 		return closed[rand.IntN(len(closed))]
+	case len(all) > 0:
+		return all[rand.IntN(len(all))]
 	}
-	return all[rand.IntN(len(all))]
+	return nil
+}
+
+func (e *Enclave) isOverloaded() bool {
+	return e != nil && e.metrics != nil && e.metrics.overloaded.Load()
 }
 
 func (e *Enclave) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -329,6 +329,15 @@ func (m *Model) NextEnclave(skip map[string]bool) *Enclave {
 	return nil
 }
 
+// EnclaveCount returns the number of configured enclaves under the model lock.
+// Callers that need to bound a retry loop on enclave cardinality should use
+// this rather than reading len(m.Enclaves) directly.
+func (m *Model) EnclaveCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.Enclaves)
+}
+
 func (e *Enclave) isOverloaded() bool {
 	return e != nil && e.metrics != nil && e.metrics.overloaded.Load()
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -312,8 +312,11 @@ func (m *Model) NextEnclave(skip map[string]bool) *Enclave {
 			}
 			continue
 		}
+		if skip[enclave.host] {
+			continue
+		}
 		closed = append(closed, enclave)
-		if !skip[enclave.host] && !enclave.isOverloaded() {
+		if !enclave.isOverloaded() {
 			preferred = append(preferred, enclave)
 		}
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -1,0 +1,70 @@
+package manager
+
+import (
+	"testing"
+	"time"
+)
+
+func newTestEnclave(host string) *Enclave {
+	return &Enclave{
+		host:    host,
+		cb:      newCircuitBreaker(),
+		metrics: newEnclaveMetrics(host, "test-model"),
+	}
+}
+
+func newTestModel(hosts ...string) *Model {
+	m := &Model{Enclaves: make(map[string]*Enclave, len(hosts))}
+	for _, h := range hosts {
+		m.Enclaves[h] = newTestEnclave(h)
+	}
+	return m
+}
+
+func TestNextEnclave_PrefersNonOverloaded(t *testing.T) {
+	m := newTestModel("a", "b")
+	m.Enclaves["a"].metrics.overloaded.Store(true)
+
+	for i := 0; i < 50; i++ {
+		if got := m.NextEnclave(nil); got == nil || got.host != "b" {
+			t.Fatalf("expected b, got %v", got)
+		}
+	}
+}
+
+func TestNextEnclave_SkipExcludesFromPreferred(t *testing.T) {
+	m := newTestModel("a", "b", "c")
+	got := m.NextEnclave(map[string]bool{"a": true, "b": true})
+	if got == nil || got.host != "c" {
+		t.Fatalf("expected c, got %v", got)
+	}
+}
+
+func TestNextEnclave_AllOverloadedFallsBack(t *testing.T) {
+	m := newTestModel("a", "b")
+	m.Enclaves["a"].metrics.overloaded.Store(true)
+	m.Enclaves["b"].metrics.overloaded.Store(true)
+	if got := m.NextEnclave(nil); got == nil {
+		t.Fatal("expected fallback pick, got nil")
+	}
+}
+
+func TestNextEnclave_ProbeOverridesSkip(t *testing.T) {
+	m := newTestModel("probe", "other")
+	probe := m.Enclaves["probe"]
+	for i := 0; i < cbFailureThreshold; i++ {
+		probe.cb.RecordFailure()
+	}
+	probe.cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
+
+	if got := m.NextEnclave(map[string]bool{"probe": true}); got == nil || got.host != "probe" {
+		t.Fatalf("expected probe, got %v", got)
+	}
+}
+
+func TestNextEnclave_EmptyModel(t *testing.T) {
+	m := &Model{Enclaves: map[string]*Enclave{}}
+	if got := m.NextEnclave(nil); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}


### PR DESCRIPTION
NextEnclave gains a `skip` parameter and one extra candidate bucket ("preferred" = closed breaker, not overloaded, not in skip). Fallbacks to any closed enclave, then any enclave, keep the degraded > unavailable policy intact.

main.go wraps the pick+ShouldReject pair in a retry loop that adds overloaded enclaves to the skip set, so a request only 429s when every sibling reports overloaded. The loop is bounded to len(model.Enclaves) picks to avoid spinning through the fallback buckets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer healthy enclaves and retry selection when one reports overload to reduce unnecessary 429s. Keeps the degraded > unavailable fallback behavior, and fixes skip handling during retries.

- **New Features**
  - Introduced `Model.NextEnclave(skip)` that prefers enclaves with closed breakers, not overloaded, and not in the skip set; falls back to closed, then any. Probes still override skip.
  - Wrapped pick + `ShouldReject` in a bounded retry loop using `EnclaveCount()`; overloaded enclaves are added to skip so we 429 only when all siblings are overloaded.
  - Updated call sites to pass `nil` for skip and added tests for preference, skip behavior, fallbacks, probe override, and empty model.

<sup>Written for commit 2df80f77036ff992304679b07df5a625ea725ba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

