### PR TITLE
chore: move kimi

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -76,7 +76,7 @@ models:
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6-b200
     enclaves:
-      - kimi-k2-6.inf13.tinfoil.sh
+      - kimi-k2-6.inf14.tinfoil.sh
     rate_limit:
       max_requests_per_minute: 4
     overload:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `config.yml` to point the `kimi-k2-6` model to the new enclave `kimi-k2-6.inf14.tinfoil.sh` (was `inf13`), reflecting the infra move. No other settings changed (rate limits and overload unchanged).

<sup>Written for commit b725f282c916a170100f1e476f89ff9cc68ab6bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

