### PR TITLE
chore: Add back enclave to gemma4-31b configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -97,6 +97,7 @@ models:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
+      - gemma4-31b-1.inf10.tinfoil.sh
       - gemma4-31b-2.inf10.tinfoil.sh
       - gemma4-31b-3.inf10.tinfoil.sh
     overload:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added back the missing enclave `gemma4-31b-1.inf10.tinfoil.sh` to the `gemma4-31b` config to restore routing and capacity.

<sup>Written for commit 9286ad26f29eefa4a9071281e3ea8d0b5063d0ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

