### PR TITLE
chore: remove 1 gemma

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -96,7 +96,6 @@ models:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
-      - gemma4-31b-inf9.tinfoil.containers.tinfoil.dev
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the `gemma4-31b-inf9.tinfoil.containers.tinfoil.dev` enclave from the `gemma4-31b` model config to stop routing traffic to that node and keep the config accurate. This reduces potential misroutes and simplifies operations.

<sup>Written for commit 8991e0e203c200a04fb90edf37729b730630e383. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/328?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

