### PR TITLE
Revert "chore: move kimi"

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -76,7 +76,7 @@ models:
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6-b200
     enclaves:
-      - kimi-k2-6.inf14.tinfoil.sh
+      - kimi-k2-6.inf13.tinfoil.sh
     rate_limit:
       max_requests_per_minute: 4
     overload:


### PR DESCRIPTION
Reverts tinfoilsh/confidential-model-router#357

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the `kimi-k2-6` model routing from `kimi-k2-6.inf14.tinfoil.sh` back to `kimi-k2-6.inf13.tinfoil.sh`. Restores the previous enclave target.

<sup>Written for commit d957b3eed0eacc8f1bac11e1c619562207758640. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

