### PR TITLE
chore: Add new enclave gemma4-31b-2 to config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -98,6 +98,7 @@ models:
     enclaves:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
       - gemma4-31b-1.inf10.tinfoil.sh
+      - gemma4-31b-2.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added new enclave `gemma4-31b-2.inf10.tinfoil.sh` to the `gemma4-31b` model config. This increases capacity and improves redundancy/failover.

<sup>Written for commit 1c9dc92a7d951756f42015cdd58cf2c50691f233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

