### PR TITLE
chore: remove qwen3-vl

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -69,11 +69,6 @@ models:
     enclaves:
       - qwen3-tts.realtime.inf10.tinfoil.sh
 
-  qwen3-vl-30b:
-    repo: tinfoilsh/confidential-qwen3-vl-30b
-    enclaves:
-      - qwen3-vl-30b.inf10.tinfoil.sh
-
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6-b200
     enclaves:


### PR DESCRIPTION
Removed configuration for qwen3-vl-30b model.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `qwen3-vl-30b` model from `config.yml` along with its enclave mapping. This retires the model and prevents requests from being routed to an unavailable deployment.

<sup>Written for commit 61ed359e322d13892d2ecd1723d0553e025e3c4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

