### PR TITLE
[codex] route org priority to vllm

### DIFF
--- a/main.go
+++ b/main.go
@@ -564,14 +564,9 @@ func main() {
 
 				if routeCtx, ok := routeContextClient.Lookup(r.Context(), apiKey, modelName); ok && routeCtx.Priority != nil {
 					body["priority"] = *routeCtx.Priority
-					tier := routeCtx.PriorityTier
-					if tier == "" {
-						tier = "configured"
-					}
-					manager.PriorityAssignmentsTotal.WithLabelValues(modelName, tier).Inc()
+					manager.PriorityAssignmentsTotal.WithLabelValues(modelName).Inc()
 					log.WithFields(log.Fields{
-						"model":         modelName,
-						"priority_tier": tier,
+						"model": modelName,
 					}).Debug("injecting configured vLLM priority")
 				}
 

--- a/main.go
+++ b/main.go
@@ -341,6 +341,8 @@ func main() {
 	defer em.Shutdown()
 	go em.StartWorker()
 
+	routeContextClient := newRouteContextClient(*controlPlaneURL)
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		var modelName string
 		var err error
@@ -559,6 +561,19 @@ func main() {
 
 				// Identify the caller for rate limiting (see rateLimitIdentity).
 				rateLimitID := rateLimitIdentity(apiKey)
+
+				if routeCtx, ok := routeContextClient.Lookup(r.Context(), apiKey, modelName); ok && routeCtx.Priority != nil {
+					body["priority"] = *routeCtx.Priority
+					tier := routeCtx.PriorityTier
+					if tier == "" {
+						tier = "configured"
+					}
+					manager.PriorityAssignmentsTotal.WithLabelValues(modelName, tier).Inc()
+					log.WithFields(log.Fields{
+						"model":         modelName,
+						"priority_tier": tier,
+					}).Debug("injecting configured vLLM priority")
+				}
 
 				// Check rate limiting and inject lower vLLM priority if over budget
 				if rlCfg := em.GetRateLimitConfig(rateLimitModel); rlCfg != nil {

--- a/main.go
+++ b/main.go
@@ -562,16 +562,19 @@ func main() {
 				// Identify the caller for rate limiting (see rateLimitIdentity).
 				rateLimitID := rateLimitIdentity(apiKey)
 
+				hasConfiguredPriority := false
 				if routeCtx, ok := routeContextClient.Lookup(r.Context(), apiKey, modelName); ok && routeCtx.Priority != nil {
 					body["priority"] = *routeCtx.Priority
+					hasConfiguredPriority = true
 					manager.PriorityAssignmentsTotal.WithLabelValues(modelName).Inc()
 					log.WithFields(log.Fields{
 						"model": modelName,
 					}).Debug("injecting configured vLLM priority")
 				}
 
-				// Check rate limiting and inject lower vLLM priority if over budget
-				if rlCfg := em.GetRateLimitConfig(rateLimitModel); rlCfg != nil {
+				// Check rate limiting and inject lower vLLM priority if over budget.
+				// Org-priority callers bypass this soft demotion.
+				if rlCfg := em.GetRateLimitConfig(rateLimitModel); !hasConfiguredPriority && rlCfg != nil {
 					if rateLimitID != "" && em.RequestTracker().RecordAndCheck(rateLimitID, rateLimitModel, rlCfg.MaxRequestsPerMinute) {
 						body["priority"] = 1
 						manager.RateLimitDemotionsTotal.WithLabelValues(rateLimitModel).Inc()

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -70,6 +70,24 @@ var (
 		[]string{"model"},
 	)
 
+	// PriorityAssignmentsTotal tracks requests assigned a configured vLLM priority tier
+	PriorityAssignmentsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_priority_assignments_total",
+			Help: "Total number of requests sent with a configured vLLM priority tier",
+		},
+		[]string{"model", "tier"},
+	)
+
+	// RouteContextLookupFailuresTotal tracks failed route-context lookups to the control plane
+	RouteContextLookupFailuresTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_route_context_lookup_failures_total",
+			Help: "Total number of failed route-context lookups to the control plane",
+		},
+		[]string{"model", "reason"},
+	)
+
 	// CircuitBreakerState tracks the current state of each enclave's circuit breaker (0=closed, 1=open, 2=half-open)
 	CircuitBreakerState = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -70,13 +70,13 @@ var (
 		[]string{"model"},
 	)
 
-	// PriorityAssignmentsTotal tracks requests assigned a configured vLLM priority tier
+	// PriorityAssignmentsTotal tracks requests assigned configured vLLM priority
 	PriorityAssignmentsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_priority_assignments_total",
-			Help: "Total number of requests sent with a configured vLLM priority tier",
+			Help: "Total number of requests sent with configured vLLM priority",
 		},
-		[]string{"model", "tier"},
+		[]string{"model"},
 	)
 
 	// RouteContextLookupFailuresTotal tracks failed route-context lookups to the control plane

--- a/route_context.go
+++ b/route_context.go
@@ -40,10 +40,9 @@ type routeContextRequest struct {
 }
 
 type routeContext struct {
-	UserID       string `json:"user_id"`
-	OrgID        string `json:"org_id,omitempty"`
-	PriorityTier string `json:"priority_tier,omitempty"`
-	Priority     *int   `json:"priority,omitempty"`
+	UserID   string `json:"user_id"`
+	OrgID    string `json:"org_id,omitempty"`
+	Priority *int   `json:"priority,omitempty"`
 }
 
 func newRouteContextClient(controlPlaneURL string) *routeContextClient {

--- a/route_context.go
+++ b/route_context.go
@@ -40,9 +40,7 @@ type routeContextRequest struct {
 }
 
 type routeContext struct {
-	UserID   string `json:"user_id"`
-	OrgID    string `json:"org_id,omitempty"`
-	Priority *int   `json:"priority,omitempty"`
+	Priority *int `json:"priority,omitempty"`
 }
 
 func newRouteContextClient(controlPlaneURL string) *routeContextClient {

--- a/route_context.go
+++ b/route_context.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tinfoilsh/confidential-model-router/manager"
+)
+
+const (
+	routeContextPath          = "/api/shim/route-context"
+	routeContextLookupTimeout = 2 * time.Second
+	routeContextCacheTTL      = time.Hour
+)
+
+type routeContextClient struct {
+	endpoint   string
+	httpClient *http.Client
+	ttl        time.Duration
+	mu         sync.RWMutex
+	cache      map[string]cachedRouteContext
+}
+
+type cachedRouteContext struct {
+	context routeContext
+	expires time.Time
+}
+
+type routeContextRequest struct {
+	APIKey string `json:"api_key"`
+}
+
+type routeContext struct {
+	UserID       string `json:"user_id"`
+	OrgID        string `json:"org_id,omitempty"`
+	PriorityTier string `json:"priority_tier,omitempty"`
+	Priority     *int   `json:"priority,omitempty"`
+}
+
+func newRouteContextClient(controlPlaneURL string) *routeContextClient {
+	return &routeContextClient{
+		endpoint:   strings.TrimRight(controlPlaneURL, "/") + routeContextPath,
+		httpClient: http.DefaultClient,
+		ttl:        routeContextCacheTTL,
+		cache:      make(map[string]cachedRouteContext),
+	}
+}
+
+func (c *routeContextClient) Lookup(ctx context.Context, apiKey, model string) (routeContext, bool) {
+	if c == nil || c.endpoint == "" || apiKey == "" || model == "" {
+		return routeContext{}, false
+	}
+
+	key := routeContextCacheKey(apiKey)
+	now := time.Now()
+	c.mu.RLock()
+	cached, ok := c.cache[key]
+	c.mu.RUnlock()
+	if ok && now.Before(cached.expires) {
+		return cached.context, true
+	}
+
+	resolved, ok := c.fetch(ctx, apiKey, model)
+	if !ok {
+		return routeContext{}, false
+	}
+
+	c.mu.Lock()
+	c.cache[key] = cachedRouteContext{
+		context: resolved,
+		expires: now.Add(c.ttl),
+	}
+	c.mu.Unlock()
+
+	return resolved, true
+}
+
+func (c *routeContextClient) fetch(ctx context.Context, apiKey, model string) (routeContext, bool) {
+	body, err := json.Marshal(routeContextRequest{APIKey: apiKey})
+	if err != nil {
+		manager.RouteContextLookupFailuresTotal.WithLabelValues(model, "marshal").Inc()
+		return routeContext{}, false
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, routeContextLookupTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		manager.RouteContextLookupFailuresTotal.WithLabelValues(model, "request").Inc()
+		return routeContext{}, false
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		manager.RouteContextLookupFailuresTotal.WithLabelValues(model, "transport").Inc()
+		return routeContext{}, false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
+		manager.RouteContextLookupFailuresTotal.WithLabelValues(model, fmt.Sprintf("http_%d", resp.StatusCode)).Inc()
+		return routeContext{}, false
+	}
+
+	var resolved routeContext
+	if err := json.NewDecoder(resp.Body).Decode(&resolved); err != nil {
+		manager.RouteContextLookupFailuresTotal.WithLabelValues(model, "decode").Inc()
+		return routeContext{}, false
+	}
+
+	return resolved, true
+}
+
+func routeContextCacheKey(apiKey string) string {
+	sum := sha256.Sum256([]byte(apiKey))
+	return hex.EncodeToString(sum[:])
+}

--- a/route_context_test.go
+++ b/route_context_test.go
@@ -30,8 +30,6 @@ func TestRouteContextClientLookupCachesSuccess(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(routeContext{
-			UserID:   "user_123",
-			OrgID:    "org_123",
 			Priority: &priority,
 		})
 	}))

--- a/route_context_test.go
+++ b/route_context_test.go
@@ -30,10 +30,9 @@ func TestRouteContextClientLookupCachesSuccess(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(routeContext{
-			UserID:       "user_123",
-			OrgID:        "org_123",
-			PriorityTier: "high",
-			Priority:     &priority,
+			UserID:   "user_123",
+			OrgID:    "org_123",
+			Priority: &priority,
 		})
 	}))
 	defer server.Close()
