### PR TITLE
Separate out prefix-cached token billing

### DIFF
--- a/billing/events.go
+++ b/billing/events.go
@@ -14,6 +14,8 @@ import (
 	usageclient "github.com/tinfoilsh/usage-reporting-go/client"
 )
 
+const meterCachedInputTokens = "cached_input_tokens"
+
 // Event represents a billing event with token usage. CachedPromptTokens is the
 // subset of PromptTokens that the model served from its prompt cache; the
 // uncached portion is derived downstream.
@@ -99,7 +101,7 @@ func (c *Collector) AddEvent(event Event) {
 		}
 		if cachedInputTokens > 0 {
 			meters = append(meters, usagereporting.Meter{
-				Name:     usagereporting.MeterCachedInputTokens,
+				Name:     meterCachedInputTokens,
 				Quantity: cachedInputTokens,
 			})
 		}

--- a/billing/events.go
+++ b/billing/events.go
@@ -14,8 +14,6 @@ import (
 	usageclient "github.com/tinfoilsh/usage-reporting-go/client"
 )
 
-const meterCachedInputTokens = "cached_input_tokens"
-
 // Event represents a billing event with token usage. CachedPromptTokens is the
 // subset of PromptTokens that the model served from its prompt cache; the
 // uncached portion is derived downstream.
@@ -101,7 +99,7 @@ func (c *Collector) AddEvent(event Event) {
 		}
 		if cachedInputTokens > 0 {
 			meters = append(meters, usagereporting.Meter{
-				Name:     meterCachedInputTokens,
+				Name:     usagereporting.MeterCachedInputTokens,
 				Quantity: cachedInputTokens,
 			})
 		}

--- a/billing/events.go
+++ b/billing/events.go
@@ -14,19 +14,22 @@ import (
 	usageclient "github.com/tinfoilsh/usage-reporting-go/client"
 )
 
-// Event represents a billing event with token usage
+// Event represents a billing event with token usage. CachedPromptTokens is the
+// subset of PromptTokens that the model served from its prompt cache; the
+// uncached portion is derived downstream.
 type Event struct {
-	Timestamp        time.Time `json:"timestamp"`
-	UserID           string    `json:"user_id"`
-	Model            string    `json:"model"`
-	PromptTokens     int       `json:"prompt_tokens"`
-	CompletionTokens int       `json:"completion_tokens"`
-	TotalTokens      int       `json:"total_tokens"`
-	RequestID        string    `json:"request_id"`
-	Enclave          string    `json:"enclave"`
-	RequestPath      string    `json:"request_path"`
-	Streaming        bool      `json:"streaming"`
-	APIKey           string    `json:"api_key"`
+	Timestamp          time.Time `json:"timestamp"`
+	UserID             string    `json:"user_id"`
+	Model              string    `json:"model"`
+	PromptTokens       int       `json:"prompt_tokens"`
+	CachedPromptTokens int       `json:"cached_prompt_tokens"`
+	CompletionTokens   int       `json:"completion_tokens"`
+	TotalTokens        int       `json:"total_tokens"`
+	RequestID          string    `json:"request_id"`
+	Enclave            string    `json:"enclave"`
+	RequestPath        string    `json:"request_path"`
+	Streaming          bool      `json:"streaming"`
+	APIKey             string    `json:"api_key"`
 }
 
 // Collector ships billing events to the control plane via the usage reporter.
@@ -85,6 +88,22 @@ func (c *Collector) AddEvent(event Event) {
 			inputTokens = int64(event.TotalTokens)
 		}
 
