### PR TITLE
Chore: double up on glm 5.2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,15 +38,11 @@ models:
     enclaves:
       - llama3-3-70b.tinfoil.containers.tinfoil.dev
 
-  glm-5-1:
-    repo: tinfoilsh/confidential-glm5-1
-    enclaves:
-      - glm-5-1.tinfoil.containers.tinfoil.dev
-
   glm-5-2:
     repo: tinfoilsh/confidential-glm5-2
     enclaves:
       - glm-5-2.tinfoil.containers.tinfoil.dev
+      - glm-5-2-1.tinfoil.containers.tinfoil.dev
 
   deepseek-v4-pro:
     repo: tinfoilsh/confidential-deepseek-v4-pro


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed `glm-5-1` from the config and added a second `glm-5-2` enclave (`glm-5-2-1.tinfoil.containers.tinfoil.dev`) to increase capacity and redundancy.

- **Migration**
  - Update any references from `glm-5-1` to `glm-5-2`.

<sup>Written for commit 6fed0a9619fb752ba6a7af7b11672787fc0c9b24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