@@ -48,10 +47,10 @@ func TestRouteContextClientLookupCachesSuccess(t *testing.T) {
 		t.Fatal("expected second lookup to succeed from cache")
 	}
 
-	if first.Priority == nil || *first.Priority != priority || first.PriorityTier != "high" {
+	if first.Priority == nil || *first.Priority != priority {
 		t.Fatalf("first context = %#v, want high priority", first)
 	}
-	if second.Priority == nil || *second.Priority != priority || second.PriorityTier != "high" {
+	if second.Priority == nil || *second.Priority != priority {
 		t.Fatalf("second context = %#v, want high priority", second)
 	}
 	if requests != 1 {

--- a/route_context_test.go
+++ b/route_context_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRouteContextClientLookupCachesSuccess(t *testing.T) {
+	priority := -1
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != routeContextPath {
+			t.Fatalf("path = %q, want %q", r.URL.Path, routeContextPath)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %q, want POST", r.Method)
+		}
+
+		var req routeContextRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.APIKey != "tk_test" {
+			t.Fatalf("request = %#v, want key", req)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(routeContext{
+			UserID:       "user_123",
+			OrgID:        "org_123",
+			PriorityTier: "high",
+			Priority:     &priority,
+		})
+	}))
+	defer server.Close()
+
+	client := newRouteContextClient(server.URL)
+	first, ok := client.Lookup(context.Background(), "tk_test", "gemma4-31b")
+	if !ok {
+		t.Fatal("expected first lookup to succeed")
+	}
+	second, ok := client.Lookup(context.Background(), "tk_test", "llama3-3-70b")
+	if !ok {
+		t.Fatal("expected second lookup to succeed from cache")
+	}
+
+	if first.Priority == nil || *first.Priority != priority || first.PriorityTier != "high" {
+		t.Fatalf("first context = %#v, want high priority", first)
+	}
+	if second.Priority == nil || *second.Priority != priority || second.PriorityTier != "high" {
+		t.Fatalf("second context = %#v, want high priority", second)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+}
+
+func TestRouteContextClientLookupFailsClosed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := newRouteContextClient(server.URL)
+	if _, ok := client.Lookup(context.Background(), "tk_test", "gemma4-31b"); ok {
+		t.Fatal("expected lookup to fail closed")
+	}
+}


### PR DESCRIPTION
## Summary
- Add a route-context client that caches priority metadata by API key for one hour.
- Strip client priority, then inject server-owned vLLM priority for configured orgs.
- Add priority assignment and route-context failure metrics.

## Validation
- go test ./...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes org-configured vLLM priority from the control plane and overrides any client-sent priority when configured. Callers with org priority bypass soft rate-limit demotion; adds metrics and cache-backed lookups.

- **New Features**
  - In-memory route-context client: POST `/api/shim/route-context`, 2s timeout, 1h per-API-key cache; fail closed.
  - Prometheus counters: `router_priority_assignments_total` (model) and `router_route_context_lookup_failures_total` (model, reason).

- **Refactors**
  - Trimmed route-context response to only include `priority`.

<sup>Written for commit 37dfb592117a1061fe27fea8cf04f9744055790c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

