### PR TITLE
fix: normalize auto-continued widget arguments

### DIFF
--- a/toolruntime/auto_continue.go
+++ b/toolruntime/auto_continue.go
@@ -1,5 +1,12 @@
 package toolruntime
 
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+)
+
 // Auto-continue client tools.
 //
 // The OpenAI tool-call protocol was designed for *function* tools — ones
@@ -174,6 +181,119 @@ func extractAndStripAutoContinueResponsesTools(rawTools any) map[string]struct{}
 		return nil
 	}
 	return out
+}
+
+// canonicalizeAutoContinueArguments normalises a tool-call `arguments`
+// payload before the router carries it back to the client. Some upstream
+// providers (notably DeepSeek-V4-Pro on non-streaming responses) emit
+// nested arrays and objects as JSON-encoded strings, e.g.
+// `{"stats":"[{\"label\":\"a\"}]"}` instead of `{"stats":[{"label":"a"}]}`.
+// Client widget schemas reject the stringified shape, which surfaces to
+// the user as "couldn't display this widget".
+//
+// vLLM's `--enable-auto-tool-choice` path does not run guided decoding
+// over function arguments, so OpenAI-style `strict: true` cannot fix the
+// quirk at the source today. Doing the unwrap once on the router lets
+// every client (web, iOS, future surfaces) stay shape-agnostic instead
+// of duplicating the same workaround.
+//
+// The transform is intentionally narrow:
+//   - only applied to arguments produced by tools the caller flagged with
+//     `x-tinfoil-tool-auto-continue: true` (`filterChatRawToolCalls` and
+//     `filterResponsesOutputItemsForToolCalls` are the only call sites);
+//   - only unwraps strings that look structurally like JSON arrays or
+//     objects (leading `{` / `[` after trimming);
+//   - leaves the input untouched on any parse failure;
+//   - idempotent: already-canonical arguments round-trip unchanged.
+//
+// Removal criteria: this function and `deepUnwrapJSONStrings` can be
+// deleted once every upstream provider the router serves emits tool-call
+// `arguments` with native JSON types for nested arrays/objects. Concretely
+// that means either:
+//  1. vLLM's `--enable-auto-tool-choice` runs guided decoding over function
+//     arguments (so `strict: true` on the tool schema constrains the shape
+//     at the source), and every served model is migrated onto that path; or
+//  2. the affected models (DeepSeek-V4-Pro and any future variants that
+//     exhibit the same stringification quirk) are retired or replaced.
+//
+// When removing, also drop the call sites in `filterChatRawToolCalls` /
+// `filterResponsesOutputItemsForToolCalls` and the canonicaliser tests in
+// `auto_continue_test.go`.
+func canonicalizeAutoContinueArguments(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return raw
+	}
+	if trimmed[0] != '{' && trimmed[0] != '[' {
+		return raw
+	}
+	decoded, err := decodeJSONValue(trimmed)
+	if err != nil {
+		return raw
+	}
+	unwrapped := deepUnwrapJSONStrings(decoded)
+	encoded, err := json.Marshal(unwrapped)
+	if err != nil {
+		return raw
+	}
+	return string(encoded)
+}
+
+// deepUnwrapJSONStrings walks a value decoded from a tool-call arguments
+// payload and replaces any string whose contents are themselves valid JSON
+// for an array or object with the decoded structure. Plain strings,
+// numbers, bools, and nulls pass through unchanged. Map keys are not
+// rewritten.
+//
+// Removal criteria: see `canonicalizeAutoContinueArguments`. This helper
+// has no other call sites and goes away with it.
+func deepUnwrapJSONStrings(value any) any {
+	switch v := value.(type) {
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return v
+		}
+		if trimmed[0] != '{' && trimmed[0] != '[' {
+			return v
+		}
+		nested, err := decodeJSONValue(trimmed)
+		if err != nil {
+			return v
+		}
+		return deepUnwrapJSONStrings(nested)
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = deepUnwrapJSONStrings(item)
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for k, item := range v {
+			out[k] = deepUnwrapJSONStrings(item)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func decodeJSONValue(raw string) (any, error) {
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, errors.New("multiple JSON values")
+		}
+		return nil, err
+	}
+	return decoded, nil
 }
 
 // splitClientToolCalls separates plain client-owned tool calls from the

