### PR TITLE
fix: bill oversized usage responses

### DIFF
--- a/manager/json_usage_extractor.go
+++ b/manager/json_usage_extractor.go
@@ -1,0 +1,271 @@
+package manager
+
+import (
+	"encoding/json"
+	"io"
+	"strconv"
+	"sync"
+
+	"github.com/tinfoilsh/confidential-model-router/tokencount"
+)
+
+const (
+	maxJSONKeyBytes   = 256
+	maxUsageJSONBytes = 64 << 10
+)
+
+type streamingJSONUsageReadCloser struct {
+	reader       io.Reader
+	body         io.ReadCloser
+	extractor    *topLevelUsageExtractor
+	usageHandler func(*tokencount.Usage)
+	once         sync.Once
+	closeErr     error
+}
+
+func newStreamingJSONUsageReadCloser(body io.ReadCloser, usageHandler func(*tokencount.Usage)) io.ReadCloser {
+	extractor := &topLevelUsageExtractor{}
+	return &streamingJSONUsageReadCloser{
+		reader:       io.TeeReader(body, extractor),
+		body:         body,
+		extractor:    extractor,
+		usageHandler: usageHandler,
+	}
+}
+
+func (r *streamingJSONUsageReadCloser) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+func (r *streamingJSONUsageReadCloser) Close() error {
+	r.once.Do(func() {
+		r.closeErr = r.body.Close()
+		if usage := r.extractor.Usage(); usage != nil && r.usageHandler != nil {
+			r.usageHandler(usage)
+		}
+	})
+	return r.closeErr
+}
+
+type topLevelUsageExtractor struct {
+	depth int
+
+	inString   bool
+	escaped    bool
+	readingKey bool
+
+	expectingKey       bool
+	awaitingUsageColon bool
+	awaitingUsageValue bool
+
+	keyBuf      []byte
+	keyTooLarge bool
+
+	capturingUsage bool
+	usageDepth     int
+	usageInString  bool
+	usageEscaped   bool
+	usageBuf       []byte
+	usageTooLarge  bool
+
+	done  bool
+	usage *tokencount.Usage
+}
+
+func (e *topLevelUsageExtractor) Write(p []byte) (int, error) {
+	for _, c := range p {
+		e.consume(c)
+	}
+	return len(p), nil
+}
+
+func (e *topLevelUsageExtractor) Usage() *tokencount.Usage {
+	return e.usage
+}
+
+func (e *topLevelUsageExtractor) consume(c byte) {
+	if e.done {
+		return
+	}
+	if e.capturingUsage {
+		e.consumeUsageByte(c)
+		return
+	}
+	if e.inString {
+		e.consumeStringByte(c)
+		return
+	}
+	if e.awaitingUsageValue {
+		if isJSONSpace(c) {
+			return
+		}
+		if c == '{' {
+			e.startUsageCapture(c)
+			return
+		}
+		e.done = true
+		return
+	}
+	if e.awaitingUsageColon {
+		if isJSONSpace(c) {
+			return
+		}
+		if c == ':' {
+			e.awaitingUsageColon = false
+			e.awaitingUsageValue = true
+			return
+		}
+		e.done = true
+		return
+	}
+
+	switch c {
+	case '"':
+		e.inString = true
+		e.escaped = false
+		e.readingKey = e.depth == 1 && e.expectingKey
+		if e.readingKey {
+			e.keyBuf = e.keyBuf[:0]
+			e.keyTooLarge = false
+		}
+	case '{':
+		e.depth++
+		if e.depth == 1 {
+			e.expectingKey = true
+		}
+	case '[':
+		e.depth++
+	case '}':
+		if e.depth == 1 {
+			e.expectingKey = false
+		}
+		if e.depth > 0 {
+			e.depth--
+		}
+	case ']':
+		if e.depth > 0 {
+			e.depth--
+		}
+	case ':':
+		if e.depth == 1 {
+			e.expectingKey = false
+		}
+	case ',':
+		if e.depth == 1 {
+			e.expectingKey = true
+		}
+	}
+}
+
+func (e *topLevelUsageExtractor) consumeStringByte(c byte) {
+	if e.escaped {
+		e.escaped = false
+		e.captureKeyByte(c)
+		return
+	}
+	if c == '\\' {
+		e.escaped = true
+		e.captureKeyByte(c)
+		return
+	}
+	if c == '"' {
+		e.inString = false
+		if e.readingKey {
+			e.finishKey()
+			e.readingKey = false
+		}
+		return
+	}
+	e.captureKeyByte(c)
+}
+
+func (e *topLevelUsageExtractor) captureKeyByte(c byte) {
+	if !e.readingKey || e.keyTooLarge {
+		return
+	}
+	if len(e.keyBuf) >= maxJSONKeyBytes {
+		e.keyTooLarge = true
+		e.keyBuf = e.keyBuf[:0]
+		return
+	}
+	e.keyBuf = append(e.keyBuf, c)
+}
+
+func (e *topLevelUsageExtractor) finishKey() {
+	if e.keyTooLarge {
+		return
+	}
+	key, err := strconv.Unquote(`"` + string(e.keyBuf) + `"`)
+	if err == nil && key == "usage" {
+		e.awaitingUsageColon = true
+		e.expectingKey = false
+	}
+}
+
+func (e *topLevelUsageExtractor) startUsageCapture(c byte) {
+	e.awaitingUsageValue = false
+	e.capturingUsage = true
+	e.usageDepth = 1
+	e.usageInString = false
+	e.usageEscaped = false
+	e.captureUsageByte(c)
+}
+
+func (e *topLevelUsageExtractor) consumeUsageByte(c byte) {
+	e.captureUsageByte(c)
+	if e.usageInString {
+		if e.usageEscaped {
+			e.usageEscaped = false
+			return
+		}
+		if c == '\\' {
+			e.usageEscaped = true
+			return
+		}
+		if c == '"' {
+			e.usageInString = false
+		}
+		return
+	}
+
+	switch c {
+	case '"':
+		e.usageInString = true
+	case '{', '[':
+		e.usageDepth++
+	case '}', ']':
+		e.usageDepth--
+		if e.usageDepth == 0 {
+			e.finishUsage()
+		}
+	}
+}
+
+func (e *topLevelUsageExtractor) captureUsageByte(c byte) {
+	if e.usageTooLarge {
+		return
+	}
+	if len(e.usageBuf) >= maxUsageJSONBytes {
+		e.usageTooLarge = true
+		e.usageBuf = e.usageBuf[:0]
+		return
+	}
+	e.usageBuf = append(e.usageBuf, c)
+}
+
+func (e *topLevelUsageExtractor) finishUsage() {
+	e.done = true
+	e.capturingUsage = false
+	if e.usageTooLarge {
+		return
+	}
+	var usage tokencount.Usage
+	if err := json.Unmarshal(e.usageBuf, &usage); err == nil {
+		usage.Normalize()
+		e.usage = &usage
+	}
+}
+
+func isJSONSpace(c byte) bool {
+	return c == ' ' || c == '\n' || c == '\r' || c == '\t'
+}

