### PR TITLE
Add header to auto-continue tool extension for client-rendered tools

### DIFF
--- a/main.go
+++ b/main.go
@@ -448,9 +448,10 @@ func main() {
 				// Detect which built-in tool profiles this request
 				// activates. The router runs the tool loop locally
 				// against one MCP session per active profile; zero
-				// profiles means no router-owned tools, so the
-				// request falls through to the plain proxy path.
+				// profiles and no auto-continue tools means no router-owned
+				// work, so the request falls through to the plain proxy path.
 				activeProfiles := detectToolProfiles(r.URL.Path, body)
+				hasAutoContinueTools := toolruntime.HasAutoContinueTools(r.URL.Path, body)
 				rateLimitModel := modelName
 
 				bodyModified := false
@@ -536,7 +537,7 @@ func main() {
 				r.Body.Close()
 				r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
-				if len(activeProfiles) > 0 {
+				if len(activeProfiles) > 0 || hasAutoContinueTools {
 					if err := toolruntime.Handle(w, r, em, activeProfiles, body, modelName); err != nil {
 						log.WithError(err).WithFields(log.Fields{
 							"model": modelName,

--- a/main_test.go
+++ b/main_test.go
@@ -381,8 +381,8 @@ func TestEnsureStreamingUsageOptions(t *testing.T) {
 }
 
 // TestDetectToolProfiles pins the contract between the request shape
-// and the set of MCP profiles the router activates. This test is the
-// single source of truth for "which requests enter the tool loop";
+// and the set of MCP profiles the router activates. Display-only client
+// tools can also enter the tool loop without activating an MCP profile;
 // adding a new profile must come with a new case here.
 func TestDetectToolProfiles(t *testing.T) {
 	profileNames := func(ps []toolprofile.Profile) []string {

--- a/toolruntime/auto_continue.go
+++ b/toolruntime/auto_continue.go
@@ -1,0 +1,198 @@
+package toolruntime
+
+// Auto-continue client tools.
+//
+// The OpenAI tool-call protocol was designed for *function* tools — ones
+// where the model asks the host to go do something real (query a DB, hit
+// an API, run code) and report back. The protocol ends the model's turn
+// after the tool call because the host needs to produce a result the
+// model didn't have. The model cannot finish its answer until that
+// result exists.
+//
+// Some classes of tools don't fit that shape. Generative-UI render tools,
+// for example, have no real side effect: the result is always "executed".
+// The round trip exists solely to satisfy a protocol that was designed for
+// a different problem. With a vanilla relay, the model emits a tool call,
+// the turn ends, the client renders a widget — and the user never sees the
+// prose the model was about to write. The answer "craps out" mid-thought.
+//
+// A caller flags such tools by setting `x-tinfoil-tool-auto-continue: true`
+// on the tool definition in the request body. The router strips that field
+// before forwarding the request upstream (so the model never sees router-
+// specific fields) and remembers the tool names. When the model later
+// emits a call to one of those tools, the tool-loop driver synthesises
+// the result, appends it to history, and re-invokes the model so it can
+// produce the surrounding prose. The client sees a single coherent
+// response that contains both the tool call and the follow-up content.
+//
+// Three classes of tools end up flowing through the router:
+//
+//   1. Router-owned (web_search, fetch): registered via MCP profiles. The
+//      router knows how to execute them and what to return.
+//   2. Auto-continue client tools: declared per-request with the flag in
+//      this file. The router synthesises a constant result and continues
+//      the loop. The widget renderer lives on the client.
+//   3. Real client function tools: any other tool the caller declares.
+//      The router cannot synthesise a result, so the turn finalizes and
+//      the caller is responsible for executing the tool and re-posting.
+
+const (
+	// autoContinueToolFlag is the per-tool boolean field a caller sets on
+	// an OpenAI tool definition to opt a tool into router-side auto-
+	// continuation. The router strips this field before forwarding the
+	// request upstream because it is router-internal metadata.
+	autoContinueToolFlag = "x-tinfoil-tool-auto-continue"
+
+	// autoContinueToolResult is the synthetic tool result the router
+	// injects into history after every auto-continue tool call so the
+	// upstream model has the protocol-mandated `role:"tool"` /
+	// `function_call_output` entry it needs to continue generating.
+	// The string is intentionally inert: just enough for the model to
+	// know the call succeeded, with no content that could influence the
+	// follow-up answer.
+	autoContinueToolResult = `{"status":"executed"}`
+)
+
+// HasAutoContinueTools reports whether the request declares any client tool
+// the router should auto-acknowledge and continue. Main uses this to route
+// auto-continue-only requests through toolruntime even when no MCP-backed
+// router tools (for example web_search) are active.
+func HasAutoContinueTools(path string, body map[string]any) bool {
+	if body == nil {
+		return false
+	}
+	switch path {
+	case "/v1/chat/completions":
+		return hasAutoContinueChatTool(body["tools"])
+	case "/v1/responses":
+		return hasAutoContinueResponsesTool(body["tools"])
+	default:
+		return false
+	}
+}
+
+func hasAutoContinueChatTool(rawTools any) bool {
+	tools, _ := rawTools.([]any)
+	for _, raw := range tools {
+		tool, _ := raw.(map[string]any)
+		if tool == nil {
+			continue
+		}
+		fn, _ := tool["function"].(map[string]any)
+		if fn == nil {
+			continue
+		}
+		if flagged, _ := fn[autoContinueToolFlag].(bool); flagged {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAutoContinueResponsesTool(rawTools any) bool {
+	tools, _ := rawTools.([]any)
+	for _, raw := range tools {
+		tool, _ := raw.(map[string]any)
+		if tool == nil {
+			continue
+		}
+		if flagged, _ := tool[autoContinueToolFlag].(bool); flagged {
+			return true
+		}
+	}
+	return false
+}
+
+// extractAndStripAutoContinueChatTools walks a chat-completions tools array,
+// records every tool whose function definition carries the auto-continue
+// flag, and removes the flag in place so the upstream model never sees a
+// router-internal field. The returned set is keyed by tool name; an entry
+// is present iff the caller flagged that tool as auto-continue on this
+// request.
+func extractAndStripAutoContinueChatTools(rawTools any) map[string]struct{} {
+	tools, _ := rawTools.([]any)
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{})
+	for _, raw := range tools {
+		tool, _ := raw.(map[string]any)
+		if tool == nil {
+			continue
+		}
+		fn, _ := tool["function"].(map[string]any)
+		if fn == nil {
+			continue
+		}
+		flagged, hasFlag := fn[autoContinueToolFlag].(bool)
+		if hasFlag {
+			delete(fn, autoContinueToolFlag)
+		}
+		if !flagged {
+			continue
+		}
+		name := stringValue(fn["name"])
+		if name == "" {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// extractAndStripAutoContinueResponsesTools mirrors
+// extractAndStripAutoContinueChatTools for the /v1/responses tools array
+// shape, where each tool is a flat map (no nested `function` block).
+func extractAndStripAutoContinueResponsesTools(rawTools any) map[string]struct{} {
+	tools, _ := rawTools.([]any)
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{})
+	for _, raw := range tools {
+		tool, _ := raw.(map[string]any)
+		if tool == nil {
+			continue
+		}
+		flagged, hasFlag := tool[autoContinueToolFlag].(bool)
+		if hasFlag {
+			delete(tool, autoContinueToolFlag)
+		}
+		if !flagged {
+			continue
+		}
+		name := stringValue(tool["name"])
+		if name == "" {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// splitClientToolCalls separates plain client-owned tool calls from the
+// auto-continue subset. Auto-continue calls are handled by the router
+// (synthetic result + loop continuation); the rest finalize the turn so
+// the caller can execute them and re-post.
+func splitClientToolCalls(
+	autoContinue map[string]struct{},
+	clientCalls []toolCall,
+) (continued []toolCall, external []toolCall) {
+	if len(clientCalls) == 0 {
+		return nil, nil
+	}
+	for _, call := range clientCalls {
+		if _, ok := autoContinue[call.name]; ok {
+			continued = append(continued, call)
+			continue
+		}
+		external = append(external, call)
+	}
+	return continued, external
+}

--- a/toolruntime/auto_continue_adapter_test.go
+++ b/toolruntime/auto_continue_adapter_test.go
@@ -1,0 +1,259 @@
+package toolruntime
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestChatAdapterClassifiesAutoContinueCalls verifies the chat adapter
+// partitions a turn's tool calls into router, auto-continue, and external
+// buckets the way the loop driver expects.
+func TestChatAdapterClassifiesAutoContinueCalls(t *testing.T) {
+	adapter := newChatLoopAdapter(
+		map[string]any{},
+		nil,
+		nil,
+		map[string]struct{}{routerSearchToolName: {}},
+		"m",
+		http.Header{},
+	)
+	adapter.autoContinueTools = map[string]struct{}{"render_stat_cards": {}}
+
+	response := &upstreamJSONResponse{
+		body: map[string]any{
+			"choices": []any{
+				map[string]any{
+					"index": float64(0),
+					"message": map[string]any{
+						"role": "assistant",
+						"tool_calls": []any{
+							map[string]any{
+								"id":   "c1",
+								"type": "function",
+								"function": map[string]any{
+									"name":      routerSearchToolName,
+									"arguments": "{}",
+								},
+							},
+							map[string]any{
+								"id":   "c2",
+								"type": "function",
+								"function": map[string]any{
+									"name":      "render_stat_cards",
+									"arguments": "{}",
+								},
+							},
+							map[string]any{
+								"id":   "c3",
+								"type": "function",
+								"function": map[string]any{
+									"name":      "get_order",
+									"arguments": "{}",
+								},
+							},
+						},
+					},
+					"finish_reason": "tool_calls",
+				},
+			},
+		},
+	}
+
+	router, display, hasExternal, _ := adapter.onUpstreamResponse(response, 0, time.Millisecond)
+	if len(router) != 1 || router[0].name != routerSearchToolName {
+		t.Fatalf("router classification wrong: %+v", router)
+	}
+	if len(display) != 1 || display[0].name != "render_stat_cards" {
+		t.Fatalf("auto-continue classification wrong: %+v", display)
+	}
+	if !hasExternal {
+		t.Fatal("expected hasExternal=true for a real client function call")
+	}
+}
+
+// TestChatAdapterAutoContinueDoesNotFinalize checks the boundary case where
+// a turn carries only router work and a auto-continue call: no external
+// client tool call exists, so hasExternal must be false so the loop
+// driver continues replaying.
+func TestChatAdapterAutoContinueDoesNotFinalize(t *testing.T) {
+	adapter := newChatLoopAdapter(
+		map[string]any{},
+		nil,
+		nil,
+		nil,
+		"m",
+		http.Header{},
+	)
+	adapter.autoContinueTools = map[string]struct{}{"render_chart": {}}
+
+	response := &upstreamJSONResponse{
+		body: map[string]any{
+			"choices": []any{
+				map[string]any{
+					"index": float64(0),
+					"message": map[string]any{
+						"role": "assistant",
+						"tool_calls": []any{
+							map[string]any{
+								"id":   "c1",
+								"type": "function",
+								"function": map[string]any{
+									"name":      "render_chart",
+									"arguments": "{}",
+								},
+							},
+						},
+					},
+					"finish_reason": "tool_calls",
+				},
+			},
+		},
+	}
+
+	router, display, hasExternal, _ := adapter.onUpstreamResponse(response, 0, time.Millisecond)
+	if len(router) != 0 {
+		t.Fatalf("expected no router calls, got %+v", router)
+	}
+	if len(display) != 1 {
+		t.Fatalf("expected one auto-continue call, got %+v", display)
+	}
+	if hasExternal {
+		t.Fatal("auto-continue-only turn must not be treated as having external client calls")
+	}
+}
+
+// TestChatAdapterStripsFlagFromUpstreamRequest verifies buildInitialRequest
+// records the auto-continue set and removes the router-internal flag so the
+// upstream model never sees it.
+func TestChatAdapterStripsFlagFromUpstreamRequest(t *testing.T) {
+	adapter := newChatLoopAdapter(
+		map[string]any{
+			"messages": []any{
+				map[string]any{"role": "user", "content": "hi"},
+			},
+			"tools": []any{
+				map[string]any{
+					"type": "function",
+					"function": map[string]any{
+						"name":                         "render_stat_cards",
+						"description":                  "kpis",
+						"x-tinfoil-tool-auto-continue": true,
+					},
+				},
+				map[string]any{
+					"type": "function",
+					"function": map[string]any{
+						"name":        "get_order",
+						"description": "real",
+					},
+				},
+			},
+		},
+		nil,
+		nil,
+		nil,
+		"m",
+		http.Header{},
+	)
+
+	req := adapter.buildInitialRequest()
+
+	if _, ok := adapter.autoContinueTools["render_stat_cards"]; !ok {
+		t.Fatalf("adapter did not record auto-continue set: %+v", adapter.autoContinueTools)
+	}
+
+	tools, _ := req["tools"].([]any)
+	if len(tools) == 0 {
+		t.Fatal("expected tools to remain in upstream request body")
+	}
+	for _, raw := range tools {
+		tool, _ := raw.(map[string]any)
+		if tool == nil {
+			continue
+		}
+		fn, _ := tool["function"].(map[string]any)
+		if fn == nil {
+			continue
+		}
+		if _, present := fn[autoContinueToolFlag]; present {
+			t.Errorf("auto-continue flag leaked into upstream tools array on %v", fn["name"])
+		}
+	}
+}
+
+func TestChatAdapterCarriesAutoContinueCallsToFinalResponse(t *testing.T) {
+	adapter := newChatLoopAdapter(map[string]any{}, nil, nil, nil, "m", http.Header{})
+	state := map[string]any{
+		"role": "assistant",
+		"tool_calls": []any{
+			map[string]any{
+				"id":   "call_widget",
+				"type": "function",
+				"function": map[string]any{
+					"name":      "render_stat_cards",
+					"arguments": `{"stats":[]}`,
+				},
+			},
+		},
+	}
+	items := adapter.autoContinueResponseItems(state, []toolCall{{id: "call_widget", name: "render_stat_cards"}})
+	final := &upstreamJSONResponse{body: map[string]any{
+		"choices": []any{
+			map[string]any{
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "Here is the explanation after the widget.",
+				},
+				"finish_reason": "stop",
+			},
+		},
+	}}
+
+	adapter.attachAutoContinueResponseItems(final, items)
+
+	choice := final.body["choices"].([]any)[0].(map[string]any)
+	message := choice["message"].(map[string]any)
+	calls := message["tool_calls"].([]any)
+	if len(calls) != 1 {
+		t.Fatalf("expected auto-continue tool call on final response, got %#v", calls)
+	}
+	call := calls[0].(map[string]any)
+	fn := call["function"].(map[string]any)
+	if stringValue(fn["name"]) != "render_stat_cards" {
+		t.Fatalf("expected render_stat_cards, got %#v", fn["name"])
+	}
+	if stringValue(message["content"]) == "" {
+		t.Fatalf("expected final prose to remain present: %#v", message)
+	}
+}
+
+func TestResponsesAdapterCarriesAutoContinueCallsToFinalResponse(t *testing.T) {
+	adapter := newResponsesLoopAdapter(map[string]any{}, nil, nil, nil)
+	state := []any{
+		map[string]any{
+			"id":        "fc_widget",
+			"type":      "function_call",
+			"name":      "render_stat_cards",
+			"call_id":   "call_widget",
+			"arguments": `{"stats":[]}`,
+		},
+	}
+	items := adapter.autoContinueResponseItems(state, []toolCall{{id: "call_widget", name: "render_stat_cards"}})
+	final := &upstreamJSONResponse{body: map[string]any{
+		"output": []any{
+			map[string]any{"id": "msg_final", "type": "message", "content": []any{}},
+		},
+	}}
+
+	adapter.attachAutoContinueResponseItems(final, items)
+
+	output := final.body["output"].([]any)
+	if len(output) != 2 {
+		t.Fatalf("expected auto-continue call plus final output, got %#v", output)
+	}
+	first := output[0].(map[string]any)
+	if stringValue(first["name"]) != "render_stat_cards" {
+		t.Fatalf("expected auto-continue function_call first, got %#v", first)
+	}
+}

--- a/toolruntime/auto_continue_test.go
+++ b/toolruntime/auto_continue_test.go
@@ -1,0 +1,168 @@
+package toolruntime
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestExtractAndStripAutoContinueChatTools verifies the helper records
+// flagged tools and removes the router-internal flag from the upstream
+// tools array.
+func TestExtractAndStripAutoContinueChatTools(t *testing.T) {
+	tools := []any{
+		map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":                         "render_stat_cards",
+				"description":                  "stat cards",
+				"x-tinfoil-tool-auto-continue": true,
+			},
+		},
+		map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        "get_weather",
+				"description": "weather",
+			},
+		},
+		map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":                         "render_chart",
+				"x-tinfoil-tool-auto-continue": true,
+			},
+		},
+	}
+
+	got := extractAndStripAutoContinueChatTools(tools)
+	wantNames := []string{"render_chart", "render_stat_cards"}
+	gotNames := setKeys(got)
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("extracted names mismatch: got %v want %v", gotNames, wantNames)
+	}
+
+	for _, raw := range tools {
+		tool := raw.(map[string]any)
+		fn := tool["function"].(map[string]any)
+		if _, present := fn[autoContinueToolFlag]; present {
+			t.Errorf("flag not stripped from %v", fn["name"])
+		}
+	}
+}
+
+func TestHasAutoContinueTools(t *testing.T) {
+	if !HasAutoContinueTools("/v1/chat/completions", map[string]any{
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":                         "render_stat_cards",
+					"x-tinfoil-tool-auto-continue": true,
+				},
+			},
+		},
+	}) {
+		t.Fatal("expected flagged chat tool to activate auto-continue runtime")
+	}
+	if !HasAutoContinueTools("/v1/responses", map[string]any{
+		"tools": []any{
+			map[string]any{
+				"type":                         "function",
+				"name":                         "render_stat_cards",
+				"x-tinfoil-tool-auto-continue": true,
+			},
+		},
+	}) {
+		t.Fatal("expected flagged responses tool to activate auto-continue runtime")
+	}
+	if HasAutoContinueTools("/v1/chat/completions", map[string]any{
+		"tools": []any{map[string]any{"type": "function", "function": map[string]any{"name": "get_order"}}},
+	}) {
+		t.Fatal("unflagged tool should not activate auto-continue runtime")
+	}
+}
+
+// TestExtractAndStripAutoContinueResponsesTools mirrors the chat-test for
+// the flat /v1/responses tool shape.
+func TestExtractAndStripAutoContinueResponsesTools(t *testing.T) {
+	tools := []any{
+		map[string]any{
+			"type":                         "function",
+			"name":                         "render_artifact_preview",
+			"x-tinfoil-tool-auto-continue": true,
+		},
+		map[string]any{
+			"type": "function",
+			"name": "lookup_order",
+		},
+	}
+
+	got := extractAndStripAutoContinueResponsesTools(tools)
+	if _, ok := got["render_artifact_preview"]; !ok {
+		t.Fatalf("expected render_artifact_preview to be marked auto-continue, got %v", got)
+	}
+	if _, ok := got["lookup_order"]; ok {
+		t.Fatalf("unflagged tool should not be auto-continue, got %v", got)
+	}
+
+	for _, raw := range tools {
+		tool := raw.(map[string]any)
+		if _, present := tool[autoContinueToolFlag]; present {
+			t.Errorf("flag not stripped from %v", tool["name"])
+		}
+	}
+}
+
+// TestExtractAutoContinueEmptyInputs covers degenerate shapes the helper
+// must tolerate without panicking.
+func TestExtractAutoContinueEmptyInputs(t *testing.T) {
+	if got := extractAndStripAutoContinueChatTools(nil); got != nil {
+		t.Errorf("nil tools should yield nil set, got %v", got)
+	}
+	if got := extractAndStripAutoContinueChatTools([]any{}); got != nil {
+		t.Errorf("empty tools should yield nil set, got %v", got)
+	}
+	if got := extractAndStripAutoContinueChatTools([]any{"not a map"}); got != nil {
+		t.Errorf("non-map entries should be skipped, got %v", got)
+	}
+	if got := extractAndStripAutoContinueResponsesTools(nil); got != nil {
+		t.Errorf("nil responses tools should yield nil set, got %v", got)
+	}
+}
+
+// TestSplitClientToolCalls verifies the partition of client-owned tool
+// calls into auto-continue and external-host buckets.
+func TestSplitClientToolCalls(t *testing.T) {
+	autoContinue := map[string]struct{}{
+		"render_stat_cards": {},
+	}
+	calls := []toolCall{
+		{id: "1", name: "render_stat_cards"},
+		{id: "2", name: "get_order"},
+		{id: "3", name: "render_stat_cards"},
+	}
+	got, external := splitClientToolCalls(autoContinue, calls)
+	if len(got) != 2 || got[0].id != "1" || got[1].id != "3" {
+		t.Errorf("auto-continue partition wrong: %+v", got)
+	}
+	if len(external) != 1 || external[0].id != "2" {
+		t.Errorf("external partition wrong: %+v", external)
+	}
+}
+
+// TestSplitClientToolCallsEmpty covers the empty-input fast path.
+func TestSplitClientToolCallsEmpty(t *testing.T) {
+	if d, e := splitClientToolCalls(nil, nil); d != nil || e != nil {
+		t.Fatalf("expected nil, nil for empty inputs; got %v, %v", d, e)
+	}
+}
+
+func setKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -518,9 +518,11 @@ func (s *chatStreamer) finalize(
 	s.flushCitations()
 
 	if len(clientToolCalls) > 0 {
-		pending := s.getClientToolCallForwarder().unstreamed(clientToolCalls)
+		forwarder := s.getClientToolCallForwarder()
+		pending := forwarder.unstreamed(clientToolCalls)
 		if len(pending) > 0 {
-			raw := rawToolCallsFromParsed(pending, result.rawToolCalls)
+			raw := rawToolCallsFromParsedAt(pending, result.rawToolCalls, forwarder.nextClientIndex)
+			forwarder.nextClientIndex += len(raw)
 			if len(raw) > 0 {
 				s.writeChunk(map[string]any{
 					"choices": []any{
@@ -668,16 +670,15 @@ func newClientToolCallDeltaForwarder(
 }
 
 // resetIteration drops per-iteration classification state so a fresh
-// upstream stream starts with no stale Drop/Live decisions and a fresh
-// client-visible index space. streamedIDs is preserved so finalize can
-// still dedupe against ids that were forwarded live in earlier iterations.
+// upstream stream starts with no stale Drop/Live decisions. streamedIDs
+// and nextClientIndex are preserved across internal continuations because
+// the client sees one logical stream and tool_call indexes must not collide.
 func (f *clientToolCallDeltaForwarder) resetIteration() {
 	if f == nil {
 		return
 	}
 	f.stateByUpstreamIndex = map[int]*clientToolCallDeltaState{}
 	f.clientIndexByUpstream = map[int]int{}
-	f.nextClientIndex = 0
 }
 
 func (f *clientToolCallDeltaForwarder) ingest(
@@ -860,6 +861,7 @@ func runChatStreaming(
 	reqBody["stream"] = true
 	reqBody["stream_options"] = map[string]any{"include_usage": true}
 	applyParallelToolCallsPolicy(reqBody)
+	autoContinueTools := extractAndStripAutoContinueChatTools(reqBody["tools"])
 	reqBody["tools"] = append(existingTools(reqBody["tools"]), chatTools(tools)...)
 	reqBody["messages"] = prependChatPrompt(prompt, reqBody["messages"])
 
@@ -920,21 +922,29 @@ func runChatStreaming(
 		dl.WriteStreamedTurn(i+1, result.usage, result.reasoning, result.content)
 
 		routerToolCalls, clientToolCalls := splitToolCalls(ownedTools, result.toolCalls)
+		autoContinueCalls, externalClientCalls := splitClientToolCalls(autoContinueTools, clientToolCalls)
 		if debugEnabled {
 			toolNames := make([]string, 0, len(result.toolCalls))
 			for _, c := range result.toolCalls {
 				toolNames = append(toolNames, c.name)
 			}
-			debugLogf("toolruntime:%s chatstream.iter=%d upstream.response elapsed=%s finish=%q total_tool_calls=%d router_tool_calls=%d client_tool_calls=%d tool_names=%v content=%q",
-				tid, i, time.Since(iterStart), result.finishReason, len(result.toolCalls), len(routerToolCalls), len(clientToolCalls), toolNames, debugPreview(result.content, 240))
+			debugLogf("toolruntime:%s chatstream.iter=%d upstream.response elapsed=%s finish=%q total_tool_calls=%d router_tool_calls=%d client_tool_calls=%d auto_continue=%d external_client=%d tool_names=%v content=%q",
+				tid, i, time.Since(iterStart), result.finishReason, len(result.toolCalls), len(routerToolCalls), len(clientToolCalls), len(autoContinueCalls), len(externalClientCalls), toolNames, debugPreview(result.content, 240))
 		}
-		if len(routerToolCalls) == 0 {
-			debugLogf("toolruntime:%s chatstream.done iterations=%d (no router tool calls)", tid, i+1)
+		// Terminal turn: nothing for the router to resolve and no
+		// auto-continue calls to auto-acknowledge. Surface any external
+		// client tool calls back to the caller as-is.
+		if len(routerToolCalls) == 0 && len(autoContinueCalls) == 0 {
+			debugLogf("toolruntime:%s chatstream.done iterations=%d (no router or auto-continue tool calls)", tid, i+1)
 			dl.WriteFinish(result.finishReason)
-			return streamer.finalize(r, em, modelName, result, clientToolCalls)
+			return streamer.finalize(r, em, modelName, result, externalClientCalls)
 		}
 
-		mixedTurn := len(clientToolCalls) > 0
+		// Mixed turn: real client function tools were requested
+		// alongside router/auto-continue work. Resolve the router work
+		// (citations, etc.) but finalize without replay so the
+		// caller-owned tool_calls survive in the response.
+		mixedTurn := len(externalClientCalls) > 0
 		dl.WriteToolCalls(routerToolCalls)
 		tracePhase := fmt.Sprintf("chatstream.iter=%d", i)
 		var messages []any
@@ -960,10 +970,22 @@ func runChatStreaming(
 				})
 			}
 		}
+		// Auto-continue client tool calls: synthesise a constant
+		// "executed" result and fold it into history so the model
+		// can keep generating the prose that surrounds the widget.
+		if !mixedTurn {
+			for _, call := range autoContinueCalls {
+				messages = append(messages, map[string]any{
+					"role":         "tool",
+					"tool_call_id": call.id,
+					"content":      autoContinueToolResult,
+				})
+			}
+		}
 		// Mixed turn: see the mixed-turn contract on runToolLoop.
 		if mixedTurn {
-			debugLogf("toolruntime:%s chatstream.mixed_turn iterations=%d (router+client calls in one turn; finalizing)", tid, i+1)
-			return streamer.finalize(r, em, modelName, result, clientToolCalls)
+			debugLogf("toolruntime:%s chatstream.mixed_turn iterations=%d (router+external client calls in one turn; finalizing)", tid, i+1)
+			return streamer.finalize(r, em, modelName, result, externalClientCalls)
 		}
 		reqBody["messages"] = messages
 	}
@@ -984,6 +1006,10 @@ func runChatStreaming(
 // rawToolCallsFromParsed keeps raw calls matching parsed client calls and
 // reindexes them into client-visible order.
 func rawToolCallsFromParsed(parsed []toolCall, raw []any) []any {
+	return rawToolCallsFromParsedAt(parsed, raw, 0)
+}
+
+func rawToolCallsFromParsedAt(parsed []toolCall, raw []any, startIndex int) []any {
 	filtered := make([]any, 0, len(parsed))
 	next := 0
 	for _, item := range raw {
@@ -992,7 +1018,7 @@ func rawToolCallsFromParsed(parsed []toolCall, raw []any) []any {
 			continue
 		}
 		reindexed := map[string]any{
-			"index":    len(filtered),
+			"index":    startIndex + len(filtered),
 			"id":       source["id"],
 			"type":     source["type"],
 			"function": source["function"],

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -180,6 +180,38 @@ func TestChatStreamerPumpResetsForwarderStateBetweenIterations(t *testing.T) {
 	}
 }
 
+func TestChatStreamerClientToolCallIndexesAreMonotonicAcrossIterations(t *testing.T) {
+	streamer, rec := newTestChatStreamer(t)
+
+	iter1 := strings.Join([]string{
+		`data: {"id":"up_1","created":1700000001,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_widget_1","type":"function","function":{"name":"render_stat_cards","arguments":"{}"}}]}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`,
+		"data: [DONE]",
+		"",
+	}, "\n\n")
+	if _, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(iter1))); err != nil {
+		t.Fatalf("iter1 pumpUpstream returned error: %v", err)
+	}
+
+	iter2 := strings.Join([]string{
+		`data: {"id":"up_2","created":1700000002,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_widget_2","type":"function","function":{"name":"render_chart","arguments":"{}"}}]}}]}`,
+		`data: {"id":"up_2","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":4,"completion_tokens":3,"total_tokens":7}}`,
+		"data: [DONE]",
+		"",
+	}, "\n\n")
+	if _, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(iter2))); err != nil {
+		t.Fatalf("iter2 pumpUpstream returned error: %v", err)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"id":"call_widget_1","index":0`) {
+		t.Fatalf("expected first widget at client index 0, got %s", body)
+	}
+	if !strings.Contains(body, `"id":"call_widget_2","index":1`) {
+		t.Fatalf("expected second widget at client index 1, got %s", body)
+	}
+}
+
 func TestChatStreamerFinalizeSkipsAlreadyStreamedClientToolCalls(t *testing.T) {
 	streamer, rec := newTestChatStreamer(t)
 	streamer.getClientToolCallForwarder().streamedIDs["call_widget"] = true

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -79,6 +79,10 @@ type responsesStreamer struct {
 	// iteration for echoing in the synthesized response.completed event.
 	finalOutput []any
 
+	// persistedOutput carries client-visible items from internal
+	// auto-continue continuations into the final response.completed snapshot.
+	persistedOutput []any
+
 	// aggregatedUsage is the last non-nil usage block observed.
 	aggregatedUsage map[string]any
 
@@ -750,7 +754,9 @@ func (s *responsesStreamer) finalize(r *http.Request, em *manager.EnclaveManager
 	// instead of (or in addition to) the live delta stream must see a
 	// terminal payload that is byte-for-byte comparable to the
 	// non-streaming response.
-	completedBody := map[string]any{"output": append([]any{}, s.finalOutput...)}
+	completedOutput := append([]any{}, s.persistedOutput...)
+	completedOutput = append(completedOutput, s.finalOutput...)
+	completedBody := map[string]any{"output": completedOutput}
 	// The Responses streaming path surfaces web_search progress via the
 	// spec-defined `response.web_search_call.*` events fired live from
 	// executeTool and via the prepended `web_search_call` output items
@@ -866,6 +872,7 @@ func runResponsesStreaming(
 	stripRouterOwnedIncludes(base)
 	base["stream"] = true
 	applyParallelToolCallsPolicy(base)
+	autoContinueTools := extractAndStripAutoContinueResponsesTools(base["tools"])
 	base["tools"] = replaceRouterOwnedResponsesTools(base["tools"], responseTools(tools))
 	base["input"] = prependResponsesPrompt(prompt, base["input"])
 
@@ -907,16 +914,19 @@ func runResponsesStreaming(
 		dl.WriteStreamedTurn(i+1, result.usage, "", "")
 
 		routerToolCalls, clientToolCalls := splitToolCalls(ownedTools, result.toolCalls)
-		if len(routerToolCalls) == 0 {
+		autoContinueCalls, externalClientCalls := splitClientToolCalls(autoContinueTools, clientToolCalls)
+		// Terminal turn: nothing for the router to resolve and no
+		// auto-continue calls to auto-acknowledge.
+		if len(routerToolCalls) == 0 && len(autoContinueCalls) == 0 {
 			dl.WriteFinish("stop (no router tool calls)")
 			return streamer.finalize(r, em, modelName, result)
 		}
 
 		dl.WriteToolCalls(routerToolCalls)
-		mixedTurn := len(clientToolCalls) > 0
+		mixedTurn := len(externalClientCalls) > 0
 		var toolOutputs []any
 		if !mixedTurn {
-			toolOutputs = make([]any, 0, len(routerToolCalls))
+			toolOutputs = make([]any, 0, len(routerToolCalls)+len(autoContinueCalls))
 		}
 		for _, call := range routerToolCalls {
 			tstart := time.Now()
@@ -936,11 +946,24 @@ func runResponsesStreaming(
 				})
 			}
 		}
+		// Auto-continue client tool calls: inject a synthetic
+		// function_call_output so the model can continue producing
+		// the prose that surrounds the rendered widget.
+		if !mixedTurn {
+			for _, call := range autoContinueCalls {
+				toolOutputs = append(toolOutputs, map[string]any{
+					"type":    "function_call_output",
+					"call_id": call.id,
+					"output":  autoContinueToolResult,
+				})
+			}
+		}
 		// Mixed turn: see the mixed-turn contract on runToolLoop.
 		if mixedTurn {
 			return streamer.finalize(r, em, modelName, result)
 		}
 
+		streamer.persistedOutput = append(streamer.persistedOutput, filterResponsesOutputItemsForToolCalls(result.outputItems, autoContinueCalls)...)
 		accumulatedInput = append(accumulatedInput, normalizeResponsesOutputItems(result.outputItems)...)
 		accumulatedInput = append(accumulatedInput, toolOutputs...)
 		reqBody = cloneJSONMap(base)

--- a/toolruntime/responses_stream_test.go
+++ b/toolruntime/responses_stream_test.go
@@ -571,6 +571,38 @@ func TestResponsesStreamerFinalOutputResetsPerIteration(t *testing.T) {
 	}
 }
 
+func TestResponsesStreamerCompletedOutputKeepsPersistedAutoContinueCalls(t *testing.T) {
+	streamer, rec := newTestResponsesStreamer(t)
+	streamer.persistedOutput = []any{
+		map[string]any{
+			"id":        "fc_widget",
+			"type":      "function_call",
+			"name":      "render_stat_cards",
+			"call_id":   "call_widget",
+			"arguments": `{"stats":[]}`,
+		},
+	}
+	streamer.finalOutput = []any{
+		map[string]any{"id": "msg_final", "type": "message", "text": "done"},
+	}
+
+	req := httptest.NewRequest("POST", "/v1/responses", nil)
+	if err := streamer.finalize(req, nil, "gpt-oss-120b", responsesIterationResult{}); err != nil {
+		t.Fatalf("finalize returned error: %v", err)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"id":"fc_widget"`) {
+		t.Fatalf("expected persisted auto-continue call in completed output, got %s", body)
+	}
+	if !strings.Contains(body, `"id":"msg_final"`) {
+		t.Fatalf("expected final message in completed output, got %s", body)
+	}
+	if strings.Index(body, `"id":"fc_widget"`) > strings.Index(body, `"id":"msg_final"`) {
+		t.Fatalf("expected auto-continue call before final message, got %s", body)
+	}
+}
+
 // TestResponsesStreamerMalformedJSONFailsStream pins that a malformed
 // upstream SSE frame terminates the stream with an upstreamError
 // instead of silently dropping the chunk -- matching the non-streaming

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -137,7 +137,10 @@ func Handle(w http.ResponseWriter, r *http.Request, em *manager.EnclaveManager, 
 	}
 
 	harmony := isHarmonyModel(modelName)
-	promptResult := buildRouterPrompt(harmony)
+	var promptResult *mcp.GetPromptResult
+	if len(profiles) > 0 {
+		promptResult = buildRouterPrompt(harmony)
+	}
 
 	streaming := isStream(body)
 	switch r.URL.Path {

--- a/toolruntime/session_registry.go
+++ b/toolruntime/session_registry.go
@@ -58,14 +58,13 @@ func buildSessionRegistry(
 	profiles []toolprofile.Profile,
 	dial func(context.Context, toolprofile.Profile) (*mcp.ClientSession, error),
 ) (*sessionRegistry, error) {
-	if len(profiles) == 0 {
-		return nil, fmt.Errorf("no tool profiles activated for this request")
-	}
-
 	r := &sessionRegistry{
 		byTool:         make(map[string]*mcp.ClientSession),
 		dispatchByTool: make(map[string]string),
 		owned:          make(map[string]struct{}),
+	}
+	if len(profiles) == 0 {
+		return r, nil
 	}
 
 	for _, profile := range profiles {

--- a/toolruntime/session_registry_test.go
+++ b/toolruntime/session_registry_test.go
@@ -200,18 +200,19 @@ func TestSessionRegistryDialFailureClosesPriorSessions(t *testing.T) {
 	}
 }
 
-// TestSessionRegistryEmptyProfilesFailsLoud pins that Handle cannot
-// accidentally open zero sessions: the outer caller is expected to
-// short-circuit on an empty detector result, and a registry built
-// against an empty profile list is a programming error we surface
-// rather than masking.
-func TestSessionRegistryEmptyProfilesFailsLoud(t *testing.T) {
-	_, err := buildSessionRegistry(context.Background(), nil, func(context.Context, toolprofile.Profile) (*mcp.ClientSession, error) {
+// TestSessionRegistryEmptyProfilesBuildsEmptyRegistry pins the
+// auto-continue-only path: the router may need toolruntime even when no
+// MCP-backed profile is active.
+func TestSessionRegistryEmptyProfilesBuildsEmptyRegistry(t *testing.T) {
+	r, err := buildSessionRegistry(context.Background(), nil, func(context.Context, toolprofile.Profile) (*mcp.ClientSession, error) {
 		t.Fatal("dial should not be invoked for empty profile list")
 		return nil, nil
 	})
-	if err == nil {
-		t.Fatalf("expected error for empty profile list")
+	if err != nil {
+		t.Fatalf("expected empty registry, got error: %v", err)
+	}
+	if len(r.allTools()) != 0 || len(r.ownedTools()) != 0 {
+		t.Fatalf("expected empty registry, got tools=%v owned=%v", r.allTools(), r.ownedTools())
 	}
 }
 

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -51,10 +51,20 @@ type toolLoopAdapter interface {
 	// onUpstreamResponse extracts router-owned tool calls plus any
 	// surface-specific state (Chat: assistant message; Responses: raw
 	// output items) that applyToolOutputs will fold back into the next
-	// request body. hasClientToolCalls reports whether the same turn
-	// also carried client-owned tool calls; see the mixed-turn contract
-	// in runToolLoop. elapsed is the upstream call's wall time.
-	onUpstreamResponse(response *upstreamJSONResponse, iteration int, elapsed time.Duration) (routerToolCalls []toolCall, hasClientToolCalls bool, state any)
+	// request body. autoContinueToolCalls is the subset of client-owned
+	// tool calls the caller flagged as auto-continue; the driver
+	// synthesises results for them and continues the loop instead of
+	// finalizing. hasExternalClientToolCalls reports whether the same
+	// turn also carried client-owned tool calls the router cannot
+	// resolve (real function tools); see the mixed-turn contract in
+	// runToolLoop. elapsed is the upstream call's wall time.
+	onUpstreamResponse(response *upstreamJSONResponse, iteration int, elapsed time.Duration) (routerToolCalls []toolCall, autoContinueToolCalls []toolCall, hasExternalClientToolCalls bool, state any)
+
+	// autoContinueResponseItems extracts the client-visible tool-call
+	// records from a auto-continue turn so finalize can return them
+	// alongside the final model prose after the internal continuation.
+	autoContinueResponseItems(state any, calls []toolCall) []any
+	attachAutoContinueResponseItems(response *upstreamJSONResponse, items []any)
 
 	applyToolOutputs(reqBody map[string]any, state any, outputs []toolOutput) map[string]any
 
@@ -123,6 +133,7 @@ func runToolLoop(
 	opts := adapter.options()
 	toolSchemas := adapter.schemas()
 	path := adapter.upstreamPath()
+	var autoContinueResponseItems []any
 
 	for i := 0; i < maxToolIterations; i++ {
 		adapter.preIteration(reqBody, i)
@@ -144,22 +155,26 @@ func runToolLoop(
 		}
 		usageTotals.Add(response)
 
-		routerToolCalls, hasClientToolCalls, state := adapter.onUpstreamResponse(response, i, time.Since(start))
+		routerToolCalls, autoContinueCalls, hasExternalClientToolCalls, state := adapter.onUpstreamResponse(response, i, time.Since(start))
 
 		dl.WriteTurn(i+1, response.body)
 
-		if len(routerToolCalls) == 0 {
+		// Terminal turn: no router work to do and no auto-continue calls
+		// to auto-acknowledge. External (host-executed) client tool
+		// calls are surfaced as-is for the caller to handle.
+		if len(routerToolCalls) == 0 && len(autoContinueCalls) == 0 {
 			if traceID := adapter.traceID(); traceID != "" {
-				debugLogf("toolruntime:%s %s done iterations=%d (no router tool calls this turn)", traceID, adapter.tracePhase(i), i+1)
+				debugLogf("toolruntime:%s %s done iterations=%d (no router or auto-continue tool calls this turn)", traceID, adapter.tracePhase(i), i+1)
 			}
 			dl.WriteFinish("stop (no router tool calls)")
+			adapter.attachAutoContinueResponseItems(response, autoContinueResponseItems)
 			adapter.applyUsage(response, usageTotals.Usage())
 			adapter.attachCitations(response.body, &citeState, &toolCalls, eventFlags)
 			return response, nil
 		}
 
 		dl.WriteToolCalls(routerToolCalls)
-		outputs := make([]toolOutput, 0, len(routerToolCalls))
+		outputs := make([]toolOutput, 0, len(routerToolCalls)+len(autoContinueCalls))
 		for _, call := range routerToolCalls {
 			tstart := time.Now()
 			output := executeRouterToolCall(ctx, registry, call, opts, toolSchemas, &citeState, &toolCalls, adapter.tracePhase(i), adapter.traceID())
@@ -170,19 +185,34 @@ func runToolLoop(
 				output: output,
 			})
 		}
+		// Auto-continue client tool calls don't reach any external
+		// service. Synthesise a constant result so the model's history
+		// stays protocol-valid and the next turn can produce the prose
+		// that would otherwise be lost when the model hands off.
+		for _, call := range autoContinueCalls {
+			outputs = append(outputs, toolOutput{
+				callID: call.id,
+				name:   call.name,
+				output: autoContinueToolResult,
+			})
+		}
 
 		// Mixed turn: finalize instead of replaying so the client's
 		// tool calls are not orphaned in the next request's history.
-		if hasClientToolCalls {
+		// Auto-continue calls do not count as external — the router
+		// resolves them above and continues looping.
+		if hasExternalClientToolCalls {
 			if traceID := adapter.traceID(); traceID != "" {
-				debugLogf("toolruntime:%s %s mixed_turn iterations=%d (router+client calls in one turn; finalizing without replay)", traceID, adapter.tracePhase(i), i+1)
+				debugLogf("toolruntime:%s %s mixed_turn iterations=%d (router+external client calls in one turn; finalizing without replay)", traceID, adapter.tracePhase(i), i+1)
 			}
 			adapter.stripRouterToolCallsFromResponse(response)
+			adapter.attachAutoContinueResponseItems(response, autoContinueResponseItems)
 			adapter.applyUsage(response, usageTotals.Usage())
 			adapter.attachCitations(response.body, &citeState, &toolCalls, eventFlags)
 			return response, nil
 		}
 
+		autoContinueResponseItems = append(autoContinueResponseItems, adapter.autoContinueResponseItems(state, autoContinueCalls)...)
 		reqBody = adapter.applyToolOutputs(reqBody, state, outputs)
 	}
 
@@ -198,6 +228,7 @@ func runToolLoop(
 	// the aggregated totals. Without this, callers billed for the tool
 	// budget would undercount by exactly the final-answer turn.
 	usageTotals.Add(finalResponse)
+	adapter.attachAutoContinueResponseItems(finalResponse, autoContinueResponseItems)
 	adapter.applyUsage(finalResponse, usageTotals.Usage())
 	adapter.attachCitations(finalResponse.body, &citeState, &toolCalls, eventFlags)
 	return finalResponse, nil
@@ -273,15 +304,16 @@ func executeRouterToolCall(
 // messages history shape, the trace id threaded through debug logs, and the
 // per-iteration assistant-history sanitization quirk.
 type chatLoopAdapter struct {
-	body           map[string]any
-	prompt         *mcp.GetPromptResult
-	tools          []*mcp.Tool
-	ownedTools     map[string]struct{}
-	modelName      string
-	requestHeaders http.Header
-	tid            string
-	opts           webSearchOptions
-	toolSchemas    map[string]*jsonschema.Schema
+	body             map[string]any
+	prompt           *mcp.GetPromptResult
+	tools            []*mcp.Tool
+	ownedTools       map[string]struct{}
+	autoContinueTools map[string]struct{}
+	modelName        string
+	requestHeaders   http.Header
+	tid              string
+	opts             webSearchOptions
+	toolSchemas      map[string]*jsonschema.Schema
 }
 
 func newChatLoopAdapter(body map[string]any, prompt *mcp.GetPromptResult, tools []*mcp.Tool, ownedTools map[string]struct{}, modelName string, requestHeaders http.Header) *chatLoopAdapter {
@@ -334,6 +366,7 @@ func (a *chatLoopAdapter) buildInitialRequest() map[string]any {
 	stripRouterOwnedIncludes(reqBody)
 	reqBody["stream"] = false
 	applyParallelToolCallsPolicy(reqBody)
+	a.autoContinueTools = extractAndStripAutoContinueChatTools(reqBody["tools"])
 	reqBody["tools"] = append(existingTools(reqBody["tools"]), chatTools(a.tools)...)
 	reqBody["messages"] = prependChatPrompt(a.prompt, reqBody["messages"])
 
@@ -356,9 +389,10 @@ func (a *chatLoopAdapter) preIteration(reqBody map[string]any, iteration int) {
 	}
 }
 
-func (a *chatLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, iteration int, elapsed time.Duration) ([]toolCall, bool, any) {
+func (a *chatLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, iteration int, elapsed time.Duration) ([]toolCall, []toolCall, bool, any) {
 	message, toolCalls := parseChatToolCalls(response.body)
 	routerToolCalls, clientToolCalls := splitToolCalls(a.ownedTools, toolCalls)
+	autoContinueCalls, externalClientCalls := splitClientToolCalls(a.autoContinueTools, clientToolCalls)
 	if debugEnabled {
 		finishReason := ""
 		content := ""
@@ -374,10 +408,42 @@ func (a *chatLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, ite
 		for _, c := range toolCalls {
 			toolNames = append(toolNames, c.name)
 		}
-		debugLogf("toolruntime:%s chat.iter=%d upstream.response elapsed=%s finish=%q total_tool_calls=%d router_tool_calls=%d client_tool_calls=%d tool_names=%v content=%q",
-			a.tid, iteration, elapsed, finishReason, len(toolCalls), len(routerToolCalls), len(clientToolCalls), toolNames, debugPreview(content, 240))
+		debugLogf("toolruntime:%s chat.iter=%d upstream.response elapsed=%s finish=%q total_tool_calls=%d router_tool_calls=%d client_tool_calls=%d auto_continue=%d external_client=%d tool_names=%v content=%q",
+			a.tid, iteration, elapsed, finishReason, len(toolCalls), len(routerToolCalls), len(clientToolCalls), len(autoContinueCalls), len(externalClientCalls), toolNames, debugPreview(content, 240))
 	}
-	return routerToolCalls, len(clientToolCalls) > 0, message
+	return routerToolCalls, autoContinueCalls, len(externalClientCalls) > 0, message
+}
+
+func (a *chatLoopAdapter) autoContinueResponseItems(state any, calls []toolCall) []any {
+	if len(calls) == 0 {
+		return nil
+	}
+	message, _ := state.(map[string]any)
+	if message == nil {
+		return nil
+	}
+	rawCalls, _ := message["tool_calls"].([]any)
+	return filterChatRawToolCalls(rawCalls, calls)
+}
+
+func (a *chatLoopAdapter) attachAutoContinueResponseItems(response *upstreamJSONResponse, items []any) {
+	if response == nil || response.body == nil || len(items) == 0 {
+		return
+	}
+	choices, _ := response.body["choices"].([]any)
+	if len(choices) == 0 {
+		return
+	}
+	choice, _ := choices[0].(map[string]any)
+	if choice == nil {
+		return
+	}
+	message, _ := choice["message"].(map[string]any)
+	if message == nil {
+		return
+	}
+	existing, _ := message["tool_calls"].([]any)
+	message["tool_calls"] = append(append([]any{}, items...), existing...)
 }
 
 // stripRouterToolCallsFromResponse keeps only the client-owned
@@ -456,6 +522,7 @@ type responsesLoopAdapter struct {
 	prompt           *mcp.GetPromptResult
 	tools            []*mcp.Tool
 	ownedTools       map[string]struct{}
+	autoContinueTools map[string]struct{}
 	base             map[string]any
 	accumulatedInput []any
 	opts             webSearchOptions
@@ -506,6 +573,7 @@ func (a *responsesLoopAdapter) buildInitialRequest() map[string]any {
 	delete(base, "pii_check_options")
 	delete(base, "prompt_injection_check_options")
 	stripRouterOwnedIncludes(base)
+	a.autoContinueTools = extractAndStripAutoContinueResponsesTools(base["tools"])
 	base["tools"] = replaceRouterOwnedResponsesTools(base["tools"], responseTools(a.tools))
 	base["input"] = prependResponsesPrompt(a.prompt, base["input"])
 	a.base = base
@@ -513,10 +581,27 @@ func (a *responsesLoopAdapter) buildInitialRequest() map[string]any {
 	return base
 }
 
-func (a *responsesLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, _ int, _ time.Duration) ([]toolCall, bool, any) {
+func (a *responsesLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, _ int, _ time.Duration) ([]toolCall, []toolCall, bool, any) {
 	routerToolCalls, clientToolCalls := splitToolCalls(a.ownedTools, parseResponsesToolCalls(response.body))
+	autoContinueCalls, externalClientCalls := splitClientToolCalls(a.autoContinueTools, clientToolCalls)
 	outputItems, _ := response.body["output"].([]any)
-	return routerToolCalls, len(clientToolCalls) > 0, outputItems
+	return routerToolCalls, autoContinueCalls, len(externalClientCalls) > 0, outputItems
+}
+
+func (a *responsesLoopAdapter) autoContinueResponseItems(state any, calls []toolCall) []any {
+	if len(calls) == 0 {
+		return nil
+	}
+	outputItems, _ := state.([]any)
+	return filterResponsesOutputItemsForToolCalls(outputItems, calls)
+}
+
+func (a *responsesLoopAdapter) attachAutoContinueResponseItems(response *upstreamJSONResponse, items []any) {
+	if response == nil || response.body == nil || len(items) == 0 {
+		return
+	}
+	outputItems, _ := response.body["output"].([]any)
+	response.body["output"] = append(append([]any{}, items...), outputItems...)
 }
 
 // stripRouterToolCallsFromResponse drops router-owned function_call
@@ -570,6 +655,65 @@ func (a *responsesLoopAdapter) forcedFinalRequest(reqBody map[string]any) map[st
 // ---------------------------------------------------------------------------
 // Unexported helpers
 // ---------------------------------------------------------------------------
+
+func filterChatRawToolCalls(rawCalls []any, calls []toolCall) []any {
+	if len(rawCalls) == 0 || len(calls) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(calls))
+	for _, raw := range rawCalls {
+		call, _ := raw.(map[string]any)
+		if call == nil {
+			continue
+		}
+		function, _ := call["function"].(map[string]any)
+		if !matchesAnyToolCall(stringValue(call["id"]), stringValue(function["name"]), calls) {
+			continue
+		}
+		out = append(out, cloneJSONMap(call))
+	}
+	return out
+}
+
+func filterResponsesOutputItemsForToolCalls(outputItems []any, calls []toolCall) []any {
+	if len(outputItems) == 0 || len(calls) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(calls))
+	for _, raw := range outputItems {
+		item, _ := raw.(map[string]any)
+		if item == nil {
+			continue
+		}
+		itemType := stringValue(item["type"])
+		if itemType != "function_call" && itemType != "mcp_call" {
+			continue
+		}
+		callID := stringValue(item["call_id"])
+		if callID == "" {
+			callID = stringValue(item["id"])
+		}
+		if !matchesAnyToolCall(callID, stringValue(item["name"]), calls) {
+			continue
+		}
+		out = append(out, cloneJSONMap(item))
+	}
+	return out
+}
+
+func matchesAnyToolCall(id, name string, calls []toolCall) bool {
+	for _, call := range calls {
+		if id != "" && call.id != "" && id == call.id {
+			return true
+		}
+		if id == "" || call.id == "" {
+			if name != "" && name == call.name {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 // applyParallelToolCallsPolicy defaults parallel_tool_calls to true so
 // the model can fan out client-owned tool calls. Router-owned tools are


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds router-side auto-continue for client-rendered tools so the model keeps writing after emitting a widget, even when no MCP profiles are active. Works for `/v1/chat/completions` and `/v1/responses` in both streaming and non‑streaming modes.

- **New Features**
  - Opt-in via `x-tinfoil-tool-auto-continue`; the flag is stripped before the upstream call.
  - Auto-acknowledge flagged tools with `{"status":"executed"}` and continue the loop so the final response includes the widget call plus follow-up prose.
  - Route through `toolruntime` when requests include auto-continue tools; empty MCP registries are supported.

- **Bug Fixes**
  - Keep client `tool_call` indexes monotonic across internal continuations to avoid index collisions in streamed deltas.
  - Ensure auto-continue `tool_calls`/`function_call` items persist into the final response (prepended before the final message in `/v1/responses`).
  - Mixed turns now finalize only when real client function tools are present; auto-continue tools no longer force premature finalization.

<sup>Written for commit 94540bd547d5fdb2be367713099edf2eaa4d67fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

