### PR TITLE
Route the auto model to a healthy backend with fallback

### DIFF
--- a/main.go
+++ b/main.go
@@ -272,17 +272,18 @@ var autoModelParamReservedKeys = map[string]bool{
 	"pii_check_options":      true,
 }
 
-// healthyModelResolver resolves an ordered candidate list to a concrete model
-// name. Implemented by *manager.EnclaveManager.
-type healthyModelResolver interface {
-	ResolveHealthyModel(candidates []string) string
+// preferredModelResolver resolves an ordered candidate list to a concrete
+// model name, preferring healthy backends. Implemented by
+// *manager.EnclaveManager.
+type preferredModelResolver interface {
+	ResolvePreferredModel(candidates []string) string
 }
 
 // resolveAutoModel consumes the router-only auto_model_options blob, picks the
 // first candidate whose model currently has a healthy enclave, shallow-merges
 // that candidate's params into body (excluding reserved keys), rewrites
 // body["model"], and strips the blob. It returns the resolved model name.
-func resolveAutoModel(resolver healthyModelResolver, body map[string]any) (string, error) {
+func resolveAutoModel(resolver preferredModelResolver, body map[string]any) (string, error) {
 	raw, ok := body["auto_model_options"].([]any)
 	delete(body, "auto_model_options")
 	if !ok || len(raw) == 0 {
@@ -301,6 +302,9 @@ func resolveAutoModel(resolver healthyModelResolver, body map[string]any) (strin
 			continue
 		}
 		names = append(names, name)
+		if _, seen := paramsByModel[name]; seen {
+			continue
+		}
 		if params, ok := opt["params"].(map[string]any); ok {
 			paramsByModel[name] = params
 		}
@@ -310,7 +314,7 @@ func resolveAutoModel(resolver healthyModelResolver, body map[string]any) (strin
 		return "", fmt.Errorf("Missing auto model choices: 'auto_model_options' has no valid model entries.")
 	}
 
-	resolved := resolver.ResolveHealthyModel(names)
+	resolved := resolver.ResolvePreferredModel(names)
 	if resolved == "" {
 		return "", fmt.Errorf("Missing auto model choices: no valid model could be resolved.")
 	}

--- a/main.go
+++ b/main.go
@@ -256,6 +256,75 @@ func ensureStreamingUsageOptions(body map[string]any, headers http.Header) {
 	}
 }
 
+// autoModelParamReservedKeys lists body fields that a per-candidate param block
+// must never overwrite when merged, so client-supplied auto params cannot
+// clobber the routing model, conversation, streaming, or tool/option blobs.
+var autoModelParamReservedKeys = map[string]bool{
+	"model":                  true,
+	"messages":               true,
+	"input":                  true,
+	"stream":                 true,
+	"stream_options":         true,
+	"tools":                  true,
+	"tool_choice":            true,
+	"web_search_options":     true,
+	"code_execution_options": true,
+	"pii_check_options":      true,
+}
+
+// healthyModelResolver resolves an ordered candidate list to a concrete model
+// name. Implemented by *manager.EnclaveManager.
+type healthyModelResolver interface {
+	ResolveHealthyModel(candidates []string) string
+}
+
+// resolveAutoModel consumes the router-only auto_model_options blob, picks the
+// first candidate whose model currently has a healthy enclave, shallow-merges
+// that candidate's params into body (excluding reserved keys), rewrites
+// body["model"], and strips the blob. It returns the resolved model name.
+func resolveAutoModel(resolver healthyModelResolver, body map[string]any) (string, error) {
+	raw, ok := body["auto_model_options"].([]any)
+	delete(body, "auto_model_options")
+	if !ok || len(raw) == 0 {
+		return "", fmt.Errorf("Missing auto model choices: 'auto_model_options' is required when model is 'auto'.")
+	}
+
+	names := make([]string, 0, len(raw))
+	paramsByModel := make(map[string]map[string]any, len(raw))
+	for _, entry := range raw {
+		opt, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, ok := opt["model"].(string)
+		if !ok || name == "" {
+			continue
+		}
+		names = append(names, name)
+		if params, ok := opt["params"].(map[string]any); ok {
+			paramsByModel[name] = params
+		}
+	}
+
+	if len(names) == 0 {
+		return "", fmt.Errorf("Missing auto model choices: 'auto_model_options' has no valid model entries.")
+	}
+
+	resolved := resolver.ResolveHealthyModel(names)
+	if resolved == "" {
+		return "", fmt.Errorf("Missing auto model choices: no valid model could be resolved.")
+	}
+
+	for key, value := range paramsByModel[resolved] {
+		if autoModelParamReservedKeys[key] {
+			continue
+		}
+		body[key] = value
+	}
+	body["model"] = resolved
+	return resolved, nil
+}
+
 func main() {
 	flag.Parse()
 	if *verbose {
@@ -457,6 +526,20 @@ func main() {
 				if !ok {
 					jsonError(w, "Invalid parameter: 'model' must be a string.", manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
+				}
+
+				// "auto" is a router-side sentinel: the candidate models and
+				// their per-model param blocks travel in the router-only
+				// auto_model_options blob. Resolve it to a concrete, healthy
+				// model and merge that model's params before any downstream
+				// logic (tool detection, rate limiting, serving) runs.
+				if modelName == "auto" {
+					resolved, mergeErr := resolveAutoModel(em, body)
+					if mergeErr != nil {
+						jsonError(w, mergeErr.Error(), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+						return
+					}
+					modelName = resolved
 				}
 
 				// Detect which built-in tool profiles this request

--- a/main_test.go
+++ b/main_test.go
@@ -552,7 +552,7 @@ type fakeResolver struct {
 	healthy map[string]bool
 }
 
-func (f fakeResolver) ResolveHealthyModel(candidates []string) string {
+func (f fakeResolver) ResolvePreferredModel(candidates []string) string {
 	var first string
 	for _, c := range candidates {
 		if c == "" {
@@ -614,6 +614,34 @@ func TestResolveAutoModel(t *testing.T) {
 	// glm-5-2 (skipped) params must not leak into the body.
 	if _, ok := body["chat_template_kwargs"]; ok {
 		t.Fatal("non-selected candidate params leaked into body")
+	}
+}
+
+func TestResolveAutoModel_DuplicateModelKeepsFirstParams(t *testing.T) {
+	resolver := fakeResolver{}
+	body := map[string]any{
+		"model": "auto",
+		"auto_model_options": []any{
+			map[string]any{
+				"model":  "kimi-k2-6",
+				"params": map[string]any{"reasoning_effort": "high"},
+			},
+			map[string]any{
+				"model":  "kimi-k2-6",
+				"params": map[string]any{"reasoning_effort": "low"},
+			},
+		},
+	}
+
+	resolved, err := resolveAutoModel(resolver, body)
+	if err != nil {
+		t.Fatalf("resolveAutoModel: %v", err)
+	}
+	if resolved != "kimi-k2-6" {
+		t.Fatalf("resolved = %q, want kimi-k2-6", resolved)
+	}
+	if body["reasoning_effort"] != "high" {
+		t.Fatalf("expected first params (high), got %v", body["reasoning_effort"])
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -546,3 +546,84 @@ func TestDetectToolProfiles(t *testing.T) {
 		})
 	}
 }
+
+// fakeResolver picks the first candidate present in healthy, else "".
+type fakeResolver struct {
+	healthy map[string]bool
+}
+
+func (f fakeResolver) ResolveHealthyModel(candidates []string) string {
+	var first string
+	for _, c := range candidates {
+		if c == "" {
+			continue
+		}
+		if first == "" {
+			first = c
+		}
+		if f.healthy[c] {
+			return c
+		}
+	}
+	return first
+}
+
+func TestResolveAutoModel(t *testing.T) {
+	resolver := fakeResolver{healthy: map[string]bool{"kimi-k2-6": true}}
+
+	body := map[string]any{
+		"model":    "auto",
+		"messages": []any{map[string]any{"role": "user", "content": "hi"}},
+		"stream":   true,
+		"auto_model_options": []any{
+			map[string]any{
+				"model":  "glm-5-2",
+				"params": map[string]any{"chat_template_kwargs": map[string]any{"enable_thinking": true}},
+			},
+			map[string]any{
+				"model": "kimi-k2-6",
+				"params": map[string]any{
+					"reasoning_effort": "high",
+					// Reserved keys must never be overwritten by a candidate.
+					"model":    "evil",
+					"messages": "evil",
+				},
+			},
+		},
+	}
+
+	resolved, err := resolveAutoModel(resolver, body)
+	if err != nil {
+		t.Fatalf("resolveAutoModel: %v", err)
+	}
+	if resolved != "kimi-k2-6" {
+		t.Fatalf("resolved = %q, want kimi-k2-6", resolved)
+	}
+	if body["model"] != "kimi-k2-6" {
+		t.Fatalf("body[model] = %v, want kimi-k2-6", body["model"])
+	}
+	if body["reasoning_effort"] != "high" {
+		t.Fatalf("expected merged reasoning_effort=high, got %v", body["reasoning_effort"])
+	}
+	if _, ok := body["auto_model_options"]; ok {
+		t.Fatal("auto_model_options should be stripped from body")
+	}
+	if msgs, ok := body["messages"].([]any); !ok || len(msgs) != 1 {
+		t.Fatalf("reserved messages field was clobbered: %v", body["messages"])
+	}
+	// glm-5-2 (skipped) params must not leak into the body.
+	if _, ok := body["chat_template_kwargs"]; ok {
+		t.Fatal("non-selected candidate params leaked into body")
+	}
+}
+
+func TestResolveAutoModel_MissingOptions(t *testing.T) {
+	resolver := fakeResolver{}
+	body := map[string]any{"model": "auto"}
+	if _, err := resolveAutoModel(resolver, body); err == nil {
+		t.Fatal("expected error when auto_model_options is missing")
+	}
+	if _, ok := body["auto_model_options"]; ok {
+		t.Fatal("auto_model_options should be stripped even on error")
+	}
+}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -351,6 +351,39 @@ func (m *Model) EnclaveCount() int {
 	return len(m.Enclaves)
 }
 
+// HasHealthyEnclave reports whether the model has at least one enclave whose
+// circuit breaker is currently closed. Used by ResolveHealthyModel to skip
+// models whose backends are all tripped (i.e. effectively down).
+func (m *Model) HasHealthyEnclave() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, enclave := range m.Enclaves {
+		if enclave.cb == nil || enclave.cb.Closed() {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveHealthyModel returns the first candidate whose model exists and has a
+// healthy enclave, falling back to the first non-empty candidate when none are
+// healthy (so normal serving surfaces the error), or "" when the list is empty.
+func (em *EnclaveManager) ResolveHealthyModel(candidates []string) string {
+	var first string
+	for _, name := range candidates {
+		if name == "" {
+			continue
+		}
+		if first == "" {
+			first = name
+		}
+		if model, found := em.GetModel(name); found && model.HasHealthyEnclave() {
+			return name
+		}
+	}
+	return first
+}
+
 func (e *Enclave) isOverloaded() bool {
 	return e != nil && e.metrics != nil && e.metrics.overloaded.Load()
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -352,7 +352,7 @@ func (m *Model) EnclaveCount() int {
 }
 
 // HasHealthyEnclave reports whether the model has at least one enclave whose
-// circuit breaker is currently closed. Used by ResolveHealthyModel to skip
+// circuit breaker is currently closed. Used by ResolvePreferredModel to skip
 // models whose backends are all tripped (i.e. effectively down).
 func (m *Model) HasHealthyEnclave() bool {
 	m.mu.RLock()
@@ -365,10 +365,11 @@ func (m *Model) HasHealthyEnclave() bool {
 	return false
 }
 
-// ResolveHealthyModel returns the first candidate whose model exists and has a
-// healthy enclave, falling back to the first non-empty candidate when none are
-// healthy (so normal serving surfaces the error), or "" when the list is empty.
-func (em *EnclaveManager) ResolveHealthyModel(candidates []string) string {
+// ResolvePreferredModel returns the first candidate whose model exists and has
+// a healthy enclave. When none are healthy it falls back to the first non-empty
+// candidate (so normal serving surfaces the error), and returns "" when the
+// list is empty. The result is therefore preferred, not guaranteed healthy.
+func (em *EnclaveManager) ResolvePreferredModel(candidates []string) string {
 	var first string
 	for _, name := range candidates {
 		if name == "" {

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -109,7 +109,7 @@ func newTestManager(models map[string]*Model) *EnclaveManager {
 	return em
 }
 
-func TestResolveHealthyModel(t *testing.T) {
+func TestResolvePreferredModel(t *testing.T) {
 	down := newTestModel("a")
 	tripBreaker(down.Enclaves["a"])
 	em := newTestManager(map[string]*Model{
@@ -119,29 +119,29 @@ func TestResolveHealthyModel(t *testing.T) {
 	})
 
 	// First candidate is down -> skip to the next healthy one.
-	if got := em.ResolveHealthyModel([]string{"glm-5-2", "kimi-k2-6", "deepseek-v4-pro"}); got != "kimi-k2-6" {
+	if got := em.ResolvePreferredModel([]string{"glm-5-2", "kimi-k2-6", "deepseek-v4-pro"}); got != "kimi-k2-6" {
 		t.Fatalf("expected kimi-k2-6, got %q", got)
 	}
 
 	// First candidate healthy -> use it.
-	if got := em.ResolveHealthyModel([]string{"kimi-k2-6", "deepseek-v4-pro"}); got != "kimi-k2-6" {
+	if got := em.ResolvePreferredModel([]string{"kimi-k2-6", "deepseek-v4-pro"}); got != "kimi-k2-6" {
 		t.Fatalf("expected kimi-k2-6, got %q", got)
 	}
 
 	// None healthy -> fall back to the first candidate.
 	tripBreaker(em.mustModel(t, "kimi-k2-6").Enclaves["b"])
 	tripBreaker(em.mustModel(t, "deepseek-v4-pro").Enclaves["c"])
-	if got := em.ResolveHealthyModel([]string{"glm-5-2", "kimi-k2-6"}); got != "glm-5-2" {
+	if got := em.ResolvePreferredModel([]string{"glm-5-2", "kimi-k2-6"}); got != "glm-5-2" {
 		t.Fatalf("expected glm-5-2 fallback, got %q", got)
 	}
 
 	// Unknown model is treated as the first candidate fallback when unhealthy.
-	if got := em.ResolveHealthyModel([]string{"does-not-exist", "kimi-k2-6"}); got != "does-not-exist" {
+	if got := em.ResolvePreferredModel([]string{"does-not-exist", "kimi-k2-6"}); got != "does-not-exist" {
 		t.Fatalf("expected does-not-exist fallback, got %q", got)
 	}
 
 	// Empty / blank-only lists resolve to "".
-	if got := em.ResolveHealthyModel([]string{"", ""}); got != "" {
+	if got := em.ResolvePreferredModel([]string{"", ""}); got != "" {
 		t.Fatalf("expected empty resolution, got %q", got)
 	}
 }

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -67,4 +68,89 @@ func TestNextEnclave_EmptyModel(t *testing.T) {
 	if got := m.NextEnclave(nil); got != nil {
 		t.Fatalf("expected nil, got %v", got)
 	}
+}
+
+func tripBreaker(e *Enclave) {
+	for i := 0; i < cbFailureThreshold; i++ {
+		e.cb.RecordFailure()
+	}
+}
+
+func TestHasHealthyEnclave(t *testing.T) {
+	healthy := newTestModel("a", "b")
+	if !healthy.HasHealthyEnclave() {
+		t.Fatal("expected healthy model with closed breakers")
+	}
+
+	down := newTestModel("a", "b")
+	tripBreaker(down.Enclaves["a"])
+	tripBreaker(down.Enclaves["b"])
+	if down.HasHealthyEnclave() {
+		t.Fatal("expected unhealthy model with all breakers open")
+	}
+
+	partial := newTestModel("a", "b")
+	tripBreaker(partial.Enclaves["a"])
+	if !partial.HasHealthyEnclave() {
+		t.Fatal("expected healthy model when one breaker is still closed")
+	}
+
+	empty := &Model{Enclaves: map[string]*Enclave{}}
+	if empty.HasHealthyEnclave() {
+		t.Fatal("expected unhealthy model with no enclaves")
+	}
+}
+
+func newTestManager(models map[string]*Model) *EnclaveManager {
+	em := &EnclaveManager{models: &sync.Map{}}
+	for name, m := range models {
+		em.models.Store(name, m)
+	}
+	return em
+}
+
+func TestResolveHealthyModel(t *testing.T) {
+	down := newTestModel("a")
+	tripBreaker(down.Enclaves["a"])
+	em := newTestManager(map[string]*Model{
+		"glm-5-2":         down,
+		"kimi-k2-6":       newTestModel("b"),
+		"deepseek-v4-pro": newTestModel("c"),
+	})
+
+	// First candidate is down -> skip to the next healthy one.
+	if got := em.ResolveHealthyModel([]string{"glm-5-2", "kimi-k2-6", "deepseek-v4-pro"}); got != "kimi-k2-6" {
+		t.Fatalf("expected kimi-k2-6, got %q", got)
+	}
+
+	// First candidate healthy -> use it.
+	if got := em.ResolveHealthyModel([]string{"kimi-k2-6", "deepseek-v4-pro"}); got != "kimi-k2-6" {
+		t.Fatalf("expected kimi-k2-6, got %q", got)
+	}
+
+	// None healthy -> fall back to the first candidate.
+	tripBreaker(em.mustModel(t, "kimi-k2-6").Enclaves["b"])
+	tripBreaker(em.mustModel(t, "deepseek-v4-pro").Enclaves["c"])
+	if got := em.ResolveHealthyModel([]string{"glm-5-2", "kimi-k2-6"}); got != "glm-5-2" {
+		t.Fatalf("expected glm-5-2 fallback, got %q", got)
+	}
+
+	// Unknown model is treated as the first candidate fallback when unhealthy.
+	if got := em.ResolveHealthyModel([]string{"does-not-exist", "kimi-k2-6"}); got != "does-not-exist" {
+		t.Fatalf("expected does-not-exist fallback, got %q", got)
+	}
+
+	// Empty / blank-only lists resolve to "".
+	if got := em.ResolveHealthyModel([]string{"", ""}); got != "" {
+		t.Fatalf("expected empty resolution, got %q", got)
+	}
+}
+
+func (em *EnclaveManager) mustModel(t *testing.T, name string) *Model {
+	t.Helper()
+	m, ok := em.GetModel(name)
+	if !ok {
+		t.Fatalf("model %q not found", name)
+	}
+	return m
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Route `model: "auto"` requests to the first healthy backend, with deterministic fallback to the first candidate when none are healthy. Merge only the selected model’s params and strip `auto_model_options` before downstream processing; return 400 when options are missing or invalid.

- New Features
  - Resolves `auto` via `auto_model_options`, preferring models with a healthy enclave (closed breaker); otherwise uses the first non-empty candidate.
  - Merges only the selected candidate’s `params` into the body; ignores reserved keys.
  - For duplicate model entries, uses params from the first occurrence to keep behavior stable.
  - Removes `auto_model_options` from the body before downstream logic, even on error.

- Migration
  - When using `model: "auto"`, clients must send `auto_model_options: [{ model: "...", params: {...} }, ...]`.
  - Reserved keys in `params` are ignored: `model`, `messages`, `input`, `stream`, `stream_options`, `tools`, `tool_choice`, `web_search_options`, `code_execution_options`, `pii_check_options`.
  - Missing or empty `auto_model_options` returns a 400 error.

<sup>Written for commit 2cd0cdc66f6fd9acccef4006d8365976498f6913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

