### PR TITLE
chore: remove gemma4-31b-3 from enclaves configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -99,7 +99,6 @@ models:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
       - gemma4-31b-1.inf10.tinfoil.sh
       - gemma4-31b-2.inf10.tinfoil.sh
-      - gemma4-31b-3.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION
Removed gemma4-31b-3.inf10.tinfoil.sh from enclaves list.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `gemma4-31b-3.inf10.tinfoil.sh` from the `enclaves` list for `gemma4-31b` to stop routing to an inactive host and avoid failed requests.
Traffic now targets the remaining `gemma4-31b` hosts with no other config changes.

<sup>Written for commit 324c44ca42aa038a032246a2b5b38bd2e2e5a38e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

