### PR TITLE
chore: new enclave for gemma4-31b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -89,6 +89,7 @@ models:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
+      - gemma4-31b-inf9.tinfoil.containers.tinfoil.dev
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a new enclave endpoint for the `gemma4-31b` model to increase capacity and improve failover.
Added `gemma4-31b-inf9.tinfoil.containers.tinfoil.dev` to the `enclaves` list in `config.yml`.

<sup>Written for commit 9d67faf60aa12355307741907f96c5ef9247fdeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

