### PR TITLE
chore: move kimi-k2-6 back

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -76,7 +76,7 @@ models:
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6-b200
     enclaves:
-      - kimi-k2-6.inf14.tinfoil.sh
+      - kimi-k2-6.inf13.tinfoil.sh
     rate_limit:
       max_requests_per_minute: 4
     overload:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Repointed the `kimi-k2-6` model from `kimi-k2-6.inf14.tinfoil.sh` back to `kimi-k2-6.inf13.tinfoil.sh` in config to match the active enclave.

<sup>Written for commit e4291e6504fceed8bcfc20a094a7b4d880492115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