--- a/toolruntime/auto_continue_adapter_test.go
+++ b/toolruntime/auto_continue_adapter_test.go
@@ -1,6 +1,7 @@
 package toolruntime
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -255,5 +256,103 @@ func TestResponsesAdapterCarriesAutoContinueCallsToFinalResponse(t *testing.T) {
 	first := output[0].(map[string]any)
 	if stringValue(first["name"]) != "render_stat_cards" {
 		t.Fatalf("expected auto-continue function_call first, got %#v", first)
+	}
+}
+
+func TestChatAdapterMixedTurnCanonicalisesAutoContinueCalls(t *testing.T) {
+	adapter := newChatLoopAdapter(map[string]any{}, nil, nil, nil, "m", http.Header{})
+	adapter.autoContinueTools = map[string]struct{}{"render_stat_cards": {}}
+	response := &upstreamJSONResponse{body: map[string]any{
+		"choices": []any{
+			map[string]any{
+				"message": map[string]any{
+					"role": "assistant",
+					"tool_calls": []any{
+						map[string]any{
+							"id":   "call_widget",
+							"type": "function",
+							"function": map[string]any{
+								"name":      "render_stat_cards",
+								"arguments": `{"stats":"[{\"label\":\"a\",\"value\":1}]"}`,
+							},
+						},
+						map[string]any{
+							"id":   "call_external",
+							"type": "function",
+							"function": map[string]any{
+								"name":      "get_order",
+								"arguments": `{"id":"123"}`,
+							},
+						},
+					},
+				},
+				"finish_reason": "tool_calls",
+			},
+		},
+	}}
+	choice := response.body["choices"].([]any)[0].(map[string]any)
+	state := choice["message"]
+	items := adapter.autoContinueResponseItems(state, []toolCall{{id: "call_widget", name: "render_stat_cards"}})
+
+	adapter.stripRouterToolCallsFromResponse(response)
+	adapter.attachAutoContinueResponseItems(response, items)
+
+	message := choice["message"].(map[string]any)
+	calls := message["tool_calls"].([]any)
+	if len(calls) != 2 {
+		t.Fatalf("expected canonicalized render call plus external call, got %#v", calls)
+	}
+	widgetFn := calls[0].(map[string]any)["function"].(map[string]any)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(stringValue(widgetFn["arguments"])), &parsed); err != nil {
+		t.Fatalf("canonicalized arguments are invalid JSON: %v", err)
+	}
+	if _, ok := parsed["stats"].([]any); !ok {
+		t.Fatalf("stats should be a native array, got %T", parsed["stats"])
+	}
+	externalFn := calls[1].(map[string]any)["function"].(map[string]any)
+	if stringValue(externalFn["name"]) != "get_order" {
+		t.Fatalf("expected external call to remain second, got %#v", externalFn)
+	}
+}
+
+func TestResponsesAdapterMixedTurnCanonicalisesAutoContinueCalls(t *testing.T) {
+	adapter := newResponsesLoopAdapter(map[string]any{}, nil, nil, nil)
+	adapter.autoContinueTools = map[string]struct{}{"render_chart": {}}
+	state := []any{
+		map[string]any{
+			"id":        "fc_widget",
+			"type":      "function_call",
+			"name":      "render_chart",
+			"call_id":   "call_widget",
+			"arguments": `{"series":"[{\"label\":\"Q1\",\"value\":10}]"}`,
+		},
+		map[string]any{
+			"id":        "fc_external",
+			"type":      "function_call",
+			"name":      "get_order",
+			"call_id":   "call_external",
+			"arguments": `{"id":"123"}`,
+		},
+	}
+	response := &upstreamJSONResponse{body: map[string]any{"output": append([]any{}, state...)}}
+	items := adapter.autoContinueResponseItems(state, []toolCall{{id: "call_widget", name: "render_chart"}})
+
+	adapter.stripRouterToolCallsFromResponse(response)
+	adapter.attachAutoContinueResponseItems(response, items)
+
+	output := response.body["output"].([]any)
+	if len(output) != 2 {
+		t.Fatalf("expected canonicalized render item plus external item, got %#v", output)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(stringValue(output[0].(map[string]any)["arguments"])), &parsed); err != nil {
+		t.Fatalf("canonicalized arguments are invalid JSON: %v", err)
+	}
+	if _, ok := parsed["series"].([]any); !ok {
+		t.Fatalf("series should be a native array, got %T", parsed["series"])
+	}
+	if stringValue(output[1].(map[string]any)["name"]) != "get_order" {
+		t.Fatalf("expected external item to remain second, got %#v", output[1])
 	}
 }

