### PR TITLE
fix: keep reasoning ahead of answer text in streamed replies

### DIFF
--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -208,20 +208,25 @@ func (s *chatStreamer) pumpUpstream(reader *sseReader) (chatIterationResult, err
 		if delta == nil {
 			continue
 		}
-		if content := stringValue(delta["content"]); content != "" {
-			result.content += content
-			s.emitContentDelta(content)
-		}
 		// Reasoning deltas (reasoning_content / reasoning) never carry
 		// citations so they bypass the citation emitter. They must still
 		// flow through to the client as-is so reasoning models keep
 		// driving the live thinking UI when web search is enabled.
+		// Reasoning is emitted before content: at the think-close
+		// boundary upstream parsers emit a single delta carrying both
+		// the final reasoning fragment and the first content tokens,
+		// and splitting it content-first would hand clients the tail of
+		// the reasoning after the answer already started.
 		if r := stringValue(delta["reasoning_content"]); r != "" {
 			result.reasoning += r
 		} else if r := stringValue(delta["reasoning"]); r != "" {
 			result.reasoning += r
 		}
 		s.emitReasoningDelta(delta)
+		if content := stringValue(delta["content"]); content != "" {
+			result.content += content
+			s.emitContentDelta(content)
+		}
 		if rawCalls, ok := delta["tool_calls"].([]any); ok {
 			builder.ingest(rawCalls)
 		}

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -695,6 +695,37 @@ func TestChatStreamerPumpForwardsReasoningDelta(t *testing.T) {
 	}
 }
 
+// TestChatStreamerPumpEmitsReasoningBeforeContentOnCombinedDelta pins the
+// chunk ordering when one upstream delta carries both the final reasoning
+// fragment and the first content tokens (how reasoning parsers emit the
+// think-close boundary). The reasoning chunk must reach the client before
+// the content chunk; the inverted order makes clients render the reasoning
+// tail as a separate phantom thinking block that splits the answer text.
+func TestChatStreamerPumpEmitsReasoningBeforeContentOnCombinedDelta(t *testing.T) {
+	streamer, rec := newTestChatStreamer(t)
+	upstream := strings.Join([]string{
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{"reasoning":"thinking about tradeoffs"}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{"reasoning":"offs. ","content":"TCP is"}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{"content":" reliable."}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		"data: [DONE]",
+		"",
+	}, "\n\n")
+
+	if _, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(upstream))); err != nil {
+		t.Fatalf("pumpUpstream returned error: %v", err)
+	}
+	body := rec.Body.String()
+	reasoningIdx := strings.Index(body, `"reasoning":"offs. "`)
+	contentIdx := strings.Index(body, `"content":"TCP is"`)
+	if reasoningIdx == -1 || contentIdx == -1 {
+		t.Fatalf("expected both reasoning tail and content forwarded, got %s", body)
+	}
+	if reasoningIdx > contentIdx {
+		t.Fatalf("expected reasoning tail before content chunk, got %s", body)
+	}
+}
+
 // chatToolCallTurn builds an SSE chunk sequence for one iteration where
 // the upstream model emits a tool call and finishes with
 // finish_reason:"tool_calls". Used by multi-iteration tests to simulate


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure streamed replies always send reasoning before answer text, even when the upstream delta includes both. This prevents phantom thinking blocks and split answers in the UI.

- **Bug Fixes**
  - Emit reasoning deltas before content when both appear in a single upstream chunk.
  - Add a test to lock this ordering and prevent regressions.

<sup>Written for commit 7639fab4c73376aa2ce5269b1d563da10e9f438d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

