### PR TITLE
chore: Add back gemma2 to config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -98,6 +98,7 @@ models:
     enclaves:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
       - gemma4-31b-1.inf10.tinfoil.sh
+      - gemma4-31b-2.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds back `gemma4-31b-2.inf10.tinfoil.sh` to the Gemma 4 31B model `enclaves` in `config.yml`. Restores routing to the second enclave for redundancy and capacity.

<sup>Written for commit 321f5be3254fd3f1d6fa2907411c1fab2aea056e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/343?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

