### PR TITLE
chore: temp remove gemma4-31b-3 from enclaves configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -99,7 +99,6 @@ models:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
       - gemma4-31b-1.inf10.tinfoil.sh
       - gemma4-31b-2.inf10.tinfoil.sh
-      - gemma4-31b-3.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION
Removed gemma4-31b-3.inf10.tinfoil.sh from enclaves list.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily removed `gemma4-31b-3.inf10.tinfoil.sh` from the `gemma4-31b` enclave pool to prevent routing traffic to this instance. No other config changes.

<sup>Written for commit b4f1e52a6fa212b570fcd9f7a7186bbb96385d15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/341?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

