### PR TITLE
chore: remove 1 gpt-oss

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -53,7 +53,6 @@ models:
     enclaves:
       - gpt-oss-120b-0.inf6.tinfoil.sh
       - gpt-oss-120b-1.inf6.tinfoil.sh
-      - gpt-oss-120b-2.inf9.tinfoil.sh
     overload:
       max_requests_waiting: 8
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed `gpt-oss-120b-2.inf9.tinfoil.sh` from the `models.enclaves` list to stop routing traffic to a retired host. 120B requests now balance across the two remaining enclaves, reducing connection errors.

<sup>Written for commit 1bc7040b4f023aaa8112e27c39cfc68939f9b2c4. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/327?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

