### PR TITLE
chore: add new gemma replicas

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -98,6 +98,8 @@ models:
     enclaves:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
       - gemma4-31b-1.inf10.tinfoil.sh
+      - gemma4-31b-2.inf10.tinfoil.sh
+      - gemma4-31b-3.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added two new `gemma4-31b` replicas to the model’s `enclaves` to increase capacity and reduce queue times. This also improves load balancing and resilience.

<sup>Written for commit 337b6638f0d5056c08668d0d043d0160e8a4e470. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/340?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

