### PR TITLE
feat: support correct pdf mode for pdf in base 64

### DIFF
--- a/main.go
+++ b/main.go
@@ -454,9 +454,9 @@ func main() {
 					rewritten := false
 					switch r.URL.Path {
 					case "/v1/responses":
-						rewritten, err = rewriteResponsesBase64Files(r.Context(), body, em, r.Header.Get("Authorization"))
+						rewritten, err = rewriteResponsesBase64Files(r.Context(), body, em, r.Header.Get("Authorization"), modelName)
 					case "/v1/chat/completions":
-						rewritten, err = rewriteChatCompletionsBase64Files(r.Context(), body, em, r.Header.Get("Authorization"))
+						rewritten, err = rewriteChatCompletionsBase64Files(r.Context(), body, em, r.Header.Get("Authorization"), modelName)
 					}
 					if err != nil {
 						var inputErr *fileInputError

--- a/manager/file_inputs.go
+++ b/manager/file_inputs.go
@@ -16,6 +16,27 @@ import (
 	tinfoilClient "github.com/tinfoilsh/tinfoil-go/verifier/client"
 )
 
+// FileConversionMode is one of the modes accepted by /v1/convert/file. The
+// empty string keeps the upstream default ("text").
+type FileConversionMode string
+
+const (
+	FileConversionModeText   FileConversionMode = "text"
+	FileConversionModeVision FileConversionMode = "vision"
+	FileConversionModeImages FileConversionMode = "images"
+	FileConversionModeRaw    FileConversionMode = "raw"
+	FileConversionModeVLM    FileConversionMode = "vlm"
+)
+
+func (m FileConversionMode) IsValid() bool {
+	switch m {
+	case "", FileConversionModeText, FileConversionModeVision,
+		FileConversionModeImages, FileConversionModeRaw, FileConversionModeVLM:
+		return true
+	}
+	return false
+}
+
 type FileConversionError struct {
 	StatusCode int
 	Message    string
@@ -25,43 +46,71 @@ func (e *FileConversionError) Error() string {
 	return e.Message
 }
 
+type ConvertedPage struct {
+	Page      int    `json:"page"`
+	Text      string `json:"text"`
+	Image     string `json:"image"`
+	IsScanned bool   `json:"is_scanned"`
+}
+
+type ConvertedFile struct {
+	MDContent string
+	Pages     []ConvertedPage
+}
+
 type docUploadResponse struct {
 	Document struct {
-		MDContent string `json:"md_content"`
+		MDContent string          `json:"md_content"`
+		Pages     []ConvertedPage `json:"pages"`
 	} `json:"document"`
 }
 
-func parseDocUploadMarkdown(respBody []byte) (string, error) {
+func parseDocUploadResponse(respBody []byte, mode FileConversionMode) (*ConvertedFile, error) {
 	var parsed docUploadResponse
 	if err := json.Unmarshal(respBody, &parsed); err != nil {
-		return "", &FileConversionError{
+		return nil, &FileConversionError{
 			StatusCode: http.StatusBadGateway,
 			Message:    "invalid document processing response",
 		}
 	}
 
-	if strings.TrimSpace(parsed.Document.MDContent) == "" {
-		return "", &FileConversionError{
+	out := &ConvertedFile{
+		MDContent: parsed.Document.MDContent,
+		Pages:     parsed.Document.Pages,
+	}
+
+	if mode == FileConversionModeImages {
+		if len(out.Pages) == 0 {
+			return nil, &FileConversionError{
+				StatusCode: http.StatusBadGateway,
+				Message:    "document processing returned no pages",
+			}
+		}
+		return out, nil
+	}
+
+	if strings.TrimSpace(out.MDContent) == "" {
+		return nil, &FileConversionError{
 			StatusCode: http.StatusBadGateway,
 			Message:    "document processing returned empty content",
 		}
 	}
-
-	return parsed.Document.MDContent, nil
+	return out, nil
 }
 
-// ConvertFileToMarkdown sends an uploaded file to the private doc-upload enclave
-// and returns the extracted markdown content.
-func (em *EnclaveManager) ConvertFileToMarkdown(
+// ConvertFile sends an uploaded file to the private doc-upload enclave with
+// the given mode and returns the parsed result.
+func (em *EnclaveManager) ConvertFile(
 	ctx context.Context,
 	authHeader string,
 	filename string,
 	contentType string,
 	data []byte,
-) (string, error) {
+	mode FileConversionMode,
+) (*ConvertedFile, error) {
 	model, found := em.GetModel("doc-upload")
 	if !found {
-		return "", &FileConversionError{
+		return nil, &FileConversionError{
 			StatusCode: http.StatusBadGateway,
 			Message:    "document processing backend is not configured",
 		}
@@ -69,7 +118,7 @@ func (em *EnclaveManager) ConvertFileToMarkdown(
 
 	enclave := model.NextEnclave(nil)
 	if enclave == nil {
-		return "", &FileConversionError{
+		return nil, &FileConversionError{
 			StatusCode: http.StatusBadGateway,
 			Message:    "document processing backend is unavailable",
 		}
@@ -85,38 +134,38 @@ func (em *EnclaveManager) ConvertFileToMarkdown(
 	}
 	part, err := writer.CreatePart(headers)
 	if err != nil {
-		return "", &FileConversionError{
+		return nil, &FileConversionError{
 			StatusCode: http.StatusInternalServerError,
 			Message:    "failed to build document upload request",
 		}
 	}
 	if _, err := part.Write(data); err != nil {
-		return "", &FileConversionError{
+		return nil, &FileConversionError{
 			StatusCode: http.StatusInternalServerError,
 			Message:    "failed to build document upload request",
 		}
 	}
 	if err := writer.WriteField("to_format", "md"); err != nil {
-		return "", &FileConversionError{
+		return nil, &FileConversionError{
 			StatusCode: http.StatusInternalServerError,
 			Message:    "failed to build document upload request",
 		}
 	}
 	if err := writer.Close(); err != nil {
-		return "", &FileConversionError{
+		return nil, &FileConversionError{
 			StatusCode: http.StatusInternalServerError,
 			Message:    "failed to finalize document upload request",
 		}
 	}
 
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		"https://"+enclave.host+"/v1/convert/file",
-		bytes.NewReader(body.Bytes()),
-	)
+	url := "https://" + enclave.host + "/v1/convert/file"
+	if mode != "" {
+		url += "?mode=" + string(mode)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body.Bytes()))
 	if err != nil {
-		return "", &FileConversionError{
+		return nil, &FileConversionError{
 			StatusCode: http.StatusInternalServerError,
 			Message:    "failed to create document upload request",
 		}
@@ -140,7 +189,7 @@ func (em *EnclaveManager) ConvertFileToMarkdown(
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", &FileConversionError{
+		return nil, &FileConversionError{
 			StatusCode: http.StatusBadGateway,
 			Message:    "document processing request failed",
 		}
@@ -149,7 +198,7 @@ func (em *EnclaveManager) ConvertFileToMarkdown(
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", &FileConversionError{
+		return nil, &FileConversionError{
 			StatusCode: http.StatusBadGateway,
 			Message:    "failed to read document processing response",
 		}
@@ -159,13 +208,13 @@ func (em *EnclaveManager) ConvertFileToMarkdown(
 		if message == "" {
 			message = "document processing failed"
 		}
-		return "", &FileConversionError{
+		return nil, &FileConversionError{
 			StatusCode: resp.StatusCode,
 			Message:    message,
 		}
 	}
 
-	return parseDocUploadMarkdown(respBody)
+	return parseDocUploadResponse(respBody, mode)
 }
 
 func escapeMultipartFilename(filename string) string {

--- a/manager/file_inputs_test.go
+++ b/manager/file_inputs_test.go
@@ -75,7 +75,80 @@ func TestSanitizeMultipartContentType(t *testing.T) {
 	}
 }
 
-func TestParseDocUploadMarkdown(t *testing.T) {
+func TestParseDocUploadResponseImagesMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		expectedMD    string
+		expectedPages int
+		expectedError string
+	}{
+		{
+			name:          "valid_with_text_and_pages",
+			body:          `{"document":{"md_content":"page text","pages":[{"page":1,"image":"data:image/png;base64,AAA","is_scanned":false}]}}`,
+			expectedMD:    "page text",
+			expectedPages: 1,
+		},
+		{
+			name:          "valid_with_pages_only",
+			body:          `{"document":{"md_content":"","pages":[{"page":1,"image":"data:image/png;base64,AAA","is_scanned":true}]}}`,
+			expectedMD:    "",
+			expectedPages: 1,
+		},
+		{
+			name:          "missing_pages_in_images_mode",
+			body:          `{"document":{"md_content":"only text"}}`,
+			expectedError: "document processing returned no pages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDocUploadResponse([]byte(tt.body), FileConversionModeImages)
+			if tt.expectedError != "" {
+				if err == nil || err.Error() != tt.expectedError {
+					t.Fatalf("expected %q, got %v", tt.expectedError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.MDContent != tt.expectedMD {
+				t.Fatalf("MDContent=%q, want %q", got.MDContent, tt.expectedMD)
+			}
+			if len(got.Pages) != tt.expectedPages {
+				t.Fatalf("len(Pages)=%d, want %d", len(got.Pages), tt.expectedPages)
+			}
+		})
+	}
+}
+
+func TestFileConversionModeIsValid(t *testing.T) {
+	for _, mode := range []FileConversionMode{
+		"",
+		FileConversionModeText,
+		FileConversionModeVision,
+		FileConversionModeImages,
+		FileConversionModeRaw,
+		FileConversionModeVLM,
+	} {
+		if !mode.IsValid() {
+			t.Errorf("expected %q to be a valid mode", mode)
+		}
+	}
+	for _, mode := range []FileConversionMode{
+		"text-mode",
+		"AUTO",
+		"unknown",
+	} {
+		if mode.IsValid() {
+			t.Errorf("expected %q to be invalid", mode)
+		}
+	}
+}
+
+func TestParseDocUploadResponseTextMode(t *testing.T) {
 	tests := []struct {
 		name          string
 		body          string
@@ -110,13 +183,13 @@ func TestParseDocUploadMarkdown(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseDocUploadMarkdown([]byte(tt.body))
+			got, err := parseDocUploadResponse([]byte(tt.body), FileConversionModeText)
 			if tt.expectedError == "" {
 				if err != nil {
-					t.Fatalf("parseDocUploadMarkdown returned unexpected error: %v", err)
+					t.Fatalf("parseDocUploadResponse returned unexpected error: %v", err)
 				}
-				if got != tt.expected {
-					t.Fatalf("parseDocUploadMarkdown() = %q, want %q", got, tt.expected)
+				if got.MDContent != tt.expected {
+					t.Fatalf("MDContent = %q, want %q", got.MDContent, tt.expected)
 				}
 				return
 			}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -40,7 +40,6 @@ type Model struct {
 	Enclaves          map[string]*Enclave      `json:"enclaves"`
 	Overload          *config.OverloadConfig   `json:"overload,omitempty"`
 	RateLimit         *config.RateLimitConfig  `json:"rate_limit,omitempty"`
-	Multimodal        bool                     `json:"multimodal,omitempty"`
 
 	expectedHosts int // number of configured hostnames; 0 means no backends expected
 	mu            sync.RWMutex
@@ -48,6 +47,7 @@ type Model struct {
 
 type EnclaveManager struct {
 	models               *sync.Map // model name -> *Model
+	multimodalModels     sync.Map  // sticky set of multimodal chat model names
 	initConfigURL        string
 	updateConfigURL      string
 	controlPlaneURL      string
@@ -508,12 +508,7 @@ func (em *EnclaveManager) sync() error {
 		return fmt.Errorf("failed to fetch config: %v", err)
 	}
 
-	if err := em.refreshModelMetadata(context.Background()); err != nil {
-		log.Warnf("failed to refresh model metadata from control plane: %v", err)
-		em.stateMu.Lock()
-		em.errors = append(em.errors, fmt.Sprintf("model metadata refresh: %v", err))
-		em.stateMu.Unlock()
-	}
+	em.refreshMultimodalModels()
 
 	// Fetch hardware measurements
 	hwMeasurements, err := em.sigstoreClient.LatestHardwareMeasurements()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -40,6 +40,7 @@ type Model struct {
 	Enclaves          map[string]*Enclave      `json:"enclaves"`
 	Overload          *config.OverloadConfig   `json:"overload,omitempty"`
 	RateLimit         *config.RateLimitConfig  `json:"rate_limit,omitempty"`
+	Multimodal        bool                     `json:"multimodal,omitempty"`
 
 	expectedHosts int // number of configured hostnames; 0 means no backends expected
 	mu            sync.RWMutex
@@ -49,6 +50,7 @@ type EnclaveManager struct {
 	models               *sync.Map // model name -> *Model
 	initConfigURL        string
 	updateConfigURL      string
+	controlPlaneURL      string
 	sigstoreClient       *sigstore.Client
 	billingCollector     *billing.Collector
 	requestTracker       *ratelimit.RequestTracker
@@ -422,6 +424,7 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterI
 		models:           &sync.Map{},
 		initConfigURL:    initConfigURL,
 		updateConfigURL:  updateConfigURL,
+		controlPlaneURL:  controlPlaneURL,
 		sigstoreClient:   sigstoreClient,
 		billingCollector: billing.NewCollector(controlPlaneURL, usageReporterID, usageReporterSecret),
 		requestTracker:   ratelimit.NewRequestTracker(),
@@ -503,6 +506,13 @@ func (em *EnclaveManager) sync() error {
 	config, err := config.Load(em.updateConfigURL, false)
 	if err != nil {
 		return fmt.Errorf("failed to fetch config: %v", err)
+	}
+
+	if err := em.refreshModelMetadata(context.Background()); err != nil {
+		log.Warnf("failed to refresh model metadata from control plane: %v", err)
+		em.stateMu.Lock()
+		em.errors = append(em.errors, fmt.Sprintf("model metadata refresh: %v", err))
+		em.stateMu.Unlock()
 	}
 
 	// Fetch hardware measurements

--- a/manager/model_metadata.go
+++ b/manager/model_metadata.go
@@ -3,7 +3,6 @@ package manager
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -24,85 +23,52 @@ type openAIModelsList struct {
 	Data []openAIModelEntry `json:"data"`
 }
 
-// fetchMultimodalFlags returns a model-name -> multimodal map from the control
-// plane's /v1/models endpoint. We restrict the flag to chat-shaped models so
-// non-chat services (e.g. doc-upload) that happen to carry multimodal:true
-// can't accidentally route PDFs as page images.
-func fetchMultimodalFlags(ctx context.Context, controlPlaneURL string) (map[string]bool, error) {
-	if strings.TrimSpace(controlPlaneURL) == "" {
-		return nil, fmt.Errorf("controlPlaneURL is empty")
-	}
-
-	fetchCtx, cancel := context.WithTimeout(ctx, modelMetadataHTTPTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, controlPlaneURL+"/v1/models", nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("control plane returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	var parsed openAIModelsList
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-		return nil, err
-	}
-
-	out := make(map[string]bool, len(parsed.Data))
-	for _, entry := range parsed.Data {
-		if entry.ID == "" {
-			continue
-		}
-		out[entry.ID] = entry.Multimodal && (entry.Type == "" || entry.Type == "chat")
-	}
-	return out, nil
-}
-
-// refreshModelMetadata stamps each known *Model with its multimodal flag. A
-// transient control-plane failure preserves the previous cache rather than
-// flipping flags, so requests in flight don't change behavior mid-sync.
-func (em *EnclaveManager) refreshModelMetadata(ctx context.Context) error {
-	if em.controlPlaneURL == "" {
-		return nil
-	}
-	flags, err := fetchMultimodalFlags(ctx, em.controlPlaneURL)
-	if err != nil {
-		return err
-	}
-	em.models.Range(func(key, value any) bool {
-		modelName, _ := key.(string)
-		model, _ := value.(*Model)
-		if model == nil {
-			return true
-		}
-		if v, ok := flags[modelName]; ok {
-			model.mu.Lock()
-			model.Multimodal = v
-			model.mu.Unlock()
-		}
-		return true
-	})
-	log.Debugf("refreshed model metadata for %d model(s) from control plane", len(flags))
-	return nil
-}
-
 // IsMultimodal reports whether the named model accepts image content parts.
-// Unknown or not-yet-synced models return false (safe default for routing
-// PDF attachments).
 func (em *EnclaveManager) IsMultimodal(modelName string) bool {
-	model, found := em.GetModel(modelName)
-	if !found {
-		return false
+	_, ok := em.multimodalModels.Load(modelName)
+	return ok
+}
+
+// refreshMultimodalModels updates the sticky multimodal cache in the
+// background. Best-effort: failures and missing entries leave the cache as-is.
+func (em *EnclaveManager) refreshMultimodalModels() {
+	if em.controlPlaneURL == "" {
+		return
 	}
-	model.mu.RLock()
-	defer model.mu.RUnlock()
-	return model.Multimodal
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), modelMetadataHTTPTimeout)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, em.controlPlaneURL+"/v1/models", nil)
+		if err != nil {
+			log.Debugf("multimodal refresh: build request: %v", err)
+			return
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.Debugf("multimodal refresh: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			log.Debugf("multimodal refresh: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+			return
+		}
+
+		var parsed openAIModelsList
+		if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+			log.Debugf("multimodal refresh: decode: %v", err)
+			return
+		}
+
+		for _, e := range parsed.Data {
+			// Restrict to chat-shaped models so non-chat services that carry
+			// multimodal:true don't route PDFs as page images.
+			if e.ID == "" || !e.Multimodal || (e.Type != "" && e.Type != "chat") {
+				continue
+			}
+			em.multimodalModels.Store(e.ID, struct{}{})
+		}
+	}()
 }

--- a/manager/model_metadata.go
+++ b/manager/model_metadata.go
@@ -1,0 +1,108 @@
+package manager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const modelMetadataHTTPTimeout = 10 * time.Second
+
+type openAIModelEntry struct {
+	ID         string `json:"id"`
+	Multimodal bool   `json:"multimodal"`
+	Type       string `json:"type"`
+}
+
+type openAIModelsList struct {
+	Data []openAIModelEntry `json:"data"`
+}
+
+// fetchMultimodalFlags returns a model-name -> multimodal map from the control
+// plane's /v1/models endpoint. We restrict the flag to chat-shaped models so
+// non-chat services (e.g. doc-upload) that happen to carry multimodal:true
+// can't accidentally route PDFs as page images.
+func fetchMultimodalFlags(ctx context.Context, controlPlaneURL string) (map[string]bool, error) {
+	if strings.TrimSpace(controlPlaneURL) == "" {
+		return nil, fmt.Errorf("controlPlaneURL is empty")
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, modelMetadataHTTPTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, controlPlaneURL+"/v1/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("control plane returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var parsed openAIModelsList
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]bool, len(parsed.Data))
+	for _, entry := range parsed.Data {
+		if entry.ID == "" {
+			continue
+		}
+		out[entry.ID] = entry.Multimodal && (entry.Type == "" || entry.Type == "chat")
+	}
+	return out, nil
+}
+
+// refreshModelMetadata stamps each known *Model with its multimodal flag. A
+// transient control-plane failure preserves the previous cache rather than
+// flipping flags, so requests in flight don't change behavior mid-sync.
+func (em *EnclaveManager) refreshModelMetadata(ctx context.Context) error {
+	if em.controlPlaneURL == "" {
+		return nil
+	}
+	flags, err := fetchMultimodalFlags(ctx, em.controlPlaneURL)
+	if err != nil {
+		return err
+	}
+	em.models.Range(func(key, value any) bool {
+		modelName, _ := key.(string)
+		model, _ := value.(*Model)
+		if model == nil {
+			return true
+		}
+		if v, ok := flags[modelName]; ok {
+			model.mu.Lock()
+			model.Multimodal = v
+			model.mu.Unlock()
+		}
+		return true
+	})
+	log.Debugf("refreshed model metadata for %d model(s) from control plane", len(flags))
+	return nil
+}
+
+// IsMultimodal reports whether the named model accepts image content parts.
+// Unknown or not-yet-synced models return false (safe default for routing
+// PDF attachments).
+func (em *EnclaveManager) IsMultimodal(modelName string) bool {
+	model, found := em.GetModel(modelName)
+	if !found {
+		return false
+	}
+	model.mu.RLock()
+	defer model.mu.RUnlock()
+	return model.Multimodal
+}

--- a/responses_file_inputs.go
+++ b/responses_file_inputs.go
@@ -14,7 +14,16 @@ import (
 	"github.com/tinfoilsh/confidential-model-router/manager"
 )
 
-type fileInputProcessor func(ctx context.Context, authHeader string, filename string, contentType string, data []byte) (string, error)
+const tinfoilModeFieldName = "tinfoil_mode"
+
+type fileInputProcessor func(
+	ctx context.Context,
+	authHeader string,
+	filename string,
+	contentType string,
+	data []byte,
+	mode manager.FileConversionMode,
+) (*manager.ConvertedFile, error)
 
 type fileInputError struct {
 	StatusCode int
@@ -25,20 +34,44 @@ func (e *fileInputError) Error() string {
 	return e.Message
 }
 
+type rewriteContext struct {
+	isMultimodal func(modelName string) bool
+	model        string
+	process      fileInputProcessor
+}
+
+func newRewriteContext(em *manager.EnclaveManager, modelName string) *rewriteContext {
+	return &rewriteContext{
+		isMultimodal: em.IsMultimodal,
+		model:        modelName,
+		process: func(
+			ctx context.Context,
+			authHeader string,
+			filename string,
+			contentType string,
+			data []byte,
+			mode manager.FileConversionMode,
+		) (*manager.ConvertedFile, error) {
+			return em.ConvertFile(ctx, authHeader, filename, contentType, data, mode)
+		},
+	}
+}
+
 func rewriteResponsesBase64Files(
 	ctx context.Context,
 	body map[string]any,
 	em *manager.EnclaveManager,
 	authHeader string,
+	modelName string,
 ) (bool, error) {
-	return rewriteResponsesBase64FilesWithProcessor(ctx, body, authHeader, em.ConvertFileToMarkdown)
+	return rewriteResponsesBase64FilesWithProcessor(ctx, body, authHeader, newRewriteContext(em, modelName))
 }
 
 func rewriteResponsesBase64FilesWithProcessor(
 	ctx context.Context,
 	body map[string]any,
 	authHeader string,
-	process fileInputProcessor,
+	rc *rewriteContext,
 ) (bool, error) {
 	inputItems, ok := body["input"].([]any)
 	if !ok {
@@ -70,19 +103,15 @@ func rewriteResponsesBase64FilesWithProcessor(
 				newContent = append(newContent, rawPart)
 				continue
 			}
-			decoded, err := decodeResponsesInputFilePart(part)
+			decoded, mode, err := decodeResponsesInputFilePart(part)
 			if err != nil {
 				return false, err
 			}
-			fileText, err := renderDecodedFile(ctx, authHeader, decoded, process)
+			parts, err := renderDecodedFile(ctx, authHeader, decoded, mode, rc, responsesPartShape)
 			if err != nil {
 				return false, err
 			}
-
-			newContent = append(newContent, map[string]any{
-				"type": "input_text",
-				"text": renderFileInputText(decoded.filename, fileText),
-			})
+			newContent = append(newContent, parts...)
 			rewritten = true
 		}
 
@@ -97,15 +126,16 @@ func rewriteChatCompletionsBase64Files(
 	body map[string]any,
 	em *manager.EnclaveManager,
 	authHeader string,
+	modelName string,
 ) (bool, error) {
-	return rewriteChatCompletionsBase64FilesWithProcessor(ctx, body, authHeader, em.ConvertFileToMarkdown)
+	return rewriteChatCompletionsBase64FilesWithProcessor(ctx, body, authHeader, newRewriteContext(em, modelName))
 }
 
 func rewriteChatCompletionsBase64FilesWithProcessor(
 	ctx context.Context,
 	body map[string]any,
 	authHeader string,
-	process fileInputProcessor,
+	rc *rewriteContext,
 ) (bool, error) {
 	messages, ok := body["messages"].([]any)
 	if !ok {
@@ -138,19 +168,15 @@ func rewriteChatCompletionsBase64FilesWithProcessor(
 				continue
 			}
 
-			decoded, err := decodeChatCompletionsFilePart(part)
+			decoded, mode, err := decodeChatCompletionsFilePart(part)
 			if err != nil {
 				return false, err
 			}
-			fileText, err := renderDecodedFile(ctx, authHeader, decoded, process)
+			parts, err := renderDecodedFile(ctx, authHeader, decoded, mode, rc, chatPartShape)
 			if err != nil {
 				return false, err
 			}
-
-			newContent = append(newContent, map[string]any{
-				"type": "text",
-				"text": renderFileInputText(decoded.filename, fileText),
-			})
+			newContent = append(newContent, parts...)
 			rewritten = true
 		}
 
@@ -166,65 +192,209 @@ type decodedFileInput struct {
 	data        []byte
 }
 
-func decodeResponsesInputFilePart(part map[string]any) (*decodedFileInput, error) {
+func decodeResponsesInputFilePart(part map[string]any) (*decodedFileInput, manager.FileConversionMode, error) {
 	filename, _ := part["filename"].(string)
 	if _, hasFileID := part["file_id"]; hasFileID {
-		return nil, &fileInputError{
+		return nil, "", &fileInputError{
 			StatusCode: http.StatusBadRequest,
 			Message:    "Only input_file.file_data is supported on this endpoint.",
 		}
 	}
-
 	fileData, _ := part["file_data"].(string)
 	if fileData == "" {
-		return nil, &fileInputError{
+		return nil, "", &fileInputError{
 			StatusCode: http.StatusBadRequest,
 			Message:    "Missing required parameter: 'file_data' on input_file.",
 		}
 	}
-
-	return decodeFileInput(filename, fileData, "input_file.file_data")
+	mode, err := readTinfoilModeOverride(part)
+	if err != nil {
+		return nil, "", err
+	}
+	decoded, err := decodeFileInput(filename, fileData, "input_file.file_data")
+	if err != nil {
+		return nil, "", err
+	}
+	return decoded, mode, nil
 }
 
-func decodeChatCompletionsFilePart(part map[string]any) (*decodedFileInput, error) {
+func decodeChatCompletionsFilePart(part map[string]any) (*decodedFileInput, manager.FileConversionMode, error) {
 	fileObj, _ := part["file"].(map[string]any)
 	if fileObj == nil {
-		return nil, &fileInputError{
+		return nil, "", &fileInputError{
 			StatusCode: http.StatusBadRequest,
 			Message:    "Missing required parameter: 'file' on file content part.",
 		}
 	}
-
 	filename, _ := fileObj["filename"].(string)
 	if _, hasFileID := fileObj["file_id"]; hasFileID {
-		return nil, &fileInputError{
+		return nil, "", &fileInputError{
 			StatusCode: http.StatusBadRequest,
 			Message:    "Only file.file_data is supported on this endpoint.",
 		}
 	}
-
 	fileData, _ := fileObj["file_data"].(string)
 	if fileData == "" {
-		return nil, &fileInputError{
+		return nil, "", &fileInputError{
 			StatusCode: http.StatusBadRequest,
 			Message:    "Missing required parameter: 'file.file_data'.",
 		}
 	}
+	mode, err := readTinfoilModeOverride(fileObj)
+	if err != nil {
+		return nil, "", err
+	}
+	decoded, err := decodeFileInput(filename, fileData, "file.file_data")
+	if err != nil {
+		return nil, "", err
+	}
+	return decoded, mode, nil
+}
 
-	return decodeFileInput(filename, fileData, "file.file_data")
+// readTinfoilModeOverride consumes the per-file tinfoil_mode field if
+// present so it never leaks upstream to OpenAI-shaped backends.
+func readTinfoilModeOverride(holder map[string]any) (manager.FileConversionMode, error) {
+	raw, ok := holder[tinfoilModeFieldName]
+	if !ok {
+		return "", nil
+	}
+	delete(holder, tinfoilModeFieldName)
+
+	switch v := raw.(type) {
+	case nil:
+		return "", nil
+	case string:
+		mode := manager.FileConversionMode(strings.TrimSpace(strings.ToLower(v)))
+		if mode == "auto" {
+			return "", nil
+		}
+		if !mode.IsValid() {
+			return "", &fileInputError{
+				StatusCode: http.StatusBadRequest,
+				Message:    fmt.Sprintf("Invalid %s value: %q. Valid values are auto, text, vision, images, raw, vlm.", tinfoilModeFieldName, v),
+			}
+		}
+		return mode, nil
+	default:
+		return "", &fileInputError{
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintf("%s must be a string.", tinfoilModeFieldName),
+		}
+	}
+}
+
+// resolveFileMode returns the doc-upload mode to use for a single attachment.
+// The bool reports whether the file is inline text (in which case mode is
+// irrelevant and the data is forwarded as-is).
+func resolveFileMode(
+	decoded *decodedFileInput,
+	override manager.FileConversionMode,
+	rc *rewriteContext,
+) (manager.FileConversionMode, bool, error) {
+	if isInlineTextFile(decoded.filename, decoded.contentType, decoded.data) {
+		return "", true, nil
+	}
+
+	visionCapable := rc.isMultimodal != nil && rc.model != "" && rc.isMultimodal(rc.model)
+
+	if override != "" {
+		if override == manager.FileConversionModeImages && !visionCapable {
+			return "", false, &fileInputError{
+				StatusCode: http.StatusBadRequest,
+				Message:    fmt.Sprintf("%s=images requires a vision-capable model; %q is text-only.", tinfoilModeFieldName, rc.model),
+			}
+		}
+		return override, false, nil
+	}
+
+	if visionCapable {
+		return manager.FileConversionModeImages, false, nil
+	}
+	return manager.FileConversionModeText, false, nil
+}
+
+// partShape captures the OpenAI-style content-part type names a given
+// endpoint uses; the two endpoints differ in textType, imageType, and how
+// the image URL itself is shaped.
+type partShape struct {
+	textType  string
+	imagePart func(url string) map[string]any
+}
+
+var responsesPartShape = partShape{
+	textType: "input_text",
+	imagePart: func(url string) map[string]any {
+		return map[string]any{
+			"type":      "input_image",
+			"image_url": url,
+			"detail":    "auto",
+		}
+	},
+}
+
+var chatPartShape = partShape{
+	textType: "text",
+	imagePart: func(url string) map[string]any {
+		return map[string]any{
+			"type": "image_url",
+			"image_url": map[string]any{
+				"url":    url,
+				"detail": "auto",
+			},
+		}
+	},
 }
 
 func renderDecodedFile(
 	ctx context.Context,
 	authHeader string,
 	decoded *decodedFileInput,
-	process fileInputProcessor,
-) (string, error) {
-	if isInlineTextFile(decoded.filename, decoded.contentType, decoded.data) {
-		return string(decoded.data), nil
+	override manager.FileConversionMode,
+	rc *rewriteContext,
+	shape partShape,
+) ([]any, error) {
+	mode, inlineText, err := resolveFileMode(decoded, override, rc)
+	if err != nil {
+		return nil, err
 	}
 
-	return process(ctx, authHeader, decoded.filename, decoded.contentType, decoded.data)
+	textPart := func(text string) any {
+		return map[string]any{"type": shape.textType, "text": text}
+	}
+
+	if inlineText {
+		return []any{textPart(renderFileInputText(decoded.filename, string(decoded.data)))}, nil
+	}
+
+	result, err := rc.process(ctx, authHeader, decoded.filename, decoded.contentType, decoded.data, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	if mode != manager.FileConversionModeImages {
+		return []any{textPart(renderFileInputText(decoded.filename, result.MDContent))}, nil
+	}
+
+	parts := make([]any, 0, 1+2*len(result.Pages))
+	parts = append(parts, textPart(fmt.Sprintf("[Attached file: %s]", decoded.filename)))
+	for _, p := range result.Pages {
+		parts = append(parts, textPart(renderPageHeader(p)))
+		if p.Image != "" {
+			parts = append(parts, shape.imagePart("data:image/png;base64,"+p.Image))
+		}
+	}
+	return parts, nil
+}
+
+func renderPageHeader(p manager.ConvertedPage) string {
+	label := fmt.Sprintf("Page %d", p.Page)
+	if p.IsScanned {
+		label += " (scanned)"
+	}
+	if strings.TrimSpace(p.Text) == "" {
+		return label + ":"
+	}
+	return label + ":\n" + p.Text
 }
 
 func decodeFileInput(filename string, fileData string, paramName string) (*decodedFileInput, error) {

--- a/responses_file_inputs_test.go
+++ b/responses_file_inputs_test.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"testing"
+
+	"github.com/tinfoilsh/confidential-model-router/manager"
 )
 
-type rewriteRunner func(context.Context, map[string]any, string, fileInputProcessor) (bool, error)
+type rewriteRunner func(context.Context, map[string]any, string, *rewriteContext) (bool, error)
 
 type rewriteTestCase struct {
 	name                string
@@ -17,8 +20,22 @@ type rewriteTestCase struct {
 	buildTextPart       func(text string) any
 	contentParts        func(body map[string]any) []any
 	expectedTextType    string
+	expectedImageType   string
 	expectedFileIDError string
 	expectedFieldName   string
+}
+
+func responsesImagePartURL(part any) string {
+	m, _ := part.(map[string]any)
+	url, _ := m["image_url"].(string)
+	return url
+}
+
+func chatImagePartURL(part any) string {
+	m, _ := part.(map[string]any)
+	inner, _ := m["image_url"].(map[string]any)
+	url, _ := inner["url"].(string)
+	return url
 }
 
 var rewriteTestCases = []rewriteTestCase{
@@ -59,6 +76,7 @@ var rewriteTestCases = []rewriteTestCase{
 			return body["input"].([]any)[0].(map[string]any)["content"].([]any)
 		},
 		expectedTextType:    "input_text",
+		expectedImageType:   "input_image",
 		expectedFileIDError: "Only input_file.file_data is supported on this endpoint.",
 		expectedFieldName:   "input_file.file_data",
 	},
@@ -103,9 +121,43 @@ var rewriteTestCases = []rewriteTestCase{
 			return body["messages"].([]any)[0].(map[string]any)["content"].([]any)
 		},
 		expectedTextType:    "text",
+		expectedImageType:   "image_url",
 		expectedFileIDError: "Only file.file_data is supported on this endpoint.",
 		expectedFieldName:   "file.file_data",
 	},
+}
+
+func newRC(visionCapable bool, process fileInputProcessor) *rewriteContext {
+	return &rewriteContext{
+		isMultimodal: func(string) bool { return visionCapable },
+		model:        "test-model",
+		process:      process,
+	}
+}
+
+func nopProcessor(t *testing.T) fileInputProcessor {
+	t.Helper()
+	return func(context.Context, string, string, string, []byte, manager.FileConversionMode) (*manager.ConvertedFile, error) {
+		t.Fatal("processor should not be called")
+		return nil, nil
+	}
+}
+
+func injectTinfoilMode(part map[string]any, value string) {
+	if file, ok := part["file"].(map[string]any); ok {
+		file[tinfoilModeFieldName] = value
+		return
+	}
+	part[tinfoilModeFieldName] = value
+}
+
+func tinfoilModeFieldLeaked(part map[string]any) bool {
+	if file, ok := part["file"].(map[string]any); ok {
+		_, ok := file[tinfoilModeFieldName]
+		return ok
+	}
+	_, ok := part[tinfoilModeFieldName]
+	return ok
 }
 
 func TestRewriteBase64FilesWithProcessorText(t *testing.T) {
@@ -117,15 +169,7 @@ func TestRewriteBase64FilesWithProcessorText(t *testing.T) {
 				tc.buildTextPart("Summarize it."),
 			)
 
-			rewritten, err := tc.run(
-				context.Background(),
-				body,
-				"Bearer test-key",
-				func(_ context.Context, _, _, _ string, _ []byte) (string, error) {
-					t.Fatal("processor should not be called for text/plain input")
-					return "", nil
-				},
-			)
+			rewritten, err := tc.run(context.Background(), body, "Bearer test-key", newRC(false, nopProcessor(t)))
 			if err != nil {
 				t.Fatalf("rewrite failed: %v", err)
 			}
@@ -146,15 +190,7 @@ func TestRewriteBase64FilesWithProcessorRejectsFileID(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			body := tc.buildBody(tc.buildFileIDPart("file-123"))
 
-			_, err := tc.run(
-				context.Background(),
-				body,
-				"Bearer test-key",
-				func(_ context.Context, _, _, _ string, _ []byte) (string, error) {
-					t.Fatal("processor should not be called")
-					return "", nil
-				},
-			)
+			_, err := tc.run(context.Background(), body, "Bearer test-key", newRC(false, nopProcessor(t)))
 			if err == nil {
 				t.Fatal("expected an error")
 			}
@@ -212,15 +248,7 @@ func TestRewriteBase64FilesUsesContextSpecificDecodeErrors(t *testing.T) {
 				t.Run(test.name, func(t *testing.T) {
 					body := tc.buildBody(tc.buildFileDataPart("notes.txt", test.fileData))
 
-					_, err := tc.run(
-						context.Background(),
-						body,
-						"Bearer test-key",
-						func(_ context.Context, _, _, _ string, _ []byte) (string, error) {
-							t.Fatal("processor should not be called")
-							return "", nil
-						},
-					)
+					_, err := tc.run(context.Background(), body, "Bearer test-key", newRC(false, nopProcessor(t)))
 					if err == nil {
 						t.Fatal("expected an error")
 					}
@@ -242,27 +270,27 @@ func TestRewriteBase64FilesUsesProcessorForBinaryFiles(t *testing.T) {
 			)
 
 			called := false
-			rewritten, err := tc.run(
-				context.Background(),
-				body,
-				"Bearer test-key",
-				func(_ context.Context, authHeader, filename, contentType string, data []byte) (string, error) {
-					called = true
-					if authHeader != "Bearer test-key" {
-						t.Fatalf("expected auth header to be forwarded, got %q", authHeader)
-					}
-					if filename != "scan.pdf" {
-						t.Fatalf("expected scan.pdf, got %q", filename)
-					}
-					if contentType != "application/pdf" {
-						t.Fatalf("expected application/pdf, got %q", contentType)
-					}
-					if string(data) != "%PDF" {
-						t.Fatalf("unexpected payload: %q", string(data))
-					}
-					return "converted markdown", nil
-				},
-			)
+			rc := newRC(false, func(_ context.Context, authHeader, filename, contentType string, data []byte, mode manager.FileConversionMode) (*manager.ConvertedFile, error) {
+				called = true
+				if authHeader != "Bearer test-key" {
+					t.Fatalf("expected auth header to be forwarded, got %q", authHeader)
+				}
+				if filename != "scan.pdf" {
+					t.Fatalf("expected scan.pdf, got %q", filename)
+				}
+				if contentType != "application/pdf" {
+					t.Fatalf("expected application/pdf, got %q", contentType)
+				}
+				if string(data) != "%PDF" {
+					t.Fatalf("unexpected payload: %q", string(data))
+				}
+				if mode != manager.FileConversionModeText {
+					t.Fatalf("expected default text mode for non-multimodal model, got %q", mode)
+				}
+				return &manager.ConvertedFile{MDContent: "converted markdown"}, nil
+			})
+
+			rewritten, err := tc.run(context.Background(), body, "Bearer test-key", rc)
 			if err != nil {
 				t.Fatalf("rewrite failed: %v", err)
 			}
@@ -275,6 +303,127 @@ func TestRewriteBase64FilesUsesProcessorForBinaryFiles(t *testing.T) {
 
 			content := tc.contentParts(body)
 			assertTextPart(t, content[0], tc.expectedTextType, "[Attached file: scan.pdf]\n\nconverted markdown")
+		})
+	}
+}
+
+func TestRewriteBase64FilesHonorsTinfoilModeOverride(t *testing.T) {
+	for _, tc := range rewriteTestCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			part := tc.buildFileDataPart("scan.pdf", "data:application/pdf;base64,"+base64.StdEncoding.EncodeToString([]byte("%PDF"))).(map[string]any)
+			injectTinfoilMode(part, "vlm")
+			body := tc.buildBody(part)
+
+			seen := manager.FileConversionMode("")
+			rc := newRC(false, func(_ context.Context, _, _, _ string, _ []byte, mode manager.FileConversionMode) (*manager.ConvertedFile, error) {
+				seen = mode
+				return &manager.ConvertedFile{MDContent: "ocr text"}, nil
+			})
+
+			if _, err := tc.run(context.Background(), body, "Bearer test-key", rc); err != nil {
+				t.Fatalf("rewrite failed: %v", err)
+			}
+			if seen != manager.FileConversionModeVLM {
+				t.Fatalf("expected vlm mode to reach processor, got %q", seen)
+			}
+			if tinfoilModeFieldLeaked(part) {
+				t.Fatal("tinfoil_mode leaked into outgoing body")
+			}
+		})
+	}
+}
+
+func TestRewriteBase64FilesRejectsImagesModeOnTextOnlyModel(t *testing.T) {
+	for _, tc := range rewriteTestCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			part := tc.buildFileDataPart("scan.pdf", "data:application/pdf;base64,"+base64.StdEncoding.EncodeToString([]byte("%PDF"))).(map[string]any)
+			injectTinfoilMode(part, "images")
+			body := tc.buildBody(part)
+
+			_, err := tc.run(context.Background(), body, "Bearer test-key", newRC(false, nopProcessor(t)))
+			if err == nil {
+				t.Fatal("expected images-on-text-only to error")
+			}
+			var inputErr *fileInputError
+			if !errors.As(err, &inputErr) {
+				t.Fatalf("expected fileInputError, got %T", err)
+			}
+			if inputErr.StatusCode != 400 {
+				t.Fatalf("expected status 400, got %d", inputErr.StatusCode)
+			}
+		})
+	}
+}
+
+func TestRewriteBase64FilesRejectsUnknownTinfoilMode(t *testing.T) {
+	for _, tc := range rewriteTestCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			part := tc.buildFileDataPart("scan.pdf", "data:application/pdf;base64,"+base64.StdEncoding.EncodeToString([]byte("%PDF"))).(map[string]any)
+			injectTinfoilMode(part, "supercharged")
+			body := tc.buildBody(part)
+
+			_, err := tc.run(context.Background(), body, "Bearer test-key", newRC(false, nopProcessor(t)))
+			if err == nil {
+				t.Fatal("expected unknown tinfoil_mode to error")
+			}
+			var inputErr *fileInputError
+			if !errors.As(err, &inputErr) {
+				t.Fatalf("expected fileInputError, got %T", err)
+			}
+			if inputErr.StatusCode != 400 {
+				t.Fatalf("expected status 400, got %d", inputErr.StatusCode)
+			}
+		})
+	}
+}
+
+func TestRewriteBase64FilesEmitsMultimodalContentForImagesMode(t *testing.T) {
+	for _, tc := range rewriteTestCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			part := tc.buildFileDataPart("doc.pdf", "data:application/pdf;base64,"+base64.StdEncoding.EncodeToString([]byte("%PDF"))).(map[string]any)
+			injectTinfoilMode(part, "images")
+			body := tc.buildBody(part)
+
+			rc := newRC(true, func(_ context.Context, _, _, _ string, _ []byte, mode manager.FileConversionMode) (*manager.ConvertedFile, error) {
+				if mode != manager.FileConversionModeImages {
+					t.Fatalf("expected images mode, got %q", mode)
+				}
+				return &manager.ConvertedFile{
+					Pages: []manager.ConvertedPage{
+						{Page: 1, Text: "page one text", Image: "AAA="},
+						{Page: 2, IsScanned: true, Image: "BBB="},
+					},
+				}, nil
+			})
+
+			if _, err := tc.run(context.Background(), body, "Bearer test-key", rc); err != nil {
+				t.Fatalf("rewrite failed: %v", err)
+			}
+
+			parts := tc.contentParts(body)
+			if len(parts) != 5 {
+				t.Fatalf("expected file header + 2*(text+image) = 5 parts, got %d", len(parts))
+			}
+			assertTextPart(t, parts[0], tc.expectedTextType, "[Attached file: doc.pdf]")
+			assertTextPart(t, parts[1], tc.expectedTextType, "Page 1:\npage one text")
+			assertPartType(t, parts[2], tc.expectedImageType)
+			assertTextPart(t, parts[3], tc.expectedTextType, "Page 2 (scanned):")
+			assertPartType(t, parts[4], tc.expectedImageType)
+
+			urlGetter := responsesImagePartURL
+			if tc.name == "chat_completions" {
+				urlGetter = chatImagePartURL
+			}
+			if got := urlGetter(parts[2]); got != "data:image/png;base64,AAA=" {
+				t.Fatalf("page 1 image url = %q", got)
+			}
+			if got := urlGetter(parts[4]); got != "data:image/png;base64,BBB=" {
+				t.Fatalf("page 2 image url = %q", got)
+			}
 		})
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
PDF base64 attachments now pick the right conversion mode per model: text for text‑only models and page images for vision‑capable chat models, with an optional per‑file override. Multimodal model detection is cached and refreshed in the background so requests never block.

- **New Features**
  - Auto-selects conversion:
    - Multimodal chat models → `images` (page images + text headers).
    - Text‑only models → `text` (markdown).
  - Per-file override via `tinfoil_mode` (`auto`, `text`, `vision`, `images`, `raw`, `vlm`); validated, stripped before forwarding, and rejects `images` on text‑only models.
  - Emits correct content parts:
    - `/v1/responses`: `input_text` and `input_image` with `image_url`.
    - `/v1/chat/completions`: `text` and `image_url` objects.
    - Adds a file header and per‑page headers; marks scanned pages.
  - Mode‑aware doc conversion:
    - Sends `?mode=` to the `doc-upload` backend.
    - Parses pages/images in `images` mode and enforces non‑empty pages.
  - Multimodal metadata:
    - Fetched from the control plane, restricted to chat‑shaped models.
    - Stored in a sticky cache and refreshed asynchronously (non‑blocking).

- **Migration**
  - No action needed. If you relied on PDFs always producing a single text blob for multimodal models, update consumers to handle image parts or set `tinfoil_mode: "text"` per file.

<sup>Written for commit 6151fc1140e665eead61ffe826e498dfef1952c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

