### PR TITLE
feat: add glm-5-2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -43,6 +43,11 @@ models:
     enclaves:
       - glm-5-1.tinfoil.containers.tinfoil.dev
 
+  glm-5-2:
+    repo: tinfoilsh/confidential-glm5-2
+    enclaves:
+      - glm-5-2.tinfoil.containers.tinfoil.dev
+
   deepseek-v4-pro:
     repo: tinfoilsh/confidential-deepseek-v4-pro
     enclaves:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added glm-5-2 to the models config to enable routing to its confidential deployment. Config includes repo `tinfoilsh/confidential-glm5-2` and enclave `glm-5-2.tinfoil.containers.tinfoil.dev`.

<sup>Written for commit 240c0887aad2b183b71e156f3eaad89340c6fd1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

