### PR TITLE
chore: add gemma4-31b-3 enclave to config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -99,6 +99,7 @@ models:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
       - gemma4-31b-1.inf10.tinfoil.sh
       - gemma4-31b-2.inf10.tinfoil.sh
+      - gemma4-31b-3.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `gemma4-31b-3.inf10.tinfoil.sh` to the `gemma4-31b` model endpoints to increase capacity and improve failover. Traffic can now route to the new enclave alongside the existing hosts.

<sup>Written for commit af2bc9043a2e6ad78405073671db48850e114edd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/344?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

