### PR TITLE
fix: domain for qwenvl

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ models:
   qwen3-vl-30b:
     repo: tinfoilsh/confidential-qwen3-vl-30b
     enclaves:
-      - qwen3-vl.inf10.tinfoil.sh
+      - qwen3-vl-30b.inf10.tinfoil.sh
 
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6-b200


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the enclave domain for the `qwen3-vl-30b` model in `config.yml` to `qwen3-vl-30b.inf10.tinfoil.sh` (was `qwen3-vl.inf10.tinfoil.sh`). This restores correct routing to the 30B model’s enclave.

<sup>Written for commit 721cc039c8392a9b5f9b55a8bcbded7abdec84b0. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/336?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

