### PR TITLE
chore: add rate limit and overload configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -77,6 +77,11 @@ models:
     repo: tinfoilsh/confidential-kimi-k2-6
     enclaves:
       - kimi-k2-6-inf10.tinfoil.containers.tinfoil.dev
+    rate_limit:
+      max_requests_per_minute: 4
+    overload:
+      max_requests_waiting: 16
+      retry_after_minutes: 1
 
   websearch:
     repo: tinfoilsh/confidential-websearch


### PR DESCRIPTION
Add rate limit and overload settings for kimi-k2-6.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added rate limiting and overload backoff for `kimi-k2-6` to protect capacity and reduce queue spikes. Config sets 4 requests/min, max 16 waiting, and a 1-minute retry-after.

<sup>Written for commit 2086bf596a9cd67535e911ea5f5f6df283f9bd4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

