### PR TITLE
chore: temp remove gemma4-31b-2 enclave from config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -98,7 +98,6 @@ models:
     enclaves:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
       - gemma4-31b-1.inf10.tinfoil.sh
-      - gemma4-31b-2.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Temporarily removed `gemma4-31b-2.inf10.tinfoil.sh` from the `gemma4-31b` model’s `enclaves` in `config.yml`. This stops routing requests to that enclave.

<sup>Written for commit 41e3deff1d6c2b2be7ec2eaf3ceb363e02056302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/342?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

