### PR TITLE
chore: update enclave hostname for gpt-oss-120b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -52,7 +52,7 @@ models:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
       - gpt-oss-120b-0.inf6.tinfoil.sh
-      - gpt-oss-120b-1.inf9.tinfoil.sh
+      - gpt-oss-120b-1.inf6.tinfoil.sh
       - gpt-oss-120b-2.inf9.tinfoil.sh
     overload:
       max_requests_waiting: 8


### PR DESCRIPTION
Updated the enclave configuration for gpt-oss-120b.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `config.yml` to route `gpt-oss-120b` to the correct enclave. Switches `gpt-oss-120b-1.inf9.tinfoil.sh` to `gpt-oss-120b-1.inf6.tinfoil.sh` to match the current cluster and prevent misrouting.

<sup>Written for commit 16acd0a91a11ade8a487fb677dfd07e287a7ff2f. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/326?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

