### PR TITLE
Separate billable meters from customer request counts

### DIFF
--- a/billing/events.go
+++ b/billing/events.go
@@ -97,6 +97,9 @@ func (c *Collector) AddEvent(event Event) {
 				{Name: "output_tokens", Quantity: int64(event.CompletionTokens)},
 				{Name: "requests", Quantity: 1},
 			},
+			Counters: []contract.Counter{
+				{Name: contract.CounterCustomerRequests, Quantity: 1},
+			},
 			Attributes: map[string]string{
 				"model":     event.Model,
 				"route":     event.RequestPath,

--- a/billing/events_test.go
+++ b/billing/events_test.go
@@ -1,0 +1,78 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tinfoilsh/usage-reporting-go/contract"
+)
+
+func TestCollectorAddsCustomerRequestCounter(t *testing.T) {
+	batches := make(chan contract.Batch, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var batch contract.Batch
+		if err := json.NewDecoder(r.Body).Decode(&batch); err != nil {
+			t.Errorf("decode usage batch: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		batches <- batch
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	collector := NewCollector(server.URL, "reporter", "secret")
+	defer collector.Stop()
+	collector.AddEvent(Event{
+		Timestamp:        time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		APIKey:           "tk_test",
+		Model:            "gpt-oss-120b",
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		TotalTokens:      15,
+		RequestID:        "request-1",
+		RequestPath:      "/v1/chat/completions",
+	})
+	if err := collector.reporter.Flush(context.Background()); err != nil {
+		t.Fatalf("flush usage reporter: %v", err)
+	}
+
+	select {
+	case batch := <-batches:
+		if len(batch.Events) != 1 {
+			t.Fatalf("expected one event, got %d", len(batch.Events))
+		}
+		event := batch.Events[0]
+		if got := meterQuantity(event, "requests"); got != 1 {
+			t.Fatalf("request meter mismatch: got %d want 1", got)
+		}
+		if got := counterQuantity(event, contract.CounterCustomerRequests); got != 1 {
+			t.Fatalf("customer request counter mismatch: got %d want 1", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for usage batch")
+	}
+}
+
+func meterQuantity(event contract.Event, name string) int64 {
+	for _, meter := range event.Meters {
+		if meter.Name == name {
+			return meter.Quantity
+		}
+	}
+	return 0
+}
+
+func counterQuantity(event contract.Event, name string) int64 {
+	for _, counter := range event.Counters {
+		if counter.Name == name {
+			return counter.Quantity
+		}
+	}
+	return 0
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/tinfoilsh/tinfoil-go v0.12.7
-	github.com/tinfoilsh/usage-reporting-go v0.0.3
+	github.com/tinfoilsh/usage-reporting-go v0.0.4
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/theupdateframework/go-tuf/v2 v2.4.1 h1:K6ewW064rKZCPkRo1W/CTbTtm/+IB4
 github.com/theupdateframework/go-tuf/v2 v2.4.1/go.mod h1:Nex2enPVYDFCklrnbTzl3OVwD7fgIAj0J5++z/rvCj8=
 github.com/tinfoilsh/tinfoil-go v0.12.7 h1:l2d2waMdbt+61yOTlcBhIU2eXD74GtifN0Svpm2kZIE=
 github.com/tinfoilsh/tinfoil-go v0.12.7/go.mod h1:i503zVkJKaFfJ2aHIUM8E5dAFbXSMw3MkiWryKGTTs8=
-github.com/tinfoilsh/usage-reporting-go v0.0.3 h1:ZWounmAxGp1fJ+6WYgfJ/+ordX74n7lHYGEI7NggXsU=
-github.com/tinfoilsh/usage-reporting-go v0.0.3/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
+github.com/tinfoilsh/usage-reporting-go v0.0.4 h1:GDztOb9ZIqn9PtEyR1BjJh/iDQJ7n4yE9U2cRkufZ3o=
+github.com/tinfoilsh/usage-reporting-go v0.0.4/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -53,6 +53,7 @@ type EnclaveManager struct {
 	controlPlaneURL      string
 	sigstoreClient       *sigstore.Client
 	billingCollector     *billing.Collector
+	usageReporterSecret  string
 	requestTracker       *ratelimit.RequestTracker
 	refreshInterval      time.Duration
 	stateMu              sync.Mutex
@@ -99,6 +100,10 @@ func (em *EnclaveManager) AddBillingEvent(event billing.Event) {
 	if em.billingCollector != nil {
 		em.billingCollector.AddEvent(event)
 	}
+}
+
+func (em *EnclaveManager) UsageReporterSecret() string {
+	return em.usageReporterSecret
 }
 
 // GetRateLimitConfig returns the rate limit config for a model, or nil if not configured.
@@ -421,14 +426,15 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterI
 	}
 
 	em := &EnclaveManager{
-		models:           &sync.Map{},
-		initConfigURL:    initConfigURL,
-		updateConfigURL:  updateConfigURL,
-		controlPlaneURL:  controlPlaneURL,
-		sigstoreClient:   sigstoreClient,
-		billingCollector: billing.NewCollector(controlPlaneURL, usageReporterID, usageReporterSecret),
-		requestTracker:   ratelimit.NewRequestTracker(),
-		refreshInterval:  refreshInterval,
+		models:              &sync.Map{},
+		initConfigURL:       initConfigURL,
+		updateConfigURL:     updateConfigURL,
+		controlPlaneURL:     controlPlaneURL,
+		sigstoreClient:      sigstoreClient,
+		billingCollector:    billing.NewCollector(controlPlaneURL, usageReporterID, usageReporterSecret),
+		usageReporterSecret: usageReporterSecret,
+		requestTracker:      ratelimit.NewRequestTracker(),
+		refreshInterval:     refreshInterval,
 	}
 
 	for modelName, modelConfig := range cfg.Models {

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -18,7 +18,10 @@ import (
 	"github.com/tinfoilsh/confidential-model-router/tokencount"
 	"github.com/tinfoilsh/confidential-model-router/toolcontext"
 	"github.com/tinfoilsh/confidential-model-router/toolprofile"
+	"github.com/tinfoilsh/usage-reporting-go/usagecontext"
 )
+
+const toolRuntimeServiceName = "router"
 
 // ---------------------------------------------------------------------------
 // Types (grouped with their methods)
@@ -190,6 +193,23 @@ func connectToolSession(ctx context.Context, em *manager.EnclaveManager, profile
 		requestID = uuid.NewString()
 	}
 
+	headers, err := toolSessionHeaders(r, requestID, modelName, body, safety, em.UsageReporterSecret(), time.Now)
+	if err != nil {
+		return nil, err
+	}
+	httpClient.Transport = &headerRoundTripper{
+		base:    httpClient.Transport,
+		headers: headers,
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "router-tool-runtime", Version: "v1"}, nil)
+	return client.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint:   endpoint,
+		HTTPClient: httpClient,
+	}, nil)
+}
+
+func toolSessionHeaders(r *http.Request, requestID string, modelName string, body map[string]any, safety safetyOptIns, usageContextSecret string, now func() time.Time) (http.Header, error) {
 	headers := make(http.Header)
 	headers.Set(toolcontext.HeaderRequestID, requestID)
 	headers.Set(toolcontext.HeaderModel, modelName)
@@ -204,16 +224,18 @@ func connectToolSession(ctx context.Context, em *manager.EnclaveManager, profile
 	if auth := r.Header.Get("Authorization"); auth != "" {
 		headers.Set("Authorization", auth)
 	}
-	httpClient.Transport = &headerRoundTripper{
-		base:    httpClient.Transport,
-		headers: headers,
+	if usageContextSecret != "" {
+		customerRequestCount := int64(0)
+		if err := usagecontext.SetHeaders(headers, usagecontext.Context{
+			RootRequestID:        requestID,
+			ParentService:        toolRuntimeServiceName,
+			CustomerRequestCount: &customerRequestCount,
+			IssuedAt:             now().UTC(),
+		}, usageContextSecret); err != nil {
+			return nil, fmt.Errorf("sign tool usage context: %w", err)
+		}
 	}
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "router-tool-runtime", Version: "v1"}, nil)
-	return client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint:   endpoint,
-		HTTPClient: httpClient,
-	}, nil)
+	return headers, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -6,15 +6,58 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tinfoilsh/confidential-model-router/manager"
 	"github.com/tinfoilsh/confidential-model-router/tokencount"
+	"github.com/tinfoilsh/confidential-model-router/toolcontext"
 	"github.com/tinfoilsh/confidential-model-router/toolruntime/citations"
+	"github.com/tinfoilsh/usage-reporting-go/usagecontext"
 )
+
+func TestToolSessionHeadersIncludeSignedUsageContext(t *testing.T) {
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer tk_test")
+
+	headers, err := toolSessionHeaders(req, "request-1", "gpt-oss-120b", map[string]any{"stream": true}, safetyOptIns{}, "secret", func() time.Time {
+		return now
+	})
+	if err != nil {
+		t.Fatalf("build tool session headers: %v", err)
+	}
+	if got := headers.Get(toolcontext.HeaderRequestID); got != "request-1" {
+		t.Fatalf("request id header mismatch: got %q want %q", got, "request-1")
+	}
+	if got := headers.Get(toolcontext.HeaderStreaming); got != "true" {
+		t.Fatalf("streaming header mismatch: got %q want true", got)
+	}
+	if got := headers.Get("Authorization"); got != "Bearer tk_test" {
+		t.Fatalf("authorization header mismatch: got %q", got)
+	}
+
+	ctx, ok, err := usagecontext.FromHeaders(headers, "secret", now, time.Minute)
+	if err != nil {
+		t.Fatalf("verify usage context headers: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected usage context headers to be present")
+	}
+	if ctx.RootRequestID != "request-1" {
+		t.Fatalf("root request id mismatch: got %q want request-1", ctx.RootRequestID)
+	}
+	if ctx.ParentService != toolRuntimeServiceName {
+		t.Fatalf("parent service mismatch: got %q want %q", ctx.ParentService, toolRuntimeServiceName)
+	}
+	if ctx.CustomerRequestCount == nil || *ctx.CustomerRequestCount != 0 {
+		t.Fatalf("customer request count mismatch: got %+v want pointer to 0", ctx.CustomerRequestCount)
+	}
+}
 
 func TestReplaceRouterOwnedResponsesTools(t *testing.T) {
 	replaced := replaceRouterOwnedResponsesTools([]any{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Separates billable meters from customer request counts and streams client-owned tool_call deltas live. Passes a signed request context to tools so they can attribute usage without adding billable requests.

- **New Features**
  - Billing: Add `contract.CounterCustomerRequests` per request; keep the `requests` meter unchanged.
  - Streaming: Forward client-owned `tool_calls` deltas; skip router-owned tools; preserve client order; dedupe at finalize.
  - Tool runtime: Send signed `usagecontext` headers (RootRequestID, ParentService=`router`, CustomerRequestCount=0, IssuedAt) and include request context (model, route, streaming, safety opt-ins, Authorization).

- **Dependencies**
  - Bump `github.com/tinfoilsh/usage-reporting-go` to `v0.0.4`.

<sup>Written for commit 2f30bf3e4090db1659271b386636bd0b8404da36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

