### PR TITLE
chore: move qwenvl

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl.tinfoil.containers.tinfoil.dev
+      - qwen3-vl.inf10.tinfoil.sh
 
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6-b200


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the `qwen3-vl-30b` model to use the new enclave host. Changed `qwen3-vl.tinfoil.containers.tinfoil.dev` to `qwen3-vl.inf10.tinfoil.sh` to route requests to the `inf10` cluster.

<sup>Written for commit 4be66dc2ee73e607ccc25ab7a64240f406da5c34. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/335?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

