### PR TITLE
feat: bill web search as a separate usage line item

### DIFF
--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -181,6 +181,20 @@ func Handle(w http.ResponseWriter, r *http.Request, em *manager.EnclaveManager, 
 // Session setup
 // ---------------------------------------------------------------------------
 
+// newToolSessionRequestID returns the per-session ID used as the outbound
+// X-Tinfoil-Tool-Request-Id header and as the ContextID / RootRequestID
+// inside the signed usage-context.
+//
+// The downstream tool service uses this ID as the per-session billing dedup
+// key, so it MUST be generated server-side. The function deliberately
+// ignores any client-supplied request-id headers on r: honoring a value the
+// caller can choose would let a malicious client collapse many billable
+// tool sessions into one by reusing the same ID across unrelated chat
+// completions within the downstream dedup window.
+func newToolSessionRequestID(_ *http.Request) string {
+	return uuid.NewString()
+}
+
 // connectToolSession opens one attested MCP session for a single
 // profile. buildSessionRegistry invokes it once per active profile
 // and aggregates the results into the per-request routing table.
@@ -190,10 +204,7 @@ func connectToolSession(ctx context.Context, em *manager.EnclaveManager, profile
 		return nil, err
 	}
 
-	requestID := r.Header.Get("X-Request-Id")
-	if requestID == "" {
-		requestID = uuid.NewString()
-	}
+	requestID := newToolSessionRequestID(r)
 
 	headers, err := toolSessionHeaders(r, requestID, modelName, body, safety, em.UsageContextSecret(), time.Now)
 	if err != nil {

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -213,9 +213,13 @@ func connectToolSession(ctx context.Context, em *manager.EnclaveManager, profile
 
 // toolSessionHeaders builds the per-request HTTP headers attached to an
 // outbound MCP tool session. When usageContextSecret is set, it also signs a
-// usage-context header carrying BillCustomerRequest=false so the downstream
-// tool service treats the call as part of the router's already-counted
-// customer request and does not double-bill it.
+// usage-context header carrying BillCustomerRequest=true so the downstream
+// tool service bills its own per-session line item alongside the router's
+// token-based chat-completion billing. Double-charging is prevented by the
+// downstream reporter's per-RequestID dedup window: every internal MCP HTTP
+// call within one chat completion shares the same X-Tinfoil-Tool-Request-Id
+// (set by connectToolSession), so multiple model-initiated tool calls inside
+// a single chat completion collapse into a single billable session event.
 func toolSessionHeaders(r *http.Request, requestID, modelName string, body map[string]any, safety safetyOptIns, usageContextSecret string, now func() time.Time) (http.Header, error) {
 	headers := make(http.Header)
 	headers.Set(toolcontext.HeaderRequestID, requestID)
@@ -242,7 +246,7 @@ func toolSessionHeaders(r *http.Request, requestID, modelName string, body map[s
 			ParentService:       contract.ServiceRouter,
 			APIKeyHash:          usagecontext.HashAPIKey(apiKey),
 			Depth:               1,
-			BillCustomerRequest: false,
+			BillCustomerRequest: true,
 			IssuedAt:            now().UTC(),
 		}, usageContextSecret); err != nil {
 			return nil, fmt.Errorf("sign tool usage context: %w", err)

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tinfoilsh/confidential-model-router/manager"
 	"github.com/tinfoilsh/confidential-model-router/tokencount"
@@ -960,5 +961,39 @@ func TestToolSessionHeadersOmitsUsageContextWhenSecretEmpty(t *testing.T) {
 
 	if _, ok, err := usagecontext.FromHeaders(headers, "irrelevant", now, time.Minute); err != nil || ok {
 		t.Fatalf("expected no usage context when secret is empty (ok=%v err=%v)", ok, err)
+	}
+}
+
+// TestNewToolSessionRequestIDIgnoresClientHeaders locks in the contract that
+// the tool-session request ID is generated server-side and does NOT derive
+// from any client-supplied request-id header. Downstream tool services use
+// this ID as their per-session billing dedup key, so honoring a value the
+// caller can choose would let a malicious client collapse many billable
+// sessions into one by reusing the same ID across unrelated chat completions.
+func TestNewToolSessionRequestIDIgnoresClientHeaders(t *testing.T) {
+	const spoofed = "client-controlled-id"
+
+	req, err := http.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("X-Request-Id", spoofed)
+	req.Header.Set("X-Request-ID", spoofed)
+	req.Header.Set("X-Tinfoil-Tool-Request-Id", spoofed)
+
+	got := newToolSessionRequestID(req)
+	if got == spoofed {
+		t.Fatalf("tool-session request id must not derive from client headers, got %q", got)
+	}
+	if got == "" {
+		t.Fatal("tool-session request id must not be empty")
+	}
+	if _, err := uuid.Parse(got); err != nil {
+		t.Fatalf("tool-session request id must be a UUID, got %q: %v", got, err)
+	}
+
+	another := newToolSessionRequestID(req)
+	if got == another {
+		t.Fatal("successive tool-session request ids must be unique")
 	}
 }

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -896,9 +896,11 @@ func TestChatAdapterStripRouterToolCallsPreservesUnparseableEntries(t *testing.T
 }
 
 // TestToolSessionHeadersSignsUsageContext asserts that outbound MCP tool
-// session headers carry a usage-context signed with BillCustomerRequest=false
-// and ParentService=router, so downstream tool services do not re-bill the
-// customer request the router has already counted.
+// session headers carry a usage-context signed with BillCustomerRequest=true
+// and ParentService=router, so downstream tool services bill their own
+// per-session line item alongside the router's chat-completion billing.
+// Per-RequestID dedup in the downstream reporter prevents double-charging
+// across multiple internal tool calls within one chat completion.
 func TestToolSessionHeadersSignsUsageContext(t *testing.T) {
 	const secret = "tool-session-secret"
 	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
@@ -935,8 +937,8 @@ func TestToolSessionHeadersSignsUsageContext(t *testing.T) {
 	if got.Depth != 1 {
 		t.Fatalf("depth mismatch: got %d want 1", got.Depth)
 	}
-	if got.BillCustomerRequest {
-		t.Fatal("router-fanned-out tool calls must set BillCustomerRequest=false")
+	if !got.BillCustomerRequest {
+		t.Fatal("router-fanned-out tool calls must set BillCustomerRequest=true so downstream services bill their own session line item")
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bill MCP web search/tool sessions as a separate usage line item. We sign tool session requests with BillCustomerRequest=true and use a server-generated request ID to safely dedup per session and prevent spoofing.

- New Features
  - Sign usage-context with BillCustomerRequest=true; ParentService stays router.
  - Use a server-generated tool session request ID shared across internal calls in one chat completion for dedup.

- Bug Fixes
  - Ignore client-supplied request-id headers and always generate a new UUID to prevent dedup bypass; added tests.

<sup>Written for commit f5ba6a1e21453569b28916a26338b3c9304cf9ff. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/333?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

