### PR TITLE
chore: update config for cvm v0.10.4

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,4 +1,4 @@
-cvm-version: 0.10.2
+cvm-version: 0.10.4
 memory: 16384
 cpus: 8
 
@@ -6,7 +6,7 @@ containers:
   - name: "proxy"
     image: "ghcr.io/tinfoilsh/confidential-model-router@sha256:0000000000000000000000000000000000000000000000000000000000000000" # placeholder - populated during release
     restart: always
-    networks: ["egress"]
+    networks: [web]
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"
@@ -22,7 +22,7 @@ containers:
       start_period: 5m
 
 networks:
-  egress:
+  web:
     egress: open
 
 shim:


### PR DESCRIPTION
Bump cvm-version to 0.10.4 and add web egress for inf14-validated CPU enclave configs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `cvm-version` to 0.10.4 and switch the proxy container to the `web` egress network (renamed from `egress`) for inf14-validated CPU enclaves. Keeps us current with CVM and ensures outbound web access is correctly configured.

<sup>Written for commit 596489a505bcbdca64b441cf76edb5fe3e453edf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

