### PR TITLE
chore: move nomic

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,7 @@ models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
     enclaves:
-      - nomic.tinfoil.containers.tinfoil.dev
+      - nomic.inf10.tinfoil.sh
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `config.yml` to point the `nomic-embed-text` model at the new enclave host `nomic.inf10.tinfoil.sh`. This routes embed requests to the new deployment.

<sup>Written for commit 6e137a045246189bfa47f6a239e7e9fa4da5df3f. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/334?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

