### PR TITLE
chore: add gemma4-31b-4.inf10.tinfoil.sh to config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -90,6 +90,7 @@ models:
       - gemma4-31b-1.inf10.tinfoil.sh
       - gemma4-31b-2.inf10.tinfoil.sh
       - gemma4-31b-3.inf10.tinfoil.sh
+      - gemma4-31b-4.inf10.tinfoil.sh
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `gemma4-31b-4.inf10.tinfoil.sh` to the `gemma4-31b` model endpoints in `config.yml` to expand capacity and improve redundancy. Traffic can now be balanced across four hosts; no other changes.

<sup>Written for commit 331284bc0b89f043edf32a2ffde56359f55c2949. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

