### PR TITLE
chore: update kimi-k2-6

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -74,9 +74,9 @@ models:
       - qwen3-vl-30b.inf9.tinfoil.sh
 
   kimi-k2-6:
-    repo: tinfoilsh/confidential-kimi-k2-6
+    repo: tinfoilsh/confidential-kimi-k2-6-b200
     enclaves:
-      - kimi-k2-6-inf10.tinfoil.containers.tinfoil.dev
+      - kimi-k2-6.inf13.tinfoil.sh
     rate_limit:
       max_requests_per_minute: 4
     overload:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the `kimi-k2-6` model config to use repo `tinfoilsh/confidential-kimi-k2-6-b200` and enclave `kimi-k2-6.inf13.tinfoil.sh`. No changes to rate limit or other settings.

<sup>Written for commit 9eb706a840af6aa94e1a23a7169b0dc9cdfcf113. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