--- a/toolruntime/auto_continue_test.go
+++ b/toolruntime/auto_continue_test.go
@@ -1,8 +1,10 @@
 package toolruntime
 
 import (
+	"encoding/json"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -155,6 +157,154 @@ func TestSplitClientToolCalls(t *testing.T) {
 func TestSplitClientToolCallsEmpty(t *testing.T) {
 	if d, e := splitClientToolCalls(nil, nil); d != nil || e != nil {
 		t.Fatalf("expected nil, nil for empty inputs; got %v, %v", d, e)
+	}
+}
+
+// TestCanonicalizeAutoContinueArgumentsUnwrapsDeepSeekShape verifies the
+// concrete DeepSeek-V4-Pro non-streaming quirk captured during validation:
+// nested arrays/objects emitted as JSON-encoded strings. Round-tripping
+// through the canonicaliser must yield native arrays/objects so client
+// widget schemas accept them.
+func TestCanonicalizeAutoContinueArgumentsUnwrapsDeepSeekShape(t *testing.T) {
+	raw := `{"stats":"[{\"label\":\"Human trials\",\"value\":\"20+\"}]"}`
+	got := canonicalizeAutoContinueArguments(raw)
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("canonicalised arguments not valid JSON: %v (raw=%s)", err, got)
+	}
+	stats, ok := parsed["stats"].([]any)
+	if !ok {
+		t.Fatalf("expected stats to be a native array, got %T (%v)", parsed["stats"], parsed["stats"])
+	}
+	if len(stats) != 1 {
+		t.Fatalf("expected one stat row, got %d (%v)", len(stats), stats)
+	}
+	row, _ := stats[0].(map[string]any)
+	if stringValue(row["label"]) != "Human trials" || stringValue(row["value"]) != "20+" {
+		t.Fatalf("row contents mangled: %v", row)
+	}
+}
+
+// TestCanonicalizeAutoContinueArgumentsIdempotent guarantees clean inputs
+// pass through unchanged so the unwrap can run on every auto-continue
+// response without risking silent shape changes for compliant providers.
+func TestCanonicalizeAutoContinueArgumentsIdempotent(t *testing.T) {
+	clean := `{"series":[{"label":"Q1","value":10},{"label":"Q2","value":15}]}`
+	once := canonicalizeAutoContinueArguments(clean)
+	twice := canonicalizeAutoContinueArguments(once)
+
+	var a, b any
+	if err := json.Unmarshal([]byte(once), &a); err != nil {
+		t.Fatalf("first pass not valid JSON: %v", err)
+	}
+	if err := json.Unmarshal([]byte(twice), &b); err != nil {
+		t.Fatalf("second pass not valid JSON: %v", err)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("not idempotent: once=%s twice=%s", once, twice)
+	}
+}
+
+// TestCanonicalizeAutoContinueArgumentsLeavesNonJSONAlone covers the
+// invariant that anything outside the JSON-object/array prefix is returned
+// verbatim. Avoids surprising downstream consumers when a tool emits a
+// malformed payload the router cannot reason about.
+func TestCanonicalizeAutoContinueArgumentsLeavesNonJSONAlone(t *testing.T) {
+	cases := []string{
+		"",
+		"plain text",
+		"{ unclosed",
+		`"already a string"`,
+	}
+	for _, in := range cases {
+		if got := canonicalizeAutoContinueArguments(in); got != in {
+			t.Errorf("canonicalise(%q) = %q; want unchanged", in, got)
+		}
+	}
+}
+
+// TestCanonicalizeAutoContinueArgumentsRecursive checks the helper unwraps
+// JSON-encoded strings nested several levels deep, which can happen when a
+// stringified array contains stringified objects.
+func TestCanonicalizeAutoContinueArgumentsRecursive(t *testing.T) {
+	raw := `{"outer":"{\"inner\":\"[1,2,3]\"}"}`
+	got := canonicalizeAutoContinueArguments(raw)
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("not valid JSON: %v (raw=%s)", err, got)
+	}
+	outer, _ := parsed["outer"].(map[string]any)
+	inner, _ := outer["inner"].([]any)
+	if len(inner) != 3 {
+		t.Fatalf("expected inner array of length 3, got %v", outer)
+	}
+}
+
+func TestCanonicalizeAutoContinueArgumentsPreservesLargeNumbers(t *testing.T) {
+	const large = "9007199254740993"
+	raw := `{"id":` + large + `,"nested":"{\"id\":` + large + `}"}`
+	got := canonicalizeAutoContinueArguments(raw)
+	if !strings.Contains(got, `"id":`+large) {
+		t.Fatalf("top-level number was not preserved: %s", got)
+	}
+	if !strings.Contains(got, `"nested":{"id":`+large+`}`) {
+		t.Fatalf("nested number was not preserved: %s", got)
+	}
+}
+
+// TestFilterChatRawToolCallsCanonicalisesArguments confirms the unwrap
+// runs as the auto-continue payload is shaped for the final response.
+func TestFilterChatRawToolCallsCanonicalisesArguments(t *testing.T) {
+	rawCalls := []any{
+		map[string]any{
+			"id":   "c1",
+			"type": "function",
+			"function": map[string]any{
+				"name":      "render_stat_cards",
+				"arguments": `{"stats":"[{\"label\":\"a\",\"value\":1}]"}`,
+			},
+		},
+	}
+	got := filterChatRawToolCalls(rawCalls, []toolCall{{id: "c1", name: "render_stat_cards"}})
+	if len(got) != 1 {
+		t.Fatalf("expected one filtered call, got %d", len(got))
+	}
+	call := got[0].(map[string]any)
+	fn := call["function"].(map[string]any)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(stringValue(fn["arguments"])), &parsed); err != nil {
+		t.Fatalf("filtered arguments not valid JSON: %v", err)
+	}
+	if _, ok := parsed["stats"].([]any); !ok {
+		t.Fatalf("stats should be a native array, got %T", parsed["stats"])
+	}
+}
+
+// TestFilterResponsesOutputItemsCanonicalisesArguments mirrors the chat
+// test for the /v1/responses output-items shape.
+func TestFilterResponsesOutputItemsCanonicalisesArguments(t *testing.T) {
+	items := []any{
+		map[string]any{
+			"id":        "fc1",
+			"type":      "function_call",
+			"name":      "render_chart",
+			"call_id":   "c1",
+			"arguments": `{"series":"[{\"label\":\"Q1\",\"value\":10}]"}`,
+		},
+	}
+	got := filterResponsesOutputItemsForToolCalls(items, []toolCall{{id: "c1", name: "render_chart"}})
+	if len(got) != 1 {
+		t.Fatalf("expected one filtered item, got %d", len(got))
+	}
+	item := got[0].(map[string]any)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(stringValue(item["arguments"])), &parsed); err != nil {
+		t.Fatalf("filtered arguments not valid JSON: %v", err)
+	}
+	if _, ok := parsed["series"].([]any); !ok {
+		t.Fatalf("series should be a native array, got %T", parsed["series"])
 	}
 }
 

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -205,8 +205,9 @@ func runToolLoop(
 			if traceID := adapter.traceID(); traceID != "" {
 				debugLogf("toolruntime:%s %s mixed_turn iterations=%d (router+external client calls in one turn; finalizing without replay)", traceID, adapter.tracePhase(i), i+1)
 			}
+			currentAutoContinueItems := adapter.autoContinueResponseItems(state, autoContinueCalls)
 			adapter.stripRouterToolCallsFromResponse(response)
-			adapter.attachAutoContinueResponseItems(response, autoContinueResponseItems)
+			adapter.attachAutoContinueResponseItems(response, append(autoContinueResponseItems, currentAutoContinueItems...))
 			adapter.applyUsage(response, usageTotals.Usage())
 			adapter.attachCitations(response.body, &citeState, &toolCalls, eventFlags)
 			return response, nil
@@ -304,16 +305,16 @@ func executeRouterToolCall(
 // messages history shape, the trace id threaded through debug logs, and the
 // per-iteration assistant-history sanitization quirk.
 type chatLoopAdapter struct {
-	body             map[string]any
-	prompt           *mcp.GetPromptResult
-	tools            []*mcp.Tool
-	ownedTools       map[string]struct{}
+	body              map[string]any
+	prompt            *mcp.GetPromptResult
+	tools             []*mcp.Tool
+	ownedTools        map[string]struct{}
 	autoContinueTools map[string]struct{}
-	modelName        string
-	requestHeaders   http.Header
-	tid              string
-	opts             webSearchOptions
-	toolSchemas      map[string]*jsonschema.Schema
+	modelName         string
+	requestHeaders    http.Header
+	tid               string
+	opts              webSearchOptions
+	toolSchemas       map[string]*jsonschema.Schema
 }
 
 func newChatLoopAdapter(body map[string]any, prompt *mcp.GetPromptResult, tools []*mcp.Tool, ownedTools map[string]struct{}, modelName string, requestHeaders http.Header) *chatLoopAdapter {
@@ -485,6 +486,9 @@ func (a *chatLoopAdapter) stripRouterToolCallsFromResponse(response *upstreamJSO
 		if _, ok := a.ownedTools[name]; ok {
 			continue
 		}
+		if _, ok := a.autoContinueTools[name]; ok {
+			continue
+		}
 		filtered = append(filtered, raw)
 	}
 	message["tool_calls"] = filtered
@@ -518,15 +522,15 @@ func (a *chatLoopAdapter) forcedFinalRequest(reqBody map[string]any) map[string]
 // list that threads every prior output back into each subsequent turn, plus
 // the `include` opt-in for `action.sources` on web_search_call items.
 type responsesLoopAdapter struct {
-	body             map[string]any
-	prompt           *mcp.GetPromptResult
-	tools            []*mcp.Tool
-	ownedTools       map[string]struct{}
+	body              map[string]any
+	prompt            *mcp.GetPromptResult
+	tools             []*mcp.Tool
+	ownedTools        map[string]struct{}
 	autoContinueTools map[string]struct{}
-	base             map[string]any
-	accumulatedInput []any
-	opts             webSearchOptions
-	toolSchemas      map[string]*jsonschema.Schema
+	base              map[string]any
+	accumulatedInput  []any
+	opts              webSearchOptions
+	toolSchemas       map[string]*jsonschema.Schema
 }
 
 func newResponsesLoopAdapter(body map[string]any, prompt *mcp.GetPromptResult, tools []*mcp.Tool, ownedTools map[string]struct{}) *responsesLoopAdapter {
@@ -627,6 +631,9 @@ func (a *responsesLoopAdapter) stripRouterToolCallsFromResponse(response *upstre
 			if _, ok := a.ownedTools[stringValue(item["name"])]; ok {
 				continue
 			}
+			if _, ok := a.autoContinueTools[stringValue(item["name"])]; ok {
+				continue
+			}
 		}
 		filtered = append(filtered, rawItem)
 	}
@@ -670,7 +677,13 @@ func filterChatRawToolCalls(rawCalls []any, calls []toolCall) []any {
 		if !matchesAnyToolCall(stringValue(call["id"]), stringValue(function["name"]), calls) {
 			continue
 		}
-		out = append(out, cloneJSONMap(call))
+		cloned := cloneJSONMap(call)
+		if clonedFn, ok := cloned["function"].(map[string]any); ok {
+			if args, ok := clonedFn["arguments"].(string); ok {
+				clonedFn["arguments"] = canonicalizeAutoContinueArguments(args)
+			}
+		}
+		out = append(out, cloned)
 	}
 	return out
 }
@@ -696,7 +709,11 @@ func filterResponsesOutputItemsForToolCalls(outputItems []any, calls []toolCall)
 		if !matchesAnyToolCall(callID, stringValue(item["name"]), calls) {
 			continue
 		}
-		out = append(out, cloneJSONMap(item))
+		cloned := cloneJSONMap(item)
+		if args, ok := cloned["arguments"].(string); ok {
+			cloned["arguments"] = canonicalizeAutoContinueArguments(args)
+		}
+		out = append(out, cloned)
 	}
 	return out
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalize auto-continue tool-call arguments for widgets by unwrapping JSON-encoded arrays/objects returned as strings. This fixes widget render failures and keeps argument shapes consistent across clients.

- **Bug Fixes**
  - Canonicalize arguments for auto-continue calls only by recursively unwrapping stringified JSON objects/arrays; idempotent and a no-op on parse errors; preserves large numbers.
  - Apply during response shaping for both chat (`tool_calls`) and responses (`function_call`) paths; in mixed turns, attach current canonicalized auto-continue items before finalizing; external client calls are untouched and order is preserved.
  - Added tests for DeepSeek non-streaming shape, idempotency, nested unwrapping, number preservation, and adapter integration.

<sup>Written for commit 43d89379f64129676775888d352952bcbcebc859. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

