### PR TITLE
chore: remove one gpt oss

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -53,7 +53,6 @@ models:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:
       - gpt-oss-120b-0.inf6.tinfoil.sh
-      - gpt-oss-120b-1.inf6.tinfoil.sh
       - gpt-oss-120b-1.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 8


### PR DESCRIPTION
Removed an enclave entry for gpt-oss-120b.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `gpt-oss-120b-1.inf6.tinfoil.sh` enclave from the `gpt-oss-120b` model in `config.yml`. Traffic will no longer be routed to this host.

<sup>Written for commit 04520f9e9e20986deacdea49f7338d876cd19424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