--- a/manager/json_usage_extractor_test.go
+++ b/manager/json_usage_extractor_test.go
@@ -1,0 +1,41 @@
+package manager
+
+import "testing"
+
+func TestTopLevelUsageExtractorExtractsUsageAcrossChunks(t *testing.T) {
+	input := `{"data":"not a \"usage\" key","nested":{"usage":{"prompt_tokens":1,"completion_tokens":1}},"usage":{"input_tokens":7,"output_tokens":3,"total_tokens":10}}`
+
+	extractor := &topLevelUsageExtractor{}
+	for i := 0; i < len(input); i += 5 {
+		end := min(i+5, len(input))
+		if _, err := extractor.Write([]byte(input[i:end])); err != nil {
+			t.Fatalf("write chunk: %v", err)
+		}
+	}
+
+	usage := extractor.Usage()
+	if usage == nil {
+		t.Fatal("expected usage")
+	}
+	if usage.PromptTokens != 7 {
+		t.Fatalf("prompt tokens = %d, want 7", usage.PromptTokens)
+	}
+	if usage.CompletionTokens != 3 {
+		t.Fatalf("completion tokens = %d, want 3", usage.CompletionTokens)
+	}
+	if usage.TotalTokens != 10 {
+		t.Fatalf("total tokens = %d, want 10", usage.TotalTokens)
+	}
+}
+
+func TestTopLevelUsageExtractorIgnoresUsageInStringValues(t *testing.T) {
+	input := `{"data":"{\"usage\":{\"prompt_tokens\":999}}","message":"usage"}`
+
+	extractor := &topLevelUsageExtractor{}
+	if _, err := extractor.Write([]byte(input)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if extractor.Usage() != nil {
+		t.Fatal("expected no usage")
+	}
+}

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -323,8 +323,26 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 			}
 			if int64(len(bodyBytes)) > maxUsageMetricsBodyBytes {
 				log.WithField("max_bytes", maxUsageMetricsBodyBytes).
-					Warn("Usage metrics extraction skipped: response body exceeds limit")
-				resp.Body = withPrefixedBody(bodyBytes, resp.Body)
+					Info("Usage metrics extraction using trailer for oversized response body")
+				addTrailerHeader(resp.Header, UsageMetricsResponseHeader)
+				if wrapper, ok := req.Context().Value(usageWriterKey{}).(*usageMetricsWriter); ok {
+					wrapper.EnableTrailer()
+				}
+				resp.Header.Del("Content-Length")
+				resp.ContentLength = -1
+				resp.Body = newStreamingJSONUsageReadCloser(withPrefixedBody(bodyBytes, resp.Body), func(usage *tokencount.Usage) {
+					usageHandler(usage)
+					if wrapper, ok := req.Context().Value(usageWriterKey{}).(*usageMetricsWriter); ok {
+						wrapper.SetUsage(usage)
+					}
+				})
+				if billingCollector != nil && apiKey != "" {
+					resp.Body = &billingCloser{
+						ReadCloser:    resp.Body,
+						handlerCalled: &handlerCalled,
+						emitEvent:     emitZeroTokenEvent,
+					}
+				}
 				return nil
 			}
 			resp.Body.Close()

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -2,15 +2,18 @@ package manager
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/tinfoilsh/confidential-model-router/billing"
+	"github.com/tinfoilsh/usage-reporting-go/contract"
 )
 
 func setupTestProxyWithModel(t *testing.T, handler http.Handler, modelName string) *httputil.ReverseProxy {
@@ -85,6 +88,83 @@ func TestProxyUsageMetrics_NonKimiModelKeepsLegacyUsageFormat(t *testing.T) {
 	want := "prompt=69,completion=20,total=89"
 	if got != want {
 		t.Fatalf("usage header = %q, want %q", got, want)
+	}
+}
+
+func TestProxyUsageMetrics_OversizedResponseExtractsUsageTrailer(t *testing.T) {
+	batches := make(chan contract.Batch, 1)
+	usageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var batch contract.Batch
+		if err := json.NewDecoder(r.Body).Decode(&batch); err != nil {
+			t.Errorf("decode usage batch: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		batches <- batch
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer usageServer.Close()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":"`))
+		_, _ = w.Write([]byte(strings.Repeat("x", int(maxUsageMetricsBodyBytes)+1)))
+		_, _ = w.Write([]byte(`","usage":{"prompt_tokens":123,"completion_tokens":45,"total_tokens":168}}`))
+	}))
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	collector := billing.NewCollector(usageServer.URL, "router-test", "test-secret")
+	defer collector.Stop()
+
+	proxy := newProxy(backendURL.Host, "", "doc-upload", collector, newCircuitBreaker())
+	proxy.Director = func(req *http.Request) {
+		req.URL.Scheme = backendURL.Scheme
+		req.URL.Host = backendURL.Host
+	}
+	proxy.Transport = http.DefaultTransport
+
+	req := httptest.NewRequest("POST", "/v1/convert/file", nil)
+	req.Header.Set("Authorization", "Bearer test-key-1234567890")
+	req.Header.Set(UsageMetricsRequestHeader, "true")
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+	ctx := context.WithValue(req.Context(), usageWriterKey{}, wrapper)
+	proxy.ServeHTTP(wrapper, req.WithContext(ctx))
+	if wrapper.TrailerEnabled() {
+		wrapper.WriteTrailer()
+	}
+
+	result := rec.Result()
+	if got, want := result.Trailer.Get(UsageMetricsResponseHeader), "prompt=123,completion=45,total=168"; got != want {
+		t.Fatalf("usage trailer = %q, want %q", got, want)
+	}
+
+	select {
+	case batch := <-batches:
+		if len(batch.Events) != 1 {
+			t.Fatalf("expected one billing event, got %d", len(batch.Events))
+		}
+		event := batch.Events[0]
+		if event.CustomerRequests != 1 {
+			t.Fatalf("customer requests mismatch: got %d want 1", event.CustomerRequests)
+		}
+		if len(event.Meters) != 2 {
+			t.Fatalf("expected input/output token meters, got %#v", event.Meters)
+		}
+		if event.Meters[0].Quantity != 123 {
+			t.Fatalf("input token meter mismatch: got %d want 123", event.Meters[0].Quantity)
+		}
+		if event.Meters[1].Quantity != 45 {
+			t.Fatalf("output token meter mismatch: got %d want 45", event.Meters[1].Quantity)
+		}
+		if event.Attributes["model"] != "doc-upload" {
+			t.Fatalf("model attribute mismatch: got %q want doc-upload", event.Attributes["model"])
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for billing event")
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes missing billing for oversized JSON responses by streaming the top-level `usage` object and writing usage to a response trailer, ensuring billing events are sent even when the body exceeds the in-memory limit.

- **Bug Fixes**
  - For bodies larger than `maxUsageMetricsBodyBytes`, stream-parse the top-level `usage` field and emit it via the response trailer, then forward it to the `billing` collector.
  - Switch oversized responses to chunked encoding (remove `Content-Length`), add the usage trailer header, and keep legacy usage format for non-Kimi models.
  - Add a lightweight streaming JSON extractor with size caps to safely locate `usage` across chunks and ignore stringified occurrences.
  - Tests cover chunked extraction, ignoring `usage` in strings, and end-to-end billing event emission for oversized responses.

<sup>Written for commit 82a1c4a40f8efc7b252fc76097945d15e7f43da1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

