### PR TITLE
Remove enclave entry for glm-5-2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,7 +42,6 @@ models:
     repo: tinfoilsh/confidential-glm5-2
     enclaves:
       - glm-5-2.tinfoil.containers.tinfoil.dev
-      - glm-5-2-1.tinfoil.containers.tinfoil.dev
 
   deepseek-v4-pro:
     repo: tinfoilsh/confidential-deepseek-v4-pro


### PR DESCRIPTION
Removed an enclave entry for glm-5-2 in config.yml.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the stale enclave entry `glm-5-2-1.tinfoil.containers.tinfoil.dev` for glm-5-2 from `config.yml` to prevent routing to an invalid host and keep the config accurate. The active enclave remains `glm-5-2.tinfoil.containers.tinfoil.dev`.

<sup>Written for commit 95a7f404b5193e84cc260a9fc3db73c562bb896b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

