### PR TITLE
core: update enclave address for kimi-k2-6

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ models:
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6
     enclaves:
-      - kimi-k2-6.tinfoil.containers.tinfoil.dev
+      - kimi-k2-6-inf10.tinfoil.containers.tinfoil.dev
 
   websearch:
     repo: tinfoilsh/confidential-websearch


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the enclave host for kimi-k2-6 to point to `kimi-k2-6-inf10.tinfoil.containers.tinfoil.dev`, routing traffic to the new enclave after the infra move. This keeps requests targeting the correct deployment.

<sup>Written for commit 55622090104fa66436573aeb98b3452932c2f04c. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/290?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

