### PR TITLE
chore: move enclave doc-upload

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,7 +11,7 @@ models:
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
     enclaves:
-      - doc-upload.inf9.tinfoil.sh
+      - doc-upload.tinfoil.containers.tinfoil.dev
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-whisper-large-v3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `config.yml` to point the `doc-upload` enclave to `doc-upload.tinfoil.containers.tinfoil.dev`, replacing `doc-upload.inf9.tinfoil.sh` after moving the service.

<sup>Written for commit a6f498dfe4595eec01e02edba2f607af946ec217. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/291?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

