### PR TITLE
chore: enclave for kimi-k2-6 configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ models:
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6-b200
     enclaves:
-      - kimi-k2-6.inf13.tinfoil.sh
+      - kimi-k2-6.inf14.tinfoil.sh
     rate_limit:
       max_requests_per_minute: 4
     overload:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the `kimi-k2-6` enclave host from kimi-k2-6.inf13.tinfoil.sh to kimi-k2-6.inf14.tinfoil.sh to point traffic at the active deployment.

<sup>Written for commit 20fc9cde89f8797ebb57f3b494d8f7acc102897e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

