### PR TITLE
chore: deepseek domain update

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -41,7 +41,7 @@ models:
   deepseek-v4-pro:
     repo: tinfoilsh/confidential-deepseek-v4-pro
     enclaves:
-      - deepseek-v4-pro.tinfoil.containers.tinfoil.dev
+      - deepseek-v4-pro-inf12.tinfoil.containers.tinfoil.dev
 
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the `deepseek-v4-pro` enclave host in `config.yml` to `deepseek-v4-pro-inf12.tinfoil.containers.tinfoil.dev`. This routes traffic to the new inf12 endpoint and ensures requests reach the correct cluster.

<sup>Written for commit c3a923d31d8045884cc7f464fb6bfd95a6d681ca. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/292?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

