### PR TITLE
Fix: strip passed synthetic items

### DIFF
--- a/toolruntime/events.go
+++ b/toolruntime/events.go
@@ -586,6 +586,37 @@ func buildCodeInterpreterCallOutputItems(records []toolCallRecord) []any {
 	return events
 }
 
+// routerSynthesizedResponseItemTypes are the Responses output-item types the
+// router builds itself rather than receiving from the upstream model. Keep
+// this in sync with the builders above: adding a synthesized type means
+// adding its builder and its entry here, so stripClientSyntheticResponseItems
+// drops the echoed-back variant on the input side too.
+var routerSynthesizedResponseItemTypes = map[string]struct{}{
+	"web_search_call":       {},
+	"code_interpreter_call": {},
+}
+
+// stripClientSyntheticResponseItems drops router-synthesized output items
+// (see routerSynthesizedResponseItemTypes) that clients echo back as input;
+// the upstream model never produced them and rejects them. Input-side
+// counterpart to the output-side builders above.
+func stripClientSyntheticResponseItems(input any) any {
+	items, ok := input.([]any)
+	if !ok {
+		return input
+	}
+	filtered := make([]any, 0, len(items))
+	for _, raw := range items {
+		if item, ok := raw.(map[string]any); ok {
+			if _, drop := routerSynthesizedResponseItemTypes[stringValue(item["type"])]; drop {
+				continue
+			}
+		}
+		filtered = append(filtered, raw)
+	}
+	return filtered
+}
+
 // ---------------------------------------------------------------------------
 // Attach output (non-streaming finalize)
 // ---------------------------------------------------------------------------

