### PR TITLE
chore: update whisper

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,9 +14,9 @@ models:
       - doc-upload.tinfoil.containers.tinfoil.dev
 
   whisper-large-v3-turbo:
-    repo: tinfoilsh/confidential-whisper-large-v3
+    repo: tinfoilsh/confidential-realtime-models
     enclaves:
-      - whisper.inf6.tinfoil.sh
+      - whisper-large-v3-turbo.realtime.inf9.tinfoil.sh
 
   voxtral-small-24b:
     repo: tinfoilsh/confidential-voxtral-small-24b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point `whisper-large-v3-turbo` to `tinfoilsh/confidential-realtime-models` and move to the new enclave host whisper-large-v3-turbo.realtime.inf9.tinfoil.sh to align with the realtime infra.

<sup>Written for commit 92d022f6cda213487b6883b5f32d25998d286ef4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

