### PR TITLE
chore: update domain for nomic-embed-text model

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,7 @@ models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:
-      - nomic.inf9.tinfoil.sh
+      - nomic.tinfoil.containers.tinfoil.dev
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update enclave domain for the `nomic-embed-text` model to ensure it resolves in the containers environment. Replaces `nomic.inf9.tinfoil.sh` with `nomic.tinfoil.containers.tinfoil.dev` in `config.yml`.

<sup>Written for commit c2822dd52df57ee92fb83c86ea31c0c673cd51af. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/330?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

