### PR TITLE
chore: delete kimi-k2-5 configuration from config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -68,13 +68,6 @@ models:
     enclaves:
       - qwen3-vl-30b.inf9.tinfoil.sh
 
-  kimi-k2-5:
-    repo: tinfoilsh/confidential-kimi-k2-5
-    enclaves:
-      - kimi-k2-5-inf8.tinfoil.containers.tinfoil.dev
-    rate_limit:
-      max_requests_per_minute: 4
-
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6
     enclaves:


### PR DESCRIPTION
Removed configuration for kimi-k2-5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `kimi-k2-5` model configuration from `config.yml`. No other model entries were changed.

<sup>Written for commit 4653f53b21ec998a1fae3e78ddaaaff6bef0a66e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

