### PR TITLE
chore: delete code-execution section from config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -83,11 +83,6 @@ models:
     enclaves:
       - websearch.tinfoil.sh
 
-  code-execution:
-    repo: tinfoilsh/confidential-code-execution
-    enclaves:
-      - code-execution.tinfoil.sh
-
   gemma4-31b:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:


### PR DESCRIPTION
Removed code-execution configuration from config.yml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `code-execution` section from `config.yml` to clean up unused configuration and avoid references to a deprecated service. No behavior change; other model configs remain unchanged.

<sup>Written for commit 3b30add443c6ca39e87ca43c320ad7ed565bbca7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

