### PR TITLE
Refactor: make billing reporting more general

### DIFF
--- a/billing/events.go
+++ b/billing/events.go
@@ -79,6 +79,12 @@ func (c *Collector) AddEvent(event Event) {
 	}
 
 	if c.reporter != nil {
+		inputTokens := int64(event.PromptTokens)
+		outputTokens := int64(event.CompletionTokens)
+		if inputTokens == 0 && outputTokens == 0 && event.TotalTokens > 0 {
+			inputTokens = int64(event.TotalTokens)
+		}
+
 		c.reporter.AddEvent(contract.Event{
 			RequestID:  event.RequestID,
 			OccurredAt: event.Timestamp,
@@ -89,8 +95,8 @@ func (c *Collector) AddEvent(event Event) {
 			},
 			CustomerRequests: 1,
 			Meters: []contract.Meter{
-				{Name: contract.MeterInputTokens, Quantity: int64(event.PromptTokens)},
-				{Name: contract.MeterOutputTokens, Quantity: int64(event.CompletionTokens)},
+				{Name: contract.MeterInputTokens, Quantity: inputTokens},
+				{Name: contract.MeterOutputTokens, Quantity: outputTokens},
 			},
 			Attributes: map[string]string{
 				"model":     event.Model,

--- a/billing/events.go
+++ b/billing/events.go
@@ -47,10 +47,8 @@ func maskAPIKey(apiKey string) string {
 
 // NewCollector creates a new billing event collector.
 //
-// Events are delivered to the signed /api/internal/usage-reports ingestion
-// endpoint. The legacy [DEPRECATED] /api/shim/collect-shadow path must never
-// be used from the router: it is unauthenticated and scheduled for removal
-// once tfshim is migrated off it.
+// Events are delivered to the signed usage-reports ingestion endpoint
+// using the shared usage-reporting client.
 func NewCollector(controlPlaneURL, reporterID, reporterSecret string) *Collector {
 	endpoint := ""
 	if controlPlaneURL != "" {

--- a/billing/events.go
+++ b/billing/events.go
@@ -54,17 +54,14 @@ func maskAPIKey(apiKey string) string {
 func NewCollector(controlPlaneURL, reporterID, reporterSecret string) *Collector {
 	endpoint := ""
 	if controlPlaneURL != "" {
-		endpoint = strings.TrimRight(controlPlaneURL, "/") + "/api/internal/usage-reports"
+		endpoint = strings.TrimRight(controlPlaneURL, "/") + contract.IngestionPath
 	}
 
 	c := &Collector{
 		reporter: usageclient.New(usageclient.Config{
-			Endpoint: endpoint,
-			Reporter: contract.Reporter{
-				ID:      reporterID,
-				Service: "router",
-			},
-			Secret: reporterSecret,
+			Endpoint:   endpoint,
+			ReporterID: reporterID,
+			Secret:     reporterSecret,
 		}),
 	}
 	return c
@@ -89,13 +86,13 @@ func (c *Collector) AddEvent(event Event) {
 			OccurredAt: event.Timestamp,
 			APIKey:     event.APIKey,
 			Operation: contract.Operation{
-				Service: "router",
-				Name:    "model_request",
+				Service: contract.ServiceRouter,
+				Name:    contract.OperationRouterModelRequest,
 			},
+			CustomerRequests: 1,
 			Meters: []contract.Meter{
-				{Name: "input_tokens", Quantity: int64(event.PromptTokens)},
-				{Name: "output_tokens", Quantity: int64(event.CompletionTokens)},
-				{Name: "requests", Quantity: 1},
+				{Name: contract.MeterInputTokens, Quantity: int64(event.PromptTokens)},
+				{Name: contract.MeterOutputTokens, Quantity: int64(event.CompletionTokens)},
 			},
 			Attributes: map[string]string{
 				"model":     event.Model,
@@ -116,7 +113,7 @@ func (c *Collector) AddEvent(event Event) {
 func (c *Collector) Stop() {
 	c.stopOnce.Do(func() {
 		if c.reporter != nil {
-			_ = c.reporter.Stop(context.Background())
+			c.reporter.Stop(context.Background())
 		}
 	})
 }

--- a/billing/events_test.go
+++ b/billing/events_test.go
@@ -1,0 +1,94 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tinfoilsh/usage-reporting-go/contract"
+)
+
+// TestCollectorEmitsCustomerRequestAndTokenMeters verifies that a billing
+// event flushed through the reporter carries CustomerRequests=1 and exactly
+// the canonical input/output token meters (no requests meter).
+func TestCollectorEmitsCustomerRequestAndTokenMeters(t *testing.T) {
+	bodies := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		bodies <- buf
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := NewCollector(server.URL, "router-test", "test-secret")
+	defer c.Stop()
+
+	c.AddEvent(Event{
+		Timestamp:        time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		Model:            "gpt-oss-120b",
+		PromptTokens:     11,
+		CompletionTokens: 7,
+		TotalTokens:      18,
+		RequestID:        "req-1",
+		Enclave:          "enclave-1",
+		RequestPath:      "/v1/chat/completions",
+		Streaming:        true,
+		APIKey:           "sk-test-1234567890",
+	})
+
+	c.reporter.Flush(context.Background())
+
+	var body []byte
+	select {
+	case body = <-bodies:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for billing event delivery")
+	}
+
+	var batch contract.Batch
+	if err := json.Unmarshal(body, &batch); err != nil {
+		t.Fatalf("decode batch: %v", err)
+	}
+	if len(batch.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(batch.Events))
+	}
+	got := batch.Events[0]
+
+	if got.Operation.Service != contract.ServiceRouter {
+		t.Errorf("service mismatch: got %q want %q", got.Operation.Service, contract.ServiceRouter)
+	}
+	if got.Operation.Name != contract.OperationRouterModelRequest {
+		t.Errorf("operation mismatch: got %q want %q", got.Operation.Name, contract.OperationRouterModelRequest)
+	}
+	if got.CustomerRequests != 1 {
+		t.Errorf("customer requests mismatch: got %d want 1", got.CustomerRequests)
+	}
+
+	meters := make(map[string]int64)
+	for _, m := range got.Meters {
+		meters[m.Name] = m.Quantity
+	}
+	if meters[contract.MeterInputTokens] != 11 {
+		t.Errorf("input_tokens mismatch: got %d want 11", meters[contract.MeterInputTokens])
+	}
+	if meters[contract.MeterOutputTokens] != 7 {
+		t.Errorf("output_tokens mismatch: got %d want 7", meters[contract.MeterOutputTokens])
+	}
+	if _, hasRequestsMeter := meters["requests"]; hasRequestsMeter {
+		t.Errorf("billing event should not emit a requests meter; got %+v", meters)
+	}
+
+	if got.Attributes["model"] != "gpt-oss-120b" {
+		t.Errorf("model attribute mismatch: got %q", got.Attributes["model"])
+	}
+	if got.Attributes["streaming"] != "true" {
+		t.Errorf("streaming attribute mismatch: got %q", got.Attributes["streaming"])
+	}
+}

--- a/billing/events_test.go
+++ b/billing/events_test.go
@@ -92,3 +92,55 @@ func TestCollectorEmitsCustomerRequestAndTokenMeters(t *testing.T) {
 		t.Errorf("streaming attribute mismatch: got %q", got.Attributes["streaming"])
 	}
 }
+
+func TestCollectorFallsBackToTotalTokensWhenSplitMissing(t *testing.T) {
+	bodies := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		bodies <- buf
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := NewCollector(server.URL, "router-test", "test-secret")
+	defer c.Stop()
+
+	c.AddEvent(Event{
+		Timestamp:   time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		Model:       "gpt-oss-120b",
+		TotalTokens: 18,
+		RequestID:   "req-1",
+		APIKey:      "tk_test",
+	})
+
+	c.reporter.Flush(context.Background())
+
+	var body []byte
+	select {
+	case body = <-bodies:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for billing event delivery")
+	}
+
+	var batch contract.Batch
+	if err := json.Unmarshal(body, &batch); err != nil {
+		t.Fatalf("decode batch: %v", err)
+	}
+	if len(batch.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(batch.Events))
+	}
+
+	meters := make(map[string]int64)
+	for _, m := range batch.Events[0].Meters {
+		meters[m.Name] = m.Quantity
+	}
+	if meters[contract.MeterInputTokens] != 18 {
+		t.Errorf("input_tokens mismatch: got %d want 18", meters[contract.MeterInputTokens])
+	}
+	if meters[contract.MeterOutputTokens] != 0 {
+		t.Errorf("output_tokens mismatch: got %d want 0", meters[contract.MeterOutputTokens])
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/tinfoilsh/tinfoil-go v0.12.7
-	github.com/tinfoilsh/usage-reporting-go v0.1.0
+	github.com/tinfoilsh/usage-reporting-go v0.1.1
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/tinfoilsh/tinfoil-go v0.12.7
-	github.com/tinfoilsh/usage-reporting-go v0.0.3
+	github.com/tinfoilsh/usage-reporting-go v0.1.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/theupdateframework/go-tuf/v2 v2.4.1 h1:K6ewW064rKZCPkRo1W/CTbTtm/+IB4
 github.com/theupdateframework/go-tuf/v2 v2.4.1/go.mod h1:Nex2enPVYDFCklrnbTzl3OVwD7fgIAj0J5++z/rvCj8=
 github.com/tinfoilsh/tinfoil-go v0.12.7 h1:l2d2waMdbt+61yOTlcBhIU2eXD74GtifN0Svpm2kZIE=
 github.com/tinfoilsh/tinfoil-go v0.12.7/go.mod h1:i503zVkJKaFfJ2aHIUM8E5dAFbXSMw3MkiWryKGTTs8=
-github.com/tinfoilsh/usage-reporting-go v0.0.3 h1:ZWounmAxGp1fJ+6WYgfJ/+ordX74n7lHYGEI7NggXsU=
-github.com/tinfoilsh/usage-reporting-go v0.0.3/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
+github.com/tinfoilsh/usage-reporting-go v0.1.0 h1:7Q/GsJ5mYfHtOFd3RfA//RltgahVJHsUybl4lN4M8J4=
+github.com/tinfoilsh/usage-reporting-go v0.1.0/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=

--- a/go.sum
+++ b/go.sum
@@ -333,6 +333,8 @@ github.com/tinfoilsh/tinfoil-go v0.12.7 h1:l2d2waMdbt+61yOTlcBhIU2eXD74GtifN0Svp
 github.com/tinfoilsh/tinfoil-go v0.12.7/go.mod h1:i503zVkJKaFfJ2aHIUM8E5dAFbXSMw3MkiWryKGTTs8=
 github.com/tinfoilsh/usage-reporting-go v0.1.0 h1:7Q/GsJ5mYfHtOFd3RfA//RltgahVJHsUybl4lN4M8J4=
 github.com/tinfoilsh/usage-reporting-go v0.1.0/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
+github.com/tinfoilsh/usage-reporting-go v0.1.1 h1:Mf1scGCjTGgf+fRF4HT4/LitEq0q/6Y9oCngUVhpvkk=
+github.com/tinfoilsh/usage-reporting-go v0.1.1/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=

--- a/local_testing.md
+++ b/local_testing.md
@@ -79,6 +79,7 @@ DOMAIN=localhost \
 INIT_CONFIG_URL="/tmp/model-router-local.yml@sha256:<sha-from-step-2>" \
 UPDATE_CONFIG_URL=/tmp/model-router-local.yml \
 USAGE_REPORTER_SECRET=test-secret \
+USAGE_CONTEXT_SECRET=test-context-secret \
 go run -tags toolruntime_debug .
 ```
 

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ var (
 	controlPlaneURL     = flag.String("C", getEnvOrDefault("CONTROL_PLANE_URL", "https://api.tinfoil.sh"), "control plane URL (env: CONTROL_PLANE_URL)")
 	usageReporterID     = flag.String("usage-reporter-id", getEnvOrDefault("USAGE_REPORTER_ID", "model-router"), "usage reporter ID (env: USAGE_REPORTER_ID)")
 	usageReporterSecret = flag.String("usage-reporter-secret", getEnvOrDefault("USAGE_REPORTER_SECRET", ""), "usage reporter HMAC secret (env: USAGE_REPORTER_SECRET)")
+	usageContextSecret  = flag.String("usage-context-secret", getEnvOrDefault("USAGE_CONTEXT_SECRET", ""), "usage-context HMAC secret used to sign request-context propagated to tool services (env: USAGE_CONTEXT_SECRET)")
 	verbose             = flag.Bool("v", getEnvBool("VERBOSE"), "enable verbose logging (env: VERBOSE)")
 	initConfigURL       = flag.String("i", getEnvOrDefault("INIT_CONFIG_URL", ""), "optional path to initial config.yml (requires to append @sha256:<hex> for integrity) (env: INIT_CONFIG_URL)")
 	updateConfigURL     = flag.String("u", getEnvOrDefault("UPDATE_CONFIG_URL", "https://raw.githubusercontent.com/tinfoilsh/confidential-model-router/main/config.yml"), "path to runtime config.yml (env: UPDATE_CONFIG_URL)")
@@ -271,8 +272,11 @@ func main() {
 	if *usageReporterSecret == "" {
 		log.Fatal("USAGE_REPORTER_SECRET is required")
 	}
+	if *usageContextSecret == "" {
+		log.Fatal("USAGE_CONTEXT_SECRET is required")
+	}
 
-	em, err := manager.NewEnclaveManager(configFile, *controlPlaneURL, *usageReporterID, *usageReporterSecret, *initConfigURL, *updateConfigURL, *refreshInterval)
+	em, err := manager.NewEnclaveManager(configFile, *controlPlaneURL, *usageReporterID, *usageReporterSecret, *usageContextSecret, *initConfigURL, *updateConfigURL, *refreshInterval)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -53,6 +53,7 @@ type EnclaveManager struct {
 	controlPlaneURL      string
 	sigstoreClient       *sigstore.Client
 	billingCollector     *billing.Collector
+	usageContextSecret   string
 	requestTracker       *ratelimit.RequestTracker
 	refreshInterval      time.Duration
 	stateMu              sync.Mutex
@@ -99,6 +100,13 @@ func (em *EnclaveManager) AddBillingEvent(event billing.Event) {
 	if em.billingCollector != nil {
 		em.billingCollector.AddEvent(event)
 	}
+}
+
+// UsageContextSecret returns the HMAC secret used to sign usage-context
+// headers attached to outbound MCP tool calls. The empty string means no
+// signing should be attempted.
+func (em *EnclaveManager) UsageContextSecret() string {
+	return em.usageContextSecret
 }
 
 // GetRateLimitConfig returns the rate limit config for a model, or nil if not configured.
@@ -399,7 +407,7 @@ func (e *Enclave) String() string {
 }
 
 // NewEnclaveManager loads model repos from the local config file (not remote) into the enclave manager
-func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterID string, usageReporterSecret string, initConfigURL string, updateConfigURL string, refreshInterval time.Duration) (*EnclaveManager, error) {
+func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterID string, usageReporterSecret string, usageContextSecret string, initConfigURL string, updateConfigURL string, refreshInterval time.Duration) (*EnclaveManager, error) {
 	if refreshInterval <= 0 {
 		return nil, fmt.Errorf("refresh interval must be positive, got %v", refreshInterval)
 	}
@@ -421,14 +429,15 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterI
 	}
 
 	em := &EnclaveManager{
-		models:           &sync.Map{},
-		initConfigURL:    initConfigURL,
-		updateConfigURL:  updateConfigURL,
-		controlPlaneURL:  controlPlaneURL,
-		sigstoreClient:   sigstoreClient,
-		billingCollector: billing.NewCollector(controlPlaneURL, usageReporterID, usageReporterSecret),
-		requestTracker:   ratelimit.NewRequestTracker(),
-		refreshInterval:  refreshInterval,
+		models:             &sync.Map{},
+		initConfigURL:      initConfigURL,
+		updateConfigURL:    updateConfigURL,
+		controlPlaneURL:    controlPlaneURL,
+		sigstoreClient:     sigstoreClient,
+		billingCollector:   billing.NewCollector(controlPlaneURL, usageReporterID, usageReporterSecret),
+		usageContextSecret: usageContextSecret,
+		requestTracker:     ratelimit.NewRequestTracker(),
+		refreshInterval:    refreshInterval,
 	}
 
 	for modelName, modelConfig := range cfg.Models {

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -13,6 +13,7 @@ containers:
       - CONTROL_PLANE_URL: "https://api.tinfoil.sh"
     secrets:
       - USAGE_REPORTER_SECRET
+      - USAGE_CONTEXT_SECRET
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8089/health"]
       interval: 30s

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -18,6 +18,8 @@ import (
 	"github.com/tinfoilsh/confidential-model-router/tokencount"
 	"github.com/tinfoilsh/confidential-model-router/toolcontext"
 	"github.com/tinfoilsh/confidential-model-router/toolprofile"
+	"github.com/tinfoilsh/usage-reporting-go/contract"
+	"github.com/tinfoilsh/usage-reporting-go/usagecontext"
 )
 
 // ---------------------------------------------------------------------------
@@ -190,6 +192,28 @@ func connectToolSession(ctx context.Context, em *manager.EnclaveManager, profile
 		requestID = uuid.NewString()
 	}
 
+	headers, err := toolSessionHeaders(r, requestID, modelName, body, safety, em.UsageContextSecret(), time.Now)
+	if err != nil {
+		return nil, err
+	}
+	httpClient.Transport = &headerRoundTripper{
+		base:    httpClient.Transport,
+		headers: headers,
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "router-tool-runtime", Version: "v1"}, nil)
+	return client.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint:   endpoint,
+		HTTPClient: httpClient,
+	}, nil)
+}
+
+// toolSessionHeaders builds the per-request HTTP headers attached to an
+// outbound MCP tool session. When usageContextSecret is set, it also signs a
+// usage-context header carrying BillCustomerRequest=false so the downstream
+// tool service treats the call as part of the router's already-counted
+// customer request and does not double-bill it.
+func toolSessionHeaders(r *http.Request, requestID, modelName string, body map[string]any, safety safetyOptIns, usageContextSecret string, now func() time.Time) (http.Header, error) {
 	headers := make(http.Header)
 	headers.Set(toolcontext.HeaderRequestID, requestID)
 	headers.Set(toolcontext.HeaderModel, modelName)
@@ -204,16 +228,17 @@ func connectToolSession(ctx context.Context, em *manager.EnclaveManager, profile
 	if auth := r.Header.Get("Authorization"); auth != "" {
 		headers.Set("Authorization", auth)
 	}
-	httpClient.Transport = &headerRoundTripper{
-		base:    httpClient.Transport,
-		headers: headers,
+	if usageContextSecret != "" {
+		if err := usagecontext.SetHeaders(headers, usagecontext.Context{
+			RootRequestID:       requestID,
+			ParentService:       contract.ServiceRouter,
+			BillCustomerRequest: false,
+			IssuedAt:            now().UTC(),
+		}, usageContextSecret); err != nil {
+			return nil, fmt.Errorf("sign tool usage context: %w", err)
+		}
 	}
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "router-tool-runtime", Version: "v1"}, nil)
-	return client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint:   endpoint,
-		HTTPClient: httpClient,
-	}, nil)
+	return headers, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -225,13 +225,20 @@ func toolSessionHeaders(r *http.Request, requestID, modelName string, body map[s
 	if safety.injection != nil {
 		headers.Set(toolcontext.HeaderInjectionCheck, strconv.FormatBool(*safety.injection))
 	}
+	apiKey := ""
 	if auth := r.Header.Get("Authorization"); auth != "" {
 		headers.Set("Authorization", auth)
+		if strings.HasPrefix(auth, "Bearer ") {
+			apiKey = strings.TrimSpace(strings.TrimPrefix(auth, "Bearer "))
+		}
 	}
 	if usageContextSecret != "" {
 		if err := usagecontext.SetHeaders(headers, usagecontext.Context{
+			ContextID:           requestID,
 			RootRequestID:       requestID,
 			ParentService:       contract.ServiceRouter,
+			APIKeyHash:          usagecontext.HashAPIKey(apiKey),
+			Depth:               1,
 			BillCustomerRequest: false,
 			IssuedAt:            now().UTC(),
 		}, usageContextSecret); err != nil {

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -906,6 +906,7 @@ func TestToolSessionHeadersSignsUsageContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
+	req.Header.Set("Authorization", "Bearer tk_test")
 
 	headers, err := toolSessionHeaders(req, "req-1", "gpt-oss-120b", map[string]any{}, safetyOptIns{}, secret, func() time.Time { return now })
 	if err != nil {
@@ -922,8 +923,17 @@ func TestToolSessionHeadersSignsUsageContext(t *testing.T) {
 	if got.RootRequestID != "req-1" {
 		t.Fatalf("root request id mismatch: got %q want req-1", got.RootRequestID)
 	}
+	if got.ContextID != "req-1" {
+		t.Fatalf("context id mismatch: got %q want req-1", got.ContextID)
+	}
 	if got.ParentService != contract.ServiceRouter {
 		t.Fatalf("parent service mismatch: got %q want %q", got.ParentService, contract.ServiceRouter)
+	}
+	if !usagecontext.VerifyAPIKeyHash("tk_test", got.APIKeyHash) {
+		t.Fatalf("api key hash does not match forwarded authorization")
+	}
+	if got.Depth != 1 {
+		t.Fatalf("depth mismatch: got %d want 1", got.Depth)
 	}
 	if got.BillCustomerRequest {
 		t.Fatal("router-fanned-out tool calls must set BillCustomerRequest=false")

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -9,11 +9,14 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tinfoilsh/confidential-model-router/manager"
 	"github.com/tinfoilsh/confidential-model-router/tokencount"
 	"github.com/tinfoilsh/confidential-model-router/toolruntime/citations"
+	"github.com/tinfoilsh/usage-reporting-go/contract"
+	"github.com/tinfoilsh/usage-reporting-go/usagecontext"
 )
 
 func TestReplaceRouterOwnedResponsesTools(t *testing.T) {
@@ -889,5 +892,61 @@ func TestChatAdapterStripRouterToolCallsPreservesUnparseableEntries(t *testing.T
 	}
 	if stringValue(choice["finish_reason"]) != "tool_calls" {
 		t.Fatalf("expected finish_reason normalized to tool_calls, got %#v", choice["finish_reason"])
+	}
+}
+
+// TestToolSessionHeadersSignsUsageContext asserts that outbound MCP tool
+// session headers carry a usage-context signed with BillCustomerRequest=false
+// and ParentService=router, so downstream tool services do not re-bill the
+// customer request the router has already counted.
+func TestToolSessionHeadersSignsUsageContext(t *testing.T) {
+	const secret = "tool-session-secret"
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	req, err := http.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	headers, err := toolSessionHeaders(req, "req-1", "gpt-oss-120b", map[string]any{}, safetyOptIns{}, secret, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("build tool session headers: %v", err)
+	}
+
+	got, ok, err := usagecontext.FromHeaders(headers, secret, now, time.Minute)
+	if err != nil {
+		t.Fatalf("parse usage context: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected signed usage context to be present")
+	}
+	if got.RootRequestID != "req-1" {
+		t.Fatalf("root request id mismatch: got %q want req-1", got.RootRequestID)
+	}
+	if got.ParentService != contract.ServiceRouter {
+		t.Fatalf("parent service mismatch: got %q want %q", got.ParentService, contract.ServiceRouter)
+	}
+	if got.BillCustomerRequest {
+		t.Fatal("router-fanned-out tool calls must set BillCustomerRequest=false")
+	}
+}
+
+// TestToolSessionHeadersOmitsUsageContextWhenSecretEmpty guards against the
+// router silently signing tool sessions with an empty secret if startup
+// validation is bypassed in tests; the helper must skip signing rather than
+// produce a zero-secret HMAC.
+func TestToolSessionHeadersOmitsUsageContextWhenSecretEmpty(t *testing.T) {
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	req, err := http.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	headers, err := toolSessionHeaders(req, "req-1", "gpt-oss-120b", map[string]any{}, safetyOptIns{}, "", func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("build tool session headers: %v", err)
+	}
+
+	if _, ok, err := usagecontext.FromHeaders(headers, "irrelevant", now, time.Minute); err != nil || ok {
+		t.Fatalf("expected no usage context when secret is empty (ok=%v err=%v)", ok, err)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Generalizes billing to `github.com/tinfoilsh/usage-reporting-go` v0.1.1, preserves total-only token counts, and signs usage context on MCP tool calls to prevent double billing.

- **New Features**
  - Use `contract.IngestionPath` and v0.1.1 `contract` constants; standardized names and removed the deprecated proxy path.
  - Emit `CustomerRequests=1` and only token meters (`input_tokens`, `output_tokens`); fall back to `total_tokens` when split counts are missing; removed the `requests` meter.
  - Sign usage-context headers on MCP tool sessions (`ParentService=router`, `BillCustomerRequest=false`, `Depth=1`, `RootRequestID=requestID`, `APIKeyHash` of the caller); skip signing if the secret is empty; manager exposes `UsageContextSecret()`.

- **Migration**
  - Set `USAGE_CONTEXT_SECRET` (or `-usage-context-secret`) and add it to container secrets; the router now requires it.

<sup>Written for commit 4d114b723ae04e6f6c6d69e0f37f20b191f01782. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