--- a/toolruntime/events_test.go
+++ b/toolruntime/events_test.go
@@ -1,0 +1,40 @@
+package toolruntime
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestStripClientSyntheticResponseItems pins that router-synthesized
+// output-item types are dropped from a client-echoed input array while
+// real conversation items survive. Covers both synthesized families
+// (web_search_call, code_interpreter_call) and the pass-through cases.
+func TestStripClientSyntheticResponseItems(t *testing.T) {
+	t.Parallel()
+
+	userMsg := map[string]any{"type": "message", "role": "user"}
+	assistantMsg := map[string]any{"type": "message", "role": "assistant"}
+	fnOutput := map[string]any{"type": "function_call_output", "call_id": "call_1", "output": "{}"}
+
+	// web_search_call without an id (what Codex echoes back) and with one.
+	wsNoID := map[string]any{"type": "web_search_call", "status": "completed"}
+	wsWithID := map[string]any{"type": "web_search_call", "id": "ws_1", "status": "completed"}
+	ciCall := map[string]any{"type": "code_interpreter_call", "id": "ci_1", "status": "completed"}
+
+	got := stripClientSyntheticResponseItems([]any{userMsg, wsNoID, assistantMsg, wsWithID, ciCall, fnOutput})
+	want := []any{userMsg, assistantMsg, fnOutput}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("stripped = %v, want %v", got, want)
+	}
+
+	// Non-slice input passes through unchanged.
+	if got := stripClientSyntheticResponseItems("not a slice"); got != "not a slice" {
+		t.Fatalf("expected non-slice passthrough, got %v", got)
+	}
+	if got := stripClientSyntheticResponseItems(nil); got != nil {
+		t.Fatalf("expected nil passthrough, got %v", got)
+	}
+	if got := stripClientSyntheticResponseItems([]any{}); !reflect.DeepEqual(got, []any{}) {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -915,6 +915,7 @@ func runResponsesStreaming(
 	autoContinueTools := extractAndStripAutoContinueResponsesTools(base["tools"])
 	base["tools"] = replaceRouterOwnedResponsesTools(base["tools"], responseTools(tools))
 	base["input"] = prependResponsesPrompt(prompt, base["input"])
+	base["input"] = stripClientSyntheticResponseItems(base["input"])
 
 	usageMetricsRequested := r.Header.Get(manager.UsageMetricsRequestHeader) == "true"
 

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -582,9 +582,32 @@ func (a *responsesLoopAdapter) buildInitialRequest() map[string]any {
 	a.autoContinueTools = extractAndStripAutoContinueResponsesTools(base["tools"])
 	base["tools"] = replaceRouterOwnedResponsesTools(base["tools"], responseTools(a.tools))
 	base["input"] = prependResponsesPrompt(a.prompt, base["input"])
+	base["input"] = stripClientSyntheticResponseItems(base["input"])
 	a.base = base
 	a.accumulatedInput, _ = base["input"].([]any)
 	return base
+}
+
+// stripClientSyntheticResponseItems removes router-synthesized hosted-tool items
+// that clients echo back into `input` on a later turn. Server-side web search
+// runs upstream as router_search/router_fetch function calls; the router
+// synthesizes `web_search_call` output items for the client (see
+// attachResponsesOutput / webSearchCallEvent). The upstream model never produced
+// those items and rejects them as input, so drop them before forwarding. The
+// assistant's answer text and citation annotations remain intact.
+func stripClientSyntheticResponseItems(input any) any {
+	items, ok := input.([]any)
+	if !ok {
+		return input
+	}
+	filtered := make([]any, 0, len(items))
+	for _, raw := range items {
+		if item, ok := raw.(map[string]any); ok && stringValue(item["type"]) == "web_search_call" {
+			continue
+		}
+		filtered = append(filtered, raw)
+	}
+	return filtered
 }
 
 func (a *responsesLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, _ int, _ time.Duration) ([]toolCall, []toolCall, bool, any) {

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -588,23 +588,6 @@ func (a *responsesLoopAdapter) buildInitialRequest() map[string]any {
 	return base
 }
 
-// stripClientSyntheticResponseItems drops router-synthesized web_search_call
-// items clients echo back as input; the upstream model never produced them.
-func stripClientSyntheticResponseItems(input any) any {
-	items, ok := input.([]any)
-	if !ok {
-		return input
-	}
-	filtered := make([]any, 0, len(items))
-	for _, raw := range items {
-		if item, ok := raw.(map[string]any); ok && stringValue(item["type"]) == "web_search_call" {
-			continue
-		}
-		filtered = append(filtered, raw)
-	}
-	return filtered
-}
-
 func (a *responsesLoopAdapter) onUpstreamResponse(response *upstreamJSONResponse, _ int, _ time.Duration) ([]toolCall, []toolCall, bool, any) {
 	routerToolCalls, clientToolCalls := splitToolCalls(a.ownedTools, parseResponsesToolCalls(response.body))
 	autoContinueCalls, externalClientCalls := splitClientToolCalls(a.autoContinueTools, clientToolCalls)

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -588,13 +588,8 @@ func (a *responsesLoopAdapter) buildInitialRequest() map[string]any {
 	return base
 }
 
-// stripClientSyntheticResponseItems removes router-synthesized hosted-tool items
-// that clients echo back into `input` on a later turn. Server-side web search
-// runs upstream as router_search/router_fetch function calls; the router
-// synthesizes `web_search_call` output items for the client (see
-// attachResponsesOutput / webSearchCallEvent). The upstream model never produced
-// those items and rejects them as input, so drop them before forwarding. The
-// assistant's answer text and citation annotations remain intact.
+// stripClientSyntheticResponseItems drops router-synthesized web_search_call
+// items clients echo back as input; the upstream model never produced them.
 func stripClientSyntheticResponseItems(input any) any {
 	items, ok := input.([]any)
 	if !ok {


### PR DESCRIPTION
websearch_call is added by the router to give to the client. The client then will sometimes then pass this back, so  we need to strip it out before it gets to vllm

the code_exec item is also stripped, though it isn't excercised in production yet, so this avoids the future footgun