### PR TITLE
chore: update config for moved models

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -16,22 +16,22 @@ models:
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-realtime-models
     enclaves:
-      - whisper-large-v3-turbo.realtime.inf9.tinfoil.sh
+      - whisper-large-v3-turbo.realtime.inf10.tinfoil.sh
 
   voxtral-small-24b:
     repo: tinfoilsh/confidential-voxtral-small-24b
     enclaves:
-      - voxtral-small-24b.inf9.tinfoil.sh
+      - voxtral-small-24b.inf10.tinfoil.sh
 
   voxtral-mini-4b-realtime:
     repo: tinfoilsh/confidential-realtime-models
     enclaves:
-      - voxtral-mini-4b-realtime.realtime.inf9.tinfoil.sh
+      - voxtral-mini-4b-realtime.realtime.inf10.tinfoil.sh
 
   voxtral-tts:
     repo: tinfoilsh/confidential-realtime-models
     enclaves:
-      - voxtral-tts.realtime.inf9.tinfoil.sh
+      - voxtral-tts.realtime.inf10.tinfoil.sh
 
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
@@ -53,6 +53,7 @@ models:
     enclaves:
       - gpt-oss-120b-0.inf6.tinfoil.sh
       - gpt-oss-120b-1.inf6.tinfoil.sh
+      - gpt-oss-120b-1.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 8
       retry_after_minutes: 1
@@ -65,7 +66,7 @@ models:
   qwen3-tts:
     repo: tinfoilsh/confidential-realtime-models
     enclaves:
-      - qwen3-tts.realtime.inf9.tinfoil.sh
+      - qwen3-tts.realtime.inf10.tinfoil.sh
 
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
@@ -96,6 +97,7 @@ models:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
+      - gemma4-31b-1.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point model enclave hosts to the new inf10 cluster and add extra capacity for two models to improve availability.
Updated whisper-large-v3-turbo, voxtral-small-24b, voxtral-mini-4b-realtime, voxtral-tts, and qwen3-tts to inf10; added inf10 nodes for gpt-oss-120b and gemma4-31b.

<sup>Written for commit 1ef28acda4f35eae6fe4aabb439deacd160151e1. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/331?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

