### PR TITLE
chore: voxtral models and qwen-tts

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -26,7 +26,12 @@ models:
   voxtral-mini-4b-realtime:
     repo: tinfoilsh/confidential-realtime-models
     enclaves:
-      - realtime-models.tinfoil.containers.tinfoil.dev
+      - voxtral-mini-4b-realtime.realtime.tinfoil.containers.tinfoil.dev
+
+  voxtral-tts:
+    repo: tinfoilsh/confidential-realtime-models
+    enclaves:
+      - voxtral-tts.realtime.tinfoil.containers.tinfoil.dev
 
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
@@ -61,7 +66,7 @@ models:
   qwen3-tts:
     repo: tinfoilsh/confidential-realtime-models
     enclaves:
-      - realtime-models.tinfoil.containers.tinfoil.dev
+      - qwen3-tts.realtime.tinfoil.containers.tinfoil.dev
 
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b


### PR DESCRIPTION
Updated enclave entries for voxtral-mini-4b-realtime and qwen3-tts.