### PR TITLE
Add new enclave for glm-5-2 configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,6 +42,7 @@ models:
     repo: tinfoilsh/confidential-glm5-2
     enclaves:
       - glm-5-2-inf7.tinfoil.containers.tinfoil.dev
+      - glm-5-2-inf11.tinfoil.containers.tinfoil.dev
 
   deepseek-v4-pro:
     repo: tinfoilsh/confidential-deepseek-v4-pro


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `glm-5-2-inf11.tinfoil.containers.tinfoil.dev` to the `glm-5-2` enclaves to increase capacity and improve failover.

<sup>Written for commit 5a0610e6a2805b735c158b99353c9f3d4adff873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

