### PR TITLE
add DeepSeek V4 Pro route

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,6 +38,11 @@ models:
     enclaves:
       - glm-5-1.tinfoil.containers.tinfoil.dev
 
+  deepseek-v4-pro:
+    repo: tinfoilsh/confidential-deepseek-v4-pro
+    enclaves:
+      - deepseek-v4-pro.tinfoil.containers.tinfoil.dev
+
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:


### PR DESCRIPTION
## Summary
- add `deepseek-v4-pro` to `config.yml`
- route it to `deepseek-v4-pro.tinfoil.containers.tinfoil.dev`

## Validation
- parsed `config.yml` with Ruby YAML loader

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `deepseek-v4-pro` to `config.yml` with repo `tinfoilsh/confidential-deepseek-v4-pro` and routing to `deepseek-v4-pro.tinfoil.containers.tinfoil.dev`. This exposes DeepSeek V4 Pro as a supported model.

<sup>Written for commit 55ad2855d52ea41d302a1a47170b9d5a3acc88b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

