### PR TITLE
chore: Remove enclave gemma4-31b-1 from config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -97,7 +97,6 @@ models:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
-      - gemma4-31b-1.inf10.tinfoil.sh
       - gemma4-31b-2.inf10.tinfoil.sh
       - gemma4-31b-3.inf10.tinfoil.sh
     overload:


### PR DESCRIPTION
Removed an enclave entry for gemma4-31b.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `gemma4-31b-1.inf10.tinfoil.sh` enclave from the `gemma4-31b` model in `config.yml`. This prevents routing to a retired host and reduces failovers.

<sup>Written for commit cff054ff01193eb69ea074f6a07b178160ad5bf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