+		cachedInputTokens := int64(event.CachedPromptTokens)
+		if cachedInputTokens > inputTokens {
+			cachedInputTokens = inputTokens
+		}
+
+		meters := []usagereporting.Meter{
+			{Name: usagereporting.MeterInputTokens, Quantity: inputTokens},
+			{Name: usagereporting.MeterOutputTokens, Quantity: outputTokens},
+		}
+		if cachedInputTokens > 0 {
+			meters = append(meters, usagereporting.Meter{
+				Name:     usagereporting.MeterCachedInputTokens,
+				Quantity: cachedInputTokens,
+			})
+		}
+
 		c.reporter.AddEvent(usagereporting.Event{
 			RequestID:  event.RequestID,
 			OccurredAt: event.Timestamp,
@@ -94,10 +113,7 @@ func (c *Collector) AddEvent(event Event) {
 				Name:    usagereporting.OperationRouterModelRequest,
 			},
 			CustomerRequests: 1,
-			Meters: []usagereporting.Meter{
-				{Name: usagereporting.MeterInputTokens, Quantity: inputTokens},
-				{Name: usagereporting.MeterOutputTokens, Quantity: outputTokens},
-			},
+			Meters:           meters,
 			Attributes: map[string]string{
 				"model":     event.Model,
 				"route":     event.RequestPath,

--- a/billing/events_test.go
+++ b/billing/events_test.go
@@ -130,8 +130,8 @@ func TestCollectorEmitsCachedInputTokensMeterWhenPresent(t *testing.T) {
 	if meters[usagereporting.MeterInputTokens] != 100 {
 		t.Errorf("input_tokens mismatch: got %d want 100", meters[usagereporting.MeterInputTokens])
 	}
-	if meters[meterCachedInputTokens] != 64 {
-		t.Errorf("cached_input_tokens mismatch: got %d want 64", meters[meterCachedInputTokens])
+	if meters[usagereporting.MeterCachedInputTokens] != 64 {
+		t.Errorf("cached_input_tokens mismatch: got %d want 64", meters[usagereporting.MeterCachedInputTokens])
 	}
 	if meters[usagereporting.MeterOutputTokens] != 7 {
 		t.Errorf("output_tokens mismatch: got %d want 7", meters[usagereporting.MeterOutputTokens])
@@ -150,7 +150,7 @@ func TestCollectorOmitsCachedMeterWhenZero(t *testing.T) {
 
 	batch := readBatch()
 	for _, m := range batch.Events[0].Meters {
-		if m.Name == meterCachedInputTokens {
+		if m.Name == usagereporting.MeterCachedInputTokens {
 			t.Fatalf("cached_input_tokens meter should be omitted when zero, got %+v", batch.Events[0].Meters)
 		}
 	}

--- a/billing/events_test.go
+++ b/billing/events_test.go
@@ -143,8 +143,8 @@ func TestCollectorEmitsCachedInputTokensMeterWhenPresent(t *testing.T) {
 	if meters[usagereporting.MeterInputTokens] != 100 {
 		t.Errorf("input_tokens mismatch: got %d want 100", meters[usagereporting.MeterInputTokens])
 	}
-	if meters[usagereporting.MeterCachedInputTokens] != 64 {
-		t.Errorf("cached_input_tokens mismatch: got %d want 64", meters[usagereporting.MeterCachedInputTokens])
+	if meters[meterCachedInputTokens] != 64 {
+		t.Errorf("cached_input_tokens mismatch: got %d want 64", meters[meterCachedInputTokens])
 	}
 	if meters[usagereporting.MeterOutputTokens] != 7 {
 		t.Errorf("output_tokens mismatch: got %d want 7", meters[usagereporting.MeterOutputTokens])
@@ -187,7 +187,7 @@ func TestCollectorOmitsCachedMeterWhenZero(t *testing.T) {
 		t.Fatalf("decode batch: %v", err)
 	}
 	for _, m := range batch.Events[0].Meters {
-		if m.Name == usagereporting.MeterCachedInputTokens {
+		if m.Name == meterCachedInputTokens {
 			t.Fatalf("cached_input_tokens meter should be omitted when zero, got %+v", batch.Events[0].Meters)
 		}
 	}

--- a/billing/events_test.go
+++ b/billing/events_test.go
@@ -12,10 +12,9 @@ import (
 	usagereporting "github.com/tinfoilsh/usage-reporting-go"
 )
 
-// TestCollectorEmitsCustomerRequestAndTokenMeters verifies that a billing
-// event flushed through the reporter carries CustomerRequests=1 and exactly
-// the canonical input/output token meters (no requests meter).
-func TestCollectorEmitsCustomerRequestAndTokenMeters(t *testing.T) {
+func setupCollectorTest(t *testing.T) (*Collector, func() usagereporting.Batch) {
+	t.Helper()
+
 	bodies := make(chan []byte, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		buf, err := io.ReadAll(r.Body)
@@ -25,10 +24,40 @@ func TestCollectorEmitsCustomerRequestAndTokenMeters(t *testing.T) {
 		bodies <- buf
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	c := NewCollector(server.URL, "router-test", "test-secret")
-	defer c.Stop()
+	t.Cleanup(c.Stop)
+
+	readBatch := func() usagereporting.Batch {
+		t.Helper()
+		c.reporter.Flush(context.Background())
+
+		var body []byte
+		select {
+		case body = <-bodies:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for billing event delivery")
+		}
+
+		var batch usagereporting.Batch
+		if err := json.Unmarshal(body, &batch); err != nil {
+			t.Fatalf("decode batch: %v", err)
+		}
+		if len(batch.Events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(batch.Events))
+		}
+		return batch
+	}
+
+	return c, readBatch
+}
+
+// TestCollectorEmitsCustomerRequestAndTokenMeters verifies that a billing
+// event flushed through the reporter carries CustomerRequests=1 and exactly
+// the canonical input/output token meters (no requests meter).
+func TestCollectorEmitsCustomerRequestAndTokenMeters(t *testing.T) {
+	c, readBatch := setupCollectorTest(t)
 
 	c.AddEvent(Event{
 		Timestamp:        time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
@@ -43,22 +72,7 @@ func TestCollectorEmitsCustomerRequestAndTokenMeters(t *testing.T) {
 		APIKey:           "sk-test-1234567890",
 	})
 
-	c.reporter.Flush(context.Background())
-
-	var body []byte
-	select {
-	case body = <-bodies:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for billing event delivery")
-	}
-
-	var batch usagereporting.Batch
-	if err := json.Unmarshal(body, &batch); err != nil {
-		t.Fatalf("decode batch: %v", err)
-	}
-	if len(batch.Events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(batch.Events))
-	}
+	batch := readBatch()
 	got := batch.Events[0]
 
 	if got.Operation.Service != usagereporting.ServiceRouter {
@@ -94,19 +108,7 @@ func TestCollectorEmitsCustomerRequestAndTokenMeters(t *testing.T) {
 }
 
 func TestCollectorEmitsCachedInputTokensMeterWhenPresent(t *testing.T) {
-	bodies := make(chan []byte, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		buf, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Errorf("read body: %v", err)
-		}
-		bodies <- buf
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	c := NewCollector(server.URL, "router-test", "test-secret")
-	defer c.Stop()
+	c, readBatch := setupCollectorTest(t)
 
 	c.AddEvent(Event{
 		Timestamp:          time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
@@ -119,22 +121,7 @@ func TestCollectorEmitsCachedInputTokensMeterWhenPresent(t *testing.T) {
 		APIKey:             "tk_test",
 	})
 
-	c.reporter.Flush(context.Background())
-
-	var body []byte
-	select {
-	case body = <-bodies:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for billing event delivery")
-	}
-
-	var batch usagereporting.Batch
-	if err := json.Unmarshal(body, &batch); err != nil {
-		t.Fatalf("decode batch: %v", err)
-	}
-	if len(batch.Events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(batch.Events))
-	}
+	batch := readBatch()
 
 	meters := make(map[string]int64)
 	for _, m := range batch.Events[0].Meters {
@@ -152,19 +139,7 @@ func TestCollectorEmitsCachedInputTokensMeterWhenPresent(t *testing.T) {
 }
 
 func TestCollectorOmitsCachedMeterWhenZero(t *testing.T) {
-	bodies := make(chan []byte, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		buf, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Errorf("read body: %v", err)
-		}
-		bodies <- buf
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	c := NewCollector(server.URL, "router-test", "test-secret")
-	defer c.Stop()
+	c, readBatch := setupCollectorTest(t)
 
 	c.AddEvent(Event{
 		Timestamp:    time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
@@ -173,19 +148,7 @@ func TestCollectorOmitsCachedMeterWhenZero(t *testing.T) {
 		APIKey:       "tk_test",
 	})
 
-	c.reporter.Flush(context.Background())
-
-	var body []byte
-	select {
-	case body = <-bodies:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for billing event delivery")
-	}
-
-	var batch usagereporting.Batch
-	if err := json.Unmarshal(body, &batch); err != nil {
-		t.Fatalf("decode batch: %v", err)
-	}
+	batch := readBatch()
 	for _, m := range batch.Events[0].Meters {
 		if m.Name == meterCachedInputTokens {
 			t.Fatalf("cached_input_tokens meter should be omitted when zero, got %+v", batch.Events[0].Meters)
@@ -194,19 +157,7 @@ func TestCollectorOmitsCachedMeterWhenZero(t *testing.T) {
 }
 
 func TestCollectorFallsBackToTotalTokensWhenSplitMissing(t *testing.T) {
-	bodies := make(chan []byte, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		buf, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Errorf("read body: %v", err)
-		}
-		bodies <- buf
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	c := NewCollector(server.URL, "router-test", "test-secret")
-	defer c.Stop()
+	c, readBatch := setupCollectorTest(t)
 
 	c.AddEvent(Event{
 		Timestamp:   time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
@@ -216,22 +167,7 @@ func TestCollectorFallsBackToTotalTokensWhenSplitMissing(t *testing.T) {
 		APIKey:      "tk_test",
 	})
 
-	c.reporter.Flush(context.Background())
-
-	var body []byte
-	select {
-	case body = <-bodies:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for billing event delivery")
-	}
-
-	var batch usagereporting.Batch
-	if err := json.Unmarshal(body, &batch); err != nil {
-		t.Fatalf("decode batch: %v", err)
-	}
-	if len(batch.Events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(batch.Events))
-	}
+	batch := readBatch()
 
 	meters := make(map[string]int64)
 	for _, m := range batch.Events[0].Meters {

--- a/billing/events_test.go
+++ b/billing/events_test.go
@@ -93,6 +93,106 @@ func TestCollectorEmitsCustomerRequestAndTokenMeters(t *testing.T) {
 	}
 }
 
+func TestCollectorEmitsCachedInputTokensMeterWhenPresent(t *testing.T) {
+	bodies := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		bodies <- buf
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := NewCollector(server.URL, "router-test", "test-secret")
+	defer c.Stop()
+
+	c.AddEvent(Event{
+		Timestamp:          time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		Model:              "kimi-k2-6",
+		PromptTokens:       100,
+		CachedPromptTokens: 64,
+		CompletionTokens:   7,
+		TotalTokens:        107,
+		RequestID:          "req-1",
+		APIKey:             "tk_test",
+	})
+
+	c.reporter.Flush(context.Background())
+
+	var body []byte
+	select {
+	case body = <-bodies:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for billing event delivery")
+	}
+
+	var batch usagereporting.Batch
+	if err := json.Unmarshal(body, &batch); err != nil {
+		t.Fatalf("decode batch: %v", err)
+	}
+	if len(batch.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(batch.Events))
+	}
+
+	meters := make(map[string]int64)
+	for _, m := range batch.Events[0].Meters {
+		meters[m.Name] = m.Quantity
+	}
+	if meters[usagereporting.MeterInputTokens] != 100 {
+		t.Errorf("input_tokens mismatch: got %d want 100", meters[usagereporting.MeterInputTokens])
+	}
+	if meters[usagereporting.MeterCachedInputTokens] != 64 {
+		t.Errorf("cached_input_tokens mismatch: got %d want 64", meters[usagereporting.MeterCachedInputTokens])
+	}
+	if meters[usagereporting.MeterOutputTokens] != 7 {
+		t.Errorf("output_tokens mismatch: got %d want 7", meters[usagereporting.MeterOutputTokens])
+	}
+}
+
+func TestCollectorOmitsCachedMeterWhenZero(t *testing.T) {
+	bodies := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		bodies <- buf
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := NewCollector(server.URL, "router-test", "test-secret")
+	defer c.Stop()
+
+	c.AddEvent(Event{
+		Timestamp:    time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		Model:        "gpt-oss-120b",
+		PromptTokens: 100,
+		APIKey:       "tk_test",
+	})
+
+	c.reporter.Flush(context.Background())
+
+	var body []byte
+	select {
+	case body = <-bodies:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for billing event delivery")
+	}
+
+	var batch usagereporting.Batch
+	if err := json.Unmarshal(body, &batch); err != nil {
+		t.Fatalf("decode batch: %v", err)
+	}
+	for _, m := range batch.Events[0].Meters {
+		if m.Name == usagereporting.MeterCachedInputTokens {
+			t.Fatalf("cached_input_tokens meter should be omitted when zero, got %+v", batch.Events[0].Meters)
+		}
+	}
+}
+
 func TestCollectorFallsBackToTotalTokensWhenSplitMissing(t *testing.T) {
 	bodies := make(chan []byte, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/tinfoilsh/tinfoil-go v0.12.7
-	github.com/tinfoilsh/usage-reporting-go v0.1.3-0.20260626214508-d4f8ce18faea
+	github.com/tinfoilsh/usage-reporting-go v0.1.3
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/tinfoilsh/tinfoil-go v0.12.7
-	github.com/tinfoilsh/usage-reporting-go v0.1.2
+	github.com/tinfoilsh/usage-reporting-go v0.1.3-0.20260626214508-d4f8ce18faea
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -333,6 +333,8 @@ github.com/tinfoilsh/tinfoil-go v0.12.7 h1:l2d2waMdbt+61yOTlcBhIU2eXD74GtifN0Svp
 github.com/tinfoilsh/tinfoil-go v0.12.7/go.mod h1:i503zVkJKaFfJ2aHIUM8E5dAFbXSMw3MkiWryKGTTs8=
 github.com/tinfoilsh/usage-reporting-go v0.1.2 h1:OFGCzVAHkiPcLZFTXDeacVv/2KefHgKPFFZsrVILQXE=
 github.com/tinfoilsh/usage-reporting-go v0.1.2/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
+github.com/tinfoilsh/usage-reporting-go v0.1.3-0.20260626214508-d4f8ce18faea h1:p3DZro7e3SGQNbYxer3l1B58pxeClKWQWChDrYiqSTQ=
+github.com/tinfoilsh/usage-reporting-go v0.1.3-0.20260626214508-d4f8ce18faea/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=

--- a/go.sum
+++ b/go.sum
@@ -331,10 +331,8 @@ github.com/theupdateframework/go-tuf/v2 v2.4.1 h1:K6ewW064rKZCPkRo1W/CTbTtm/+IB4
 github.com/theupdateframework/go-tuf/v2 v2.4.1/go.mod h1:Nex2enPVYDFCklrnbTzl3OVwD7fgIAj0J5++z/rvCj8=
 github.com/tinfoilsh/tinfoil-go v0.12.7 h1:l2d2waMdbt+61yOTlcBhIU2eXD74GtifN0Svpm2kZIE=
 github.com/tinfoilsh/tinfoil-go v0.12.7/go.mod h1:i503zVkJKaFfJ2aHIUM8E5dAFbXSMw3MkiWryKGTTs8=
-github.com/tinfoilsh/usage-reporting-go v0.1.2 h1:OFGCzVAHkiPcLZFTXDeacVv/2KefHgKPFFZsrVILQXE=
-github.com/tinfoilsh/usage-reporting-go v0.1.2/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
-github.com/tinfoilsh/usage-reporting-go v0.1.3-0.20260626214508-d4f8ce18faea h1:p3DZro7e3SGQNbYxer3l1B58pxeClKWQWChDrYiqSTQ=
-github.com/tinfoilsh/usage-reporting-go v0.1.3-0.20260626214508-d4f8ce18faea/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
+github.com/tinfoilsh/usage-reporting-go v0.1.3 h1:q3WJK1auo65BFDxQ+hkSRXF6B+jKhii3RUxeU18hvkA=
+github.com/tinfoilsh/usage-reporting-go v0.1.3/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -289,7 +289,10 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 					// user's API key and gets billed there directly.
 					emitZeroTokenEvent()
 				} else {
-					cachedPromptTokens, _ := usage.CachedPromptTokens()
+					cachedPromptTokens := 0
+					if value, ok := usage.CachedPromptTokens(); ok {
+						cachedPromptTokens = value
+					}
 					event := billing.Event{
 						Timestamp:          time.Now(),
 						UserID:             userID,

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -289,18 +289,20 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 					// user's API key and gets billed there directly.
 					emitZeroTokenEvent()
 				} else {
+					cachedPromptTokens, _ := usage.CachedPromptTokens()
 					event := billing.Event{
-						Timestamp:        time.Now(),
-						UserID:           userID,
-						APIKey:           apiKey,
-						Model:            modelName,
-						PromptTokens:     usage.PromptTokens,
-						CompletionTokens: usage.CompletionTokens,
-						TotalTokens:      usage.TotalTokens,
-						RequestID:        requestID,
-						Enclave:          host,
-						RequestPath:      requestPath,
-						Streaming:        streaming,
+						Timestamp:          time.Now(),
+						UserID:             userID,
+						APIKey:             apiKey,
+						Model:              modelName,
+						PromptTokens:       usage.PromptTokens,
+						CachedPromptTokens: cachedPromptTokens,
+						CompletionTokens:   usage.CompletionTokens,
+						TotalTokens:        usage.TotalTokens,
+						RequestID:          requestID,
+						Enclave:            host,
+						RequestPath:        requestPath,
+						Streaming:          streaming,
 					}
 					billingCollector.AddEvent(event)
 				}

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -607,11 +607,7 @@ func (s *chatStreamer) finalUsage() map[string]any {
 	if usage == nil {
 		return nil
 	}
-	return map[string]any{
-		"prompt_tokens":     usage.PromptTokens,
-		"completion_tokens": usage.CompletionTokens,
-		"total_tokens":      usage.TotalTokens,
-	}
+	return chatUsageMap(usage)
 }
 
 // terminateWithError is the single point at which a mid-stream upstream

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -253,6 +253,9 @@ func TestChatStreamerFinalizeEmitsFinishAndUsage(t *testing.T) {
 			"prompt_tokens":     float64(4),
 			"completion_tokens": float64(6),
 			"total_tokens":      float64(10),
+			"prompt_tokens_details": map[string]any{
+				"cached_tokens": float64(3),
+			},
 		},
 	}})
 	result := chatIterationResult{
@@ -269,6 +272,7 @@ func TestChatStreamerFinalizeEmitsFinishAndUsage(t *testing.T) {
 	body := rec.Body.String()
 	for _, fragment := range []string{
 		`"finish_reason":"stop"`,
+		`"prompt_tokens_details":{"cached_tokens":3}`,
 		`"usage":{"completion_tokens":6`,
 		"data: [DONE]",
 	} {

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -779,11 +779,7 @@ func (s *responsesStreamer) finalize(r *http.Request, em *manager.EnclaveManager
 	}
 	totals := s.usageTotals.Usage()
 	if totals != nil {
-		usage = map[string]any{
-			"input_tokens":  totals.PromptTokens,
-			"output_tokens": totals.CompletionTokens,
-			"total_tokens":  totals.TotalTokens,
-		}
+		usage = responsesUsageMap(totals)
 	}
 	// Build the final `output` array. Run it through the citation attachment
 	// on a synthetic body so the final snapshot carries the same normalized
@@ -860,11 +856,7 @@ func (s *responsesStreamer) terminateWithError(r *http.Request, em *manager.Encl
 // most recent single-turn usage block if no totals were recorded.
 func (s *responsesStreamer) totalsBillingUsage() map[string]any {
 	if totals := s.usageTotals.Usage(); totals != nil {
-		return map[string]any{
-			"input_tokens":  totals.PromptTokens,
-			"output_tokens": totals.CompletionTokens,
-			"total_tokens":  totals.TotalTokens,
-		}
+		return responsesUsageMap(totals)
 	}
 	return s.aggregatedUsage
 }

--- a/toolruntime/responses_stream_test.go
+++ b/toolruntime/responses_stream_test.go
@@ -107,6 +107,9 @@ func TestResponsesStreamerFinalizeEmitsCompletedEvent(t *testing.T) {
 			"input_tokens":  float64(7),
 			"output_tokens": float64(11),
 			"total_tokens":  float64(18),
+			"input_tokens_details": map[string]any{
+				"cached_tokens": float64(5),
+			},
 		},
 	}})
 
@@ -118,6 +121,7 @@ func TestResponsesStreamerFinalizeEmitsCompletedEvent(t *testing.T) {
 	body := rec.Body.String()
 	for _, fragment := range []string{
 		"event: response.completed",
+		`"input_tokens_details":{"cached_tokens":5}`,
 		`"status":"completed"`,
 		`"output_tokens":11`,
 	} {

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -42,9 +42,10 @@ func (e *upstreamError) Error() string {
 }
 
 type usageAccumulator struct {
-	promptTokens     int
-	completionTokens int
-	totalTokens      int
+	promptTokens       int
+	cachedPromptTokens int
+	completionTokens   int
+	totalTokens        int
 }
 
 func (a *usageAccumulator) Add(response *upstreamJSONResponse) {
@@ -54,6 +55,9 @@ func (a *usageAccumulator) Add(response *upstreamJSONResponse) {
 	}
 
 	a.promptTokens += usage.PromptTokens
+	if cachedPromptTokens, ok := usage.CachedPromptTokens(); ok {
+		a.cachedPromptTokens += cachedPromptTokens
+	}
 	a.completionTokens += usage.CompletionTokens
 	if usage.TotalTokens > 0 {
 		a.totalTokens += usage.TotalTokens
@@ -72,13 +76,19 @@ func (a *usageAccumulator) Usage() *tokencount.Usage {
 		totalTokens = a.promptTokens + a.completionTokens
 	}
 
-	return &tokencount.Usage{
+	usage := &tokencount.Usage{
 		PromptTokens:     a.promptTokens,
 		CompletionTokens: a.completionTokens,
 		TotalTokens:      totalTokens,
 		InputTokens:      a.promptTokens,
 		OutputTokens:     a.completionTokens,
 	}
+	if a.cachedPromptTokens > 0 {
+		details := &tokencount.PromptTokensDetails{CachedTokens: min(a.promptTokens, a.cachedPromptTokens)}
+		usage.PromptTokensDetails = details
+		usage.InputTokensDetails = details
+	}
+	return usage
 }
 
 type headerRoundTripper struct {
@@ -412,6 +422,36 @@ func formatUsageHeader(usage *tokencount.Usage) string {
 	return "prompt=" + strconv.Itoa(usage.PromptTokens) +
 		",completion=" + strconv.Itoa(usage.CompletionTokens) +
 		",total=" + strconv.Itoa(usage.TotalTokens)
+}
+
+func chatUsageMap(usage *tokencount.Usage) map[string]any {
+	if usage == nil {
+		return nil
+	}
+	usageMap := map[string]any{
+		"prompt_tokens":     usage.PromptTokens,
+		"completion_tokens": usage.CompletionTokens,
+		"total_tokens":      usage.TotalTokens,
+	}
+	if cachedPromptTokens, ok := usage.CachedPromptTokens(); ok {
+		usageMap["prompt_tokens_details"] = map[string]any{"cached_tokens": cachedPromptTokens}
+	}
+	return usageMap
+}
+
+func responsesUsageMap(usage *tokencount.Usage) map[string]any {
+	if usage == nil {
+		return nil
+	}
+	usageMap := map[string]any{
+		"input_tokens":  usage.PromptTokens,
+		"output_tokens": usage.CompletionTokens,
+		"total_tokens":  usage.TotalTokens,
+	}
+	if cachedPromptTokens, ok := usage.CachedPromptTokens(); ok {
+		usageMap["input_tokens_details"] = map[string]any{"cached_tokens": cachedPromptTokens}
+	}
+	return usageMap
 }
 
 func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested bool) {

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -84,7 +84,7 @@ func (a *usageAccumulator) Usage() *tokencount.Usage {
 		OutputTokens:     a.completionTokens,
 	}
 	if a.cachedPromptTokens > 0 {
-		details := &tokencount.PromptTokensDetails{CachedTokens: min(a.promptTokens, a.cachedPromptTokens)}
+		details := &tokencount.PromptTokensDetails{CachedTokens: a.cachedPromptTokens}
 		usage.PromptTokensDetails = details
 		usage.InputTokensDetails = details
 	}
@@ -425,31 +425,21 @@ func formatUsageHeader(usage *tokencount.Usage) string {
 }
 
 func chatUsageMap(usage *tokencount.Usage) map[string]any {
-	if usage == nil {
-		return nil
-	}
-	usageMap := map[string]any{
-		"prompt_tokens":     usage.PromptTokens,
-		"completion_tokens": usage.CompletionTokens,
-		"total_tokens":      usage.TotalTokens,
-	}
-	if cachedPromptTokens, ok := usage.CachedPromptTokens(); ok {
-		usageMap["prompt_tokens_details"] = map[string]any{"cached_tokens": cachedPromptTokens}
-	}
-	return usageMap
+	return usageMap(usage, "prompt_tokens", "completion_tokens", "prompt_tokens_details")
 }
 
 func responsesUsageMap(usage *tokencount.Usage) map[string]any {
-	if usage == nil {
-		return nil
-	}
+	return usageMap(usage, "input_tokens", "output_tokens", "input_tokens_details")
+}
+
+func usageMap(usage *tokencount.Usage, inputTokensKey, outputTokensKey, detailsKey string) map[string]any {
 	usageMap := map[string]any{
-		"input_tokens":  usage.PromptTokens,
-		"output_tokens": usage.CompletionTokens,
+		inputTokensKey:  usage.PromptTokens,
+		outputTokensKey: usage.CompletionTokens,
 		"total_tokens":  usage.TotalTokens,
 	}
 	if cachedPromptTokens, ok := usage.CachedPromptTokens(); ok {
-		usageMap["input_tokens_details"] = map[string]any{"cached_tokens": cachedPromptTokens}
+		usageMap[detailsKey] = map[string]any{"cached_tokens": cachedPromptTokens}
 	}
 	return usageMap
 }

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -444,26 +444,29 @@ func emitBillingEvent(em *manager.EnclaveManager, r *http.Request, response *ups
 
 	usage := usageFromRaw(response.body["usage"])
 	promptTokens := 0
+	cachedPromptTokens := 0
 	completionTokens := 0
 	totalTokens := 0
 	if usage != nil {
 		promptTokens = usage.PromptTokens
+		cachedPromptTokens, _ = usage.CachedPromptTokens()
 		completionTokens = usage.CompletionTokens
 		totalTokens = usage.TotalTokens
 	}
 
 	em.AddBillingEvent(billing.Event{
-		Timestamp:        time.Now(),
-		UserID:           "authenticated_user",
-		APIKey:           apiKey,
-		Model:            modelName,
-		PromptTokens:     promptTokens,
-		CompletionTokens: completionTokens,
-		TotalTokens:      totalTokens,
-		RequestID:        responseRequestID(response.header, r.Header),
-		Enclave:          response.header.Get("Tinfoil-Enclave"),
-		RequestPath:      r.URL.Path,
-		Streaming:        streaming,
+		Timestamp:          time.Now(),
+		UserID:             "authenticated_user",
+		APIKey:             apiKey,
+		Model:              modelName,
+		PromptTokens:       promptTokens,
+		CachedPromptTokens: cachedPromptTokens,
+		CompletionTokens:   completionTokens,
+		TotalTokens:        totalTokens,
+		RequestID:          responseRequestID(response.header, r.Header),
+		Enclave:            response.header.Get("Tinfoil-Enclave"),
+		RequestPath:        r.URL.Path,
+		Streaming:          streaming,
 	})
 }
 

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -212,6 +212,78 @@ func TestResponsesAdapterApplyUsageReplacesResponsesTotals(t *testing.T) {
 	}
 }
 
+func TestUsageAccumulatorPreservesCachedPromptTokens(t *testing.T) {
+	acc := usageAccumulator{}
+	acc.Add(&upstreamJSONResponse{body: map[string]any{
+		"usage": map[string]any{
+			"prompt_tokens":     10,
+			"completion_tokens": 2,
+			"total_tokens":      12,
+			"prompt_tokens_details": map[string]any{
+				"cached_tokens": 6,
+			},
+		},
+	}})
+	acc.Add(&upstreamJSONResponse{body: map[string]any{
+		"usage": map[string]any{
+			"input_tokens":  20,
+			"output_tokens": 3,
+			"total_tokens":  23,
+			"input_tokens_details": map[string]any{
+				"cached_tokens": 14,
+			},
+		},
+	}})
+
+	usage := acc.Usage()
+	if usage == nil {
+		t.Fatal("expected usage")
+	}
+	if usage.PromptTokens != 30 || usage.CompletionTokens != 5 || usage.TotalTokens != 35 {
+		t.Fatalf("unexpected aggregated usage: %#v", usage)
+	}
+	cachedPromptTokens, ok := usage.CachedPromptTokens()
+	if !ok {
+		t.Fatal("expected cached prompt token details")
+	}
+	if cachedPromptTokens != 20 {
+		t.Fatalf("cached prompt tokens = %d, want 20", cachedPromptTokens)
+	}
+}
+
+func TestAdaptersApplyUsagePreserveCachedPromptTokens(t *testing.T) {
+	usage := &tokencount.Usage{
+		PromptTokens:        7,
+		CompletionTokens:    11,
+		TotalTokens:         18,
+		PromptTokensDetails: &tokencount.PromptTokensDetails{CachedTokens: 4},
+	}
+
+	chatResponse := &upstreamJSONResponse{body: map[string]any{}, header: make(http.Header)}
+	chatAdapter := newChatLoopAdapter(map[string]any{}, nil, nil, nil, "m", http.Header{}, nil)
+	chatAdapter.applyUsage(chatResponse, usage)
+	chatUsage := usageFromRaw(chatResponse.body["usage"])
+	if chatUsage == nil {
+		t.Fatal("expected chat usage")
+	}
+	cachedPromptTokens, ok := chatUsage.CachedPromptTokens()
+	if !ok || cachedPromptTokens != 4 {
+		t.Fatalf("chat cached prompt tokens = %d, %v; want 4, true", cachedPromptTokens, ok)
+	}
+
+	responsesResponse := &upstreamJSONResponse{body: map[string]any{}, header: make(http.Header)}
+	responsesAdapter := newResponsesLoopAdapter(map[string]any{}, nil, nil, nil, nil)
+	responsesAdapter.applyUsage(responsesResponse, usage)
+	responsesUsage := usageFromRaw(responsesResponse.body["usage"])
+	if responsesUsage == nil {
+		t.Fatal("expected responses usage")
+	}
+	cachedPromptTokens, ok = responsesUsage.CachedPromptTokens()
+	if !ok || cachedPromptTokens != 4 {
+		t.Fatalf("responses cached prompt tokens = %d, %v; want 4, true", cachedPromptTokens, ok)
+	}
+}
+
 func TestChatAdapterFinalizeAggregatesForcedFinalUsage(t *testing.T) {
 	response := &upstreamJSONResponse{
 		body: map[string]any{

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -347,11 +347,7 @@ func (a *chatLoopAdapter) applyUsage(response *upstreamJSONResponse, usage *toke
 	if response == nil || response.body == nil || usage == nil {
 		return
 	}
-	response.body["usage"] = map[string]any{
-		"prompt_tokens":     usage.PromptTokens,
-		"completion_tokens": usage.CompletionTokens,
-		"total_tokens":      usage.TotalTokens,
-	}
+	response.body["usage"] = chatUsageMap(usage)
 }
 
 func (a *chatLoopAdapter) attachCitations(body map[string]any, state *citations.State, toolCalls *toolCallLog, eventFlags tinfoilEventFlags) {
@@ -560,11 +556,7 @@ func (a *responsesLoopAdapter) applyUsage(response *upstreamJSONResponse, usage 
 	if response == nil || response.body == nil || usage == nil {
 		return
 	}
-	response.body["usage"] = map[string]any{
-		"input_tokens":  usage.PromptTokens,
-		"output_tokens": usage.CompletionTokens,
-		"total_tokens":  usage.TotalTokens,
-	}
+	response.body["usage"] = responsesUsageMap(usage)
 }
 
 func (a *responsesLoopAdapter) attachCitations(body map[string]any, state *citations.State, toolCalls *toolCallLog, _ tinfoilEventFlags) {


### PR DESCRIPTION
Work in progress to add separate billing for cached tokens at inference time. See controlplane PR for full plan and work-in-progress

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds separate billing for prefix-cached prompt tokens and surfaces cached token details in usage across chat/responses and tool flows. Also centralizes usage mapping and simplifies tests.

- **New Features**
  - Added `CachedPromptTokens` to `billing.Event` and emit a `cached_input_tokens` meter (capped to input; omitted when zero). Input/output meters unchanged.
  - Bills cached tokens across `manager/proxy`, `emitBillingEvent`, and tool flows; propagates `usage.CachedPromptTokens()` end-to-end.
  - Usage includes `prompt_tokens_details.cached_tokens` (chat) and `input_tokens_details.cached_tokens` (responses) via shared helpers; aggregator sums cached tokens.

- **Dependencies**
  - Pinned `github.com/tinfoilsh/usage-reporting-go` to `v0.1.3` and reused `MeterCachedInputTokens`.

<sup>Written for commit e749a624901bedcb6bceeaa9c1e08551150adb22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

