### PR TITLE
File uploading (code-exec)

### DIFF
--- a/toolruntime/options.go
+++ b/toolruntime/options.go
@@ -23,6 +23,15 @@ type CodeExecutionOptions struct {
 	AccessToken        string
 	EncryptionKey      string
 	ContainerAuthToken string
+	// pointer to distinguish absent from empty
+	Uploads *[]UploadedFile
+}
+
+// code_execution_options.uploads. Handled by code-exec mcp
+type UploadedFile struct {
+	FileAccessToken string
+	Filename        string
+	Sha256          string
 }
 
 // WebSearchOptions wraps the caller's web_search_options block so it
@@ -102,7 +111,44 @@ func parseCodeExecutionOptions(raw any) (*CodeExecutionOptions, error) {
 	if ce.ContainerAuthToken == "" {
 		return nil, fmt.Errorf("code_execution_options.containerAuthToken is required")
 	}
+	if rawUploads, ok := m["uploads"]; ok {
+		uploads, err := parseUploads(rawUploads)
+		if err != nil {
+			return nil, err
+		}
+		ce.Uploads = &uploads
+	}
 	return ce, nil
+}
+
+func parseUploads(raw any) ([]UploadedFile, error) {
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("code_execution_options.uploads must be an array")
+	}
+	out := make([]UploadedFile, len(arr))
+	for i, item := range arr {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("code_execution_options.uploads[%d] must be an object", i)
+		}
+		u := UploadedFile{
+			FileAccessToken: stringField(entry, "fileAccessToken"),
+			Filename:        stringField(entry, "filename"),
+			Sha256:          stringField(entry, "sha256"),
+		}
+		if u.FileAccessToken == "" {
+			return nil, fmt.Errorf("code_execution_options.uploads[%d].fileAccessToken is required", i)
+		}
+		if u.Filename == "" {
+			return nil, fmt.Errorf("code_execution_options.uploads[%d].filename is required", i)
+		}
+		if u.Sha256 == "" {
+			return nil, fmt.Errorf("code_execution_options.uploads[%d].sha256 is required", i)
+		}
+		out[i] = u
+	}
+	return out, nil
 }
 
 func stringField(m map[string]any, key string) string {
@@ -119,12 +165,24 @@ func attachRouterOptionsMeta(registry *sessionRegistry, opts *RouterOptions) {
 		return
 	}
 	if ce := opts.CodeExecution; ce != nil {
+		metaBlock := map[string]any{
+			"accessToken":        ce.AccessToken,
+			"encryptionKey":      ce.EncryptionKey,
+			"containerAuthToken": ce.ContainerAuthToken,
+		}
+		if ce.Uploads != nil {
+			arr := make([]any, len(*ce.Uploads))
+			for i, u := range *ce.Uploads {
+				arr[i] = map[string]any{
+					"fileAccessToken": u.FileAccessToken,
+					"filename":        u.Filename,
+					"sha256":          u.Sha256,
+				}
+			}
+			metaBlock["uploads"] = arr
+		}
 		registry.metaByProfile[toolprofile.CodeExecution.Name] = mcp.Meta{
-			toolprofile.CodeExecutionMetaKey: map[string]any{
-				"accessToken":        ce.AccessToken,
-				"encryptionKey":      ce.EncryptionKey,
-				"containerAuthToken": ce.ContainerAuthToken,
-			},
+			toolprofile.CodeExecutionMetaKey: metaBlock,
 		}
 	}
 }

--- a/toolruntime/options_test.go
+++ b/toolruntime/options_test.go
@@ -3,6 +3,10 @@ package toolruntime
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/tinfoilsh/confidential-model-router/toolprofile"
 )
 
 func unmarshal(t *testing.T, raw string) map[string]any {
@@ -140,6 +144,94 @@ func TestExtractRouterOptions_WebSearchInnerPayloadIsPreserved(t *testing.T) {
 	}
 }
 
