### PR TITLE
chore: Remove gemma4-31b-2 enclave from config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -98,7 +98,6 @@ models:
     enclaves:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
       - gemma4-31b-1.inf10.tinfoil.sh
-      - gemma4-31b-2.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed `gemma4-31b-2.inf10.tinfoil.sh` from the `gemma4-31b` model enclave list to stop routing traffic to that host. Traffic continues through the remaining enclaves.

<sup>Written for commit 7eecc182c2372c121bb3a8fcc06866c0368da817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

