### PR TITLE
Update enclave for glm-5-2 configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -41,7 +41,7 @@ models:
   glm-5-2:
     repo: tinfoilsh/confidential-glm5-2
     enclaves:
-      - glm-5-2.tinfoil.containers.tinfoil.dev
+      - glm-5-2-inf7.tinfoil.containers.tinfoil.dev
 
   deepseek-v4-pro:
     repo: tinfoilsh/confidential-deepseek-v4-pro


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update glm-5-2 to use the new enclave `glm-5-2-inf7.tinfoil.containers.tinfoil.dev`. This routes traffic to the active environment and deprecates the old endpoint.

<sup>Written for commit b87d6aaf8fbd875c34e5e096955993a1bf80374e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