+func TestExtractRouterOptions_CodeExecUploadsAbsentMeansNil(t *testing.T) {
+	body := unmarshal(t, `{
+		"code_execution_options": {
+			"accessToken": "tok-a",
+			"encryptionKey": "key-b",
+			"containerAuthToken": "ctr-c"
+		}
+	}`)
+	opts, err := ExtractRouterOptions(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.CodeExecution.Uploads != nil {
+		t.Fatalf("Uploads must be nil when uploads field is absent, got %+v", *opts.CodeExecution.Uploads)
+	}
+}
+
+func TestExtractRouterOptions_CodeExecUploadsEmptyArrayPreserved(t *testing.T) {
+	// Empty array (not absent) is the signal to clear /user-uploads;
+	// must round-trip as non-nil pointer to a zero-length slice.
+	body := unmarshal(t, `{
+		"code_execution_options": {
+			"accessToken": "tok-a",
+			"encryptionKey": "key-b",
+			"containerAuthToken": "ctr-c",
+			"uploads": []
+		}
+	}`)
+	opts, err := ExtractRouterOptions(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.CodeExecution.Uploads == nil {
+		t.Fatalf("Uploads must be non-nil when uploads:[] is sent")
+	}
+	if len(*opts.CodeExecution.Uploads) != 0 {
+		t.Fatalf("Uploads must be empty, got %+v", *opts.CodeExecution.Uploads)
+	}
+}
+
+func TestExtractRouterOptions_CodeExecUploadsParsesEntries(t *testing.T) {
+	body := unmarshal(t, `{
+		"code_execution_options": {
+			"accessToken": "tok-a",
+			"encryptionKey": "key-b",
+			"containerAuthToken": "ctr-c",
+			"uploads": [
+				{"fileAccessToken": "fat-1", "filename": "report.pdf", "sha256": "abc"},
+				{"fileAccessToken": "fat-2", "filename": "data.csv",   "sha256": "def"}
+			]
+		}
+	}`)
+	opts, err := ExtractRouterOptions(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.CodeExecution.Uploads == nil || len(*opts.CodeExecution.Uploads) != 2 {
+		t.Fatalf("expected 2 uploads, got %+v", opts.CodeExecution.Uploads)
+	}
+	got := (*opts.CodeExecution.Uploads)[0]
+	if got.FileAccessToken != "fat-1" || got.Filename != "report.pdf" || got.Sha256 != "abc" {
+		t.Fatalf("upload[0] mismatch: %+v", got)
+	}
+	got = (*opts.CodeExecution.Uploads)[1]
+	if got.FileAccessToken != "fat-2" || got.Filename != "data.csv" || got.Sha256 != "def" {
+		t.Fatalf("upload[1] mismatch: %+v", got)
+	}
+}
+
+func TestExtractRouterOptions_CodeExecUploadsRejectsBadShape(t *testing.T) {
+	cases := map[string]string{
+		"not-an-array":          `{"code_execution_options":{"accessToken":"a","encryptionKey":"b","containerAuthToken":"c","uploads":"oops"}}`,
+		"entry-not-object":      `{"code_execution_options":{"accessToken":"a","encryptionKey":"b","containerAuthToken":"c","uploads":["oops"]}}`,
+		"entry-missing-fat":     `{"code_execution_options":{"accessToken":"a","encryptionKey":"b","containerAuthToken":"c","uploads":[{"filename":"x","sha256":"y"}]}}`,
+		"entry-missing-name":    `{"code_execution_options":{"accessToken":"a","encryptionKey":"b","containerAuthToken":"c","uploads":[{"fileAccessToken":"x","sha256":"y"}]}}`,
+		"entry-missing-sha":     `{"code_execution_options":{"accessToken":"a","encryptionKey":"b","containerAuthToken":"c","uploads":[{"fileAccessToken":"x","filename":"y"}]}}`,
+		"entry-non-string-name": `{"code_execution_options":{"accessToken":"a","encryptionKey":"b","containerAuthToken":"c","uploads":[{"fileAccessToken":"x","filename":42,"sha256":"y"}]}}`,
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			body := unmarshal(t, raw)
+			if _, err := ExtractRouterOptions(body); err == nil {
+				t.Fatalf("expected error for %s", name)
+			}
+		})
+	}
+}
+
 func TestExtractRouterOptions_OnlySomeOptionsPresent(t *testing.T) {
 	body := unmarshal(t, `{
 		"model": "x",
@@ -157,5 +249,76 @@ func TestExtractRouterOptions_OnlySomeOptionsPresent(t *testing.T) {
 	}
 	if opts.PIICheck != nil {
 		t.Fatalf("PIICheck must be nil when pii_check_options is absent")
+	}
+}
+
+// codeExecMeta returns the inner tinfoil_code_exec map after running
+// attachRouterOptionsMeta on a freshly built registry — the boundary
+// the MCP server actually sees.
+func codeExecMeta(t *testing.T, opts *RouterOptions) map[string]any {
+	t.Helper()
+	r := &sessionRegistry{metaByProfile: map[string]mcp.Meta{}}
+	attachRouterOptionsMeta(r, opts)
+	meta := r.metaByProfile[toolprofile.CodeExecution.Name]
+	if meta == nil {
+		t.Fatalf("expected meta for %q, got nil", toolprofile.CodeExecution.Name)
+	}
+	block, ok := meta[toolprofile.CodeExecutionMetaKey].(map[string]any)
+	if !ok {
+		t.Fatalf("meta block has wrong type: %T", meta[toolprofile.CodeExecutionMetaKey])
+	}
+	return block
+}
+
+func TestAttachRouterOptionsMeta_NoUploadsKeyWhenAbsent(t *testing.T) {
+	block := codeExecMeta(t, &RouterOptions{
+		CodeExecution: &CodeExecutionOptions{
+			AccessToken: "a", EncryptionKey: "b", ContainerAuthToken: "c",
+		},
+	})
+	if _, present := block["uploads"]; present {
+		t.Fatalf("uploads key must be absent when ce.Uploads is nil; got %+v", block)
+	}
+}
+
+func TestAttachRouterOptionsMeta_UploadsKeyPresentWhenEmpty(t *testing.T) {
+	empty := []UploadedFile{}
+	block := codeExecMeta(t, &RouterOptions{
+		CodeExecution: &CodeExecutionOptions{
+			AccessToken: "a", EncryptionKey: "b", ContainerAuthToken: "c",
+			Uploads: &empty,
+		},
+	})
+	got, ok := block["uploads"].([]any)
+	if !ok {
+		t.Fatalf("uploads must be []any, got %T", block["uploads"])
+	}
+	if len(got) != 0 {
+		t.Fatalf("uploads must be length 0, got %+v", got)
+	}
+}
+
+func TestAttachRouterOptionsMeta_UploadsForwardedVerbatim(t *testing.T) {
+	files := []UploadedFile{
+		{FileAccessToken: "fat-1", Filename: "report.pdf", Sha256: "abc"},
+		{FileAccessToken: "fat-2", Filename: "data.csv", Sha256: "def"},
+	}
+	block := codeExecMeta(t, &RouterOptions{
+		CodeExecution: &CodeExecutionOptions{
+			AccessToken: "a", EncryptionKey: "b", ContainerAuthToken: "c",
+			Uploads: &files,
+		},
+	})
+	got, ok := block["uploads"].([]any)
+	if !ok || len(got) != 2 {
+		t.Fatalf("uploads not propagated: %+v", block["uploads"])
+	}
+	first, _ := got[0].(map[string]any)
+	if first["fileAccessToken"] != "fat-1" || first["filename"] != "report.pdf" || first["sha256"] != "abc" {
+		t.Fatalf("uploads[0] mismatch: %+v", first)
+	}
+	second, _ := got[1].(map[string]any)
+	if second["fileAccessToken"] != "fat-2" || second["filename"] != "data.csv" || second["sha256"] != "def" {
+		t.Fatalf("uploads[1] mismatch: %+v", second)
 	}
 }


### PR DESCRIPTION
pass through uploaded files. Validates format to ensure failing quickly, like code exec credentials do.