### PR TITLE
Update cvmimage to 0.10.2 (+ explicit egress network)

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,4 +1,4 @@
-cvm-version: 0.7.5
+cvm-version: 0.10.2
 memory: 16384
 cpus: 8
 
@@ -6,6 +6,7 @@ containers:
   - name: "proxy"
     image: "ghcr.io/tinfoilsh/confidential-model-router@sha256:0000000000000000000000000000000000000000000000000000000000000000" # placeholder - populated during release
     restart: always
+    networks: ["egress"]
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"
@@ -19,6 +20,10 @@ containers:
       interval: 30s
       timeout: 5s
       start_period: 5m
+
+networks:
+  egress:
+    egress: open
 
 shim:
   upstream-port: 8089


### PR DESCRIPTION
## What

Updates the model router to **cvmimage 0.10.2** (latest), from 0.7.5.

This is **not** a plain version bump — cvmimage 0.10.x rewrote the in-CVM networking model, which requires a config change for the router to keep working.

## Why the networking change is required

In 0.7.x each container defaulted to `network_mode: host`, which is how the `proxy` container gets outbound access today. In 0.10.x:

- `network_mode` was **removed**. Containers attach to explicit bridge networks declared under a top-level `networks:` map.
- A container with **no `networks:`** gets `NetworkMode: none` — or, for the shim's upstream container (which `proxy` is, by default), only the internal `shim-net`, which is **always closed egress**.

So without this change the router would boot on 0.10.x with **zero outbound access** and would fail to reach the control plane, fetch its runtime config, or route to any inference enclave.

## Changes

- `cvm-version: 0.7.5` → `0.10.2`
- Declare an `egress: open` bridge and attach `proxy` to it via `networks: ["egress"]`

```yaml
networks:
  egress:
    egress: open
```

## Why `egress: open` (not an allowlist)

The router fans out to a **dynamic** set of inference enclaves discovered at runtime from `config.yml` (fetched from GitHub), plus `api.tinfoil.sh` and `raw.githubusercontent.com`. An `egress: allowlist` would need every exact enclave FQDN (wildcards aren't supported) and — because `tinfoil-config.yml` is attested — **every model add/remove would force a router re-release**. `open` avoids that coupling. Host/private/internal address ranges remain firewall-blocked even on `open`.

## Other 0.10.x defaults — verified, no action needed

- **Read-only rootfs is now the default.** The router does multipart handling in-memory (`multipart.NewReader` over a `bytes.Reader`; `multipart.NewWriter` over a `bytes.Buffer`) and has no non-debug disk writes (the only `os.OpenFile` is gated behind the `toolruntime_debug` build tag), so it runs fine read-only — no `read_only: false` or tmpfs needed.
- `pids_limit` now defaults to `65536` and `cap_drop: ALL` is applied automatically — both fine for the router.

## Deploy-time check

Watch the CVM / router logs on first boot for any egress-blocked or upstream-connectivity errors and confirm the shim health check (`http://localhost:8089/health`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
