### PR TITLE
feat: key rate limiting on JWT subject

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -34,6 +35,45 @@ var configFile []byte // Initial (attested) config
 
 // Set by build process
 var version = "dev"
+
+// rateLimitIdentity returns the identity used to key rate limiting. For OAuth
+// JWT access tokens it is the token's `sub` claim, so a user's bucket stays
+// stable across the short-lived token's ~15m refreshes (and across multiple
+// tokens minted for the same user); opaque API keys, and anything that is not a
+// well-formed JWT, fall back to the bearer itself.
+//
+// The signature is intentionally NOT verified here. The shim authenticates
+// every inference request and the router is reachable only over the closed
+// shim-net hop, so a token that reaches this point has already been verified
+// upstream; re-verifying would re-introduce the per-request round trip the
+// stateless JWT design exists to avoid.
+func rateLimitIdentity(apiKey string) string {
+	if sub := jwtSubject(apiKey); sub != "" {
+		return sub
+	}
+	return apiKey
+}
+
+// jwtSubject returns the `sub` claim of a compact-JWS access token, or "" if s
+// is not a well-formed three-part JWT or carries no string subject. It inspects
+// the payload only; it does not verify the signature (see rateLimitIdentity).
+func jwtSubject(s string) string {
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims struct {
+		Sub string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	return claims.Sub
+}
 
 // getEnvOrDefault returns the environment variable value if set, otherwise returns the default
 func getEnvOrDefault(envKey, defaultVal string) string {
@@ -511,9 +551,12 @@ func main() {
 				// or jumping ahead of other users.
 				delete(body, "priority")
 
+				// Identify the caller for rate limiting (see rateLimitIdentity).
+				rateLimitID := rateLimitIdentity(apiKey)
+
 				// Check rate limiting and inject lower vLLM priority if over budget
 				if rlCfg := em.GetRateLimitConfig(rateLimitModel); rlCfg != nil {
-					if apiKey != "" && em.RequestTracker().RecordAndCheck(apiKey, rateLimitModel, rlCfg.MaxRequestsPerMinute) {
+					if rateLimitID != "" && em.RequestTracker().RecordAndCheck(rateLimitID, rateLimitModel, rlCfg.MaxRequestsPerMinute) {
 						body["priority"] = 1
 						manager.RateLimitDemotionsTotal.WithLabelValues(rateLimitModel).Inc()
 						log.WithFields(log.Fields{

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"mime/multipart"
@@ -12,6 +13,38 @@ import (
 	"github.com/tinfoilsh/confidential-model-router/toolprofile"
 	"github.com/tinfoilsh/confidential-model-router/toolruntime"
 )
+
+func TestRateLimitIdentity(t *testing.T) {
+	// mkJWT builds a compact-JWS-shaped token (header.payload.sig) with the
+	// given JSON payload; the signature is irrelevant here since rateLimitIdentity
+	// reads the payload without verifying.
+	mkJWT := func(payload string) string {
+		enc := func(s string) string { return base64.RawURLEncoding.EncodeToString([]byte(s)) }
+		return enc(`{"alg":"EdDSA","typ":"at+jwt"}`) + "." + enc(payload) + ".sig"
+	}
+	jwtWithSub := mkJWT(`{"sub":"user_42","client_id":"tinfoil-chat"}`)
+	jwtNoSub := mkJWT(`{"client_id":"tinfoil-chat"}`)
+
+	tests := []struct {
+		name   string
+		apiKey string
+		want   string
+	}{
+		{"jwt sub extracted", jwtWithSub, "user_42"},
+		{"jwt without sub falls back to bearer", jwtNoSub, jwtNoSub},
+		{"opaque token key falls back", "tk_abc123", "tk_abc123"},
+		{"chat key falls back", "chat_xyz789", "chat_xyz789"},
+		{"non-jwt dotted string falls back", "a.b.c", "a.b.c"},
+		{"empty stays empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rateLimitIdentity(tt.apiKey); got != tt.want {
+				t.Errorf("rateLimitIdentity(%q) = %q, want %q", tt.apiKey, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestExtractModelFromMultipart(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Self-contained — **no dependency on any cvmimage change.**

## Why
The per-model rate limiter keys its buckets on the raw `Authorization: Bearer` string (`main.go` → `RequestTracker.RecordAndCheck`). That's a stable identity for opaque API keys, but an OAuth **JWT access token is not**: it rotates on every ~15-minute refresh, and a user can mint several concurrently. So for JWT traffic the per-user fairness throttle (which demotes vLLM priority for heavy users) resets at every refresh and can be evaded by re-minting tokens.

## What
- `rateLimitIdentity` derives the caller identity from the JWT **`sub`** claim when the bearer is a well-formed JWT; opaque keys (and anything unparseable) fall back to the bearer. This keeps a user's bucket stable across token refreshes and across multiple tokens.
- The `sub` is read from the token payload **without verifying the signature** — see trust model below.
- Extracted into `rateLimitIdentity` / `jwtSubject` with a table-driven unit test.

## Trust model
The router is reachable only over the closed `shim-net` hop (`172.31.255.0/30`, per `cvmimage/internal/containernet` — "always closed; never declarable by the operator"), and the shim authenticates every inference request before forwarding. So a token that reaches this router on an authenticated inference path has already been signature-verified by the shim; re-verifying here would re-introduce the per-request control-plane round trip the stateless JWT design exists to avoid.

**Known edge (low severity):** on any inference endpoint that the shim does *not* authenticate (i.e. requires no key), a client could send a JWT-shaped bearer with an arbitrary `sub` and grief another user's *soft* priority bucket for that minute. This is contingent on an unauthenticated-but-rate-limited inference endpoint existing, affects only the soft (priority-demotion) limiter, and self-resolves each minute. If that surface is a concern, the alternative is to have the shim set a trusted `X-Tinfoil-Subject` header only after verification (tied to auth) — heavier, and unnecessary while the shim's own hard limiter is disabled everywhere.

## Explicitly unchanged
- **Billing.** The control plane attributes JWT usage by verifying the raw token itself (`looksLikeJWT` → `Subject()`), so usage events still carry the bearer — swapping in the bare `sub` would break that detection.

## Tests
`TestRateLimitIdentity` (sub extracted / no-sub fallback / opaque keys / non-JWT / empty); full module builds, vets, and tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)