### PR TITLE
chore: update enclave for qwen3-vl-30b configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -70,7 +70,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl-30b.inf9.tinfoil.sh
+      - qwen3-vl.tinfoil.containers.tinfoil.dev
 
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the `qwen3-vl-30b` model to use the new enclave hostname, switching from `qwen3-vl-30b.inf9.tinfoil.sh` to `qwen3-vl.tinfoil.containers.tinfoil.dev`.
This routes traffic to the new enclave; no other changes.

<sup>Written for commit f6ea254e51cc48d4972e1b31c60baab9f70fb60c. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/329?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

