### PR TITLE
Update enclave hostname for kimi-k2-6

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ models:
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6-b200
     enclaves:
-      - kimi-k2-6.inf14.tinfoil.sh
+      - kimi-k2-6-inf13.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 4
     overload:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point the `kimi-k2-6` model to the new enclave by updating its hostname in the config. Replaces kimi-k2-6.inf14.tinfoil.sh with kimi-k2-6-inf13.tinfoil.containers.tinfoil.dev; no other changes.

<sup>Written for commit 2f930c38b91d4576e1c0cb0464bce370aa26b1f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

