### PR TITLE
feat: make slow and cancel events non breaking

### DIFF
--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -90,12 +90,36 @@ var (
 
 	// ProxyFailureTotal tracks failed proxy responses and transport errors per enclave.
 	// The "reason" label classifies the failure: timeout, tls_mismatch, connection_refused,
-	// connection_reset, dns_error, tls_error, canceled, transport_error, or http_<status>.
+	// connection_reset, dns_error, tls_error, transport_error, or http_<status>. These are
+	// all inputs to the circuit breaker. Client cancellations and slow-header observations
+	// are tracked separately in ClientCancellationsTotal and SlowHeadersTotal.
 	ProxyFailureTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_proxy_failure_total",
 			Help: "Total number of failed proxy responses (status >= 500 or transport error)",
 		},
 		[]string{"model", "enclave", "reason"},
+	)
+
+	// ClientCancellationsTotal tracks requests that ended because the client
+	// disconnected or aborted. Not a backend fault; does not trip the breaker.
+	ClientCancellationsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_client_cancellations_total",
+			Help: "Total number of requests that ended because the client disconnected or aborted",
+		},
+		[]string{"model", "enclave"},
+	)
+
+	// SlowHeadersTotal tracks requests where response headers took longer than
+	// responseHeaderTimeout to arrive. Observed passively while the request is
+	// still in flight; its terminal outcome is counted separately in
+	// ProxySuccessTotal or ProxyFailureTotal. Does not trip the breaker.
+	SlowHeadersTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_slow_headers_total",
+			Help: "Total number of requests where response headers took longer than responseHeaderTimeout to arrive",
+		},
+		[]string{"model", "enclave"},
 	)
 )

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -136,8 +136,14 @@ func (t *slowHeaderTripper) RoundTrip(req *http.Request) (*http.Response, error)
 
 func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Collector, cb *circuitBreaker) *httputil.ReverseProxy {
 	recordFailure := func(reason string) {
-		cb.RecordFailure()
+		// Client cancellations aren't backend faults — track in a dedicated
+		// counter, don't trip the breaker.
+		if reason == "canceled" {
+			ClientCancellationsTotal.WithLabelValues(modelName, host).Inc()
+			return
+		}
 		ProxyFailureTotal.WithLabelValues(modelName, host, reason).Inc()
+		cb.RecordFailure()
 		CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cb.State()))
 	}
 	recordSuccess := func() {
@@ -157,7 +163,10 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				"enclave": host,
 				"timeout": responseHeaderTimeout,
 			}).Warn("backend slow: response headers not received within timeout")
-			recordFailure("slow")
+			// Purely observational: the request is still in flight; its
+			// terminal outcome will be counted in ProxySuccessTotal or
+			// ProxyFailureTotal. Does not feed the breaker.
+			SlowHeadersTotal.WithLabelValues(modelName, host).Inc()
 		},
 	}
 	proxy := httputil.NewSingleHostReverseProxy(&url.URL{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Client cancellations and slow-header events no longer trip the circuit breaker. We now track them with dedicated Prometheus counters without treating them as backend failures.

- **New Features**
  - Added `router_client_cancellations_total` (labels: `model`, `enclave`) for client disconnects; does not feed the breaker.
  - Added `router_slow_headers_total` (labels: `model`, `enclave`) for responses exceeding `responseHeaderTimeout`; observational only.
  - Updated `router_proxy_failure_total` semantics to exclude `canceled` and `slow` reasons; only backend faults and HTTP 5xx feed the breaker.

<sup>Written for commit 18ed417ff2a104352fa26a9490358fd33547bfa7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

