### PR TITLE
feat: include served model in usage metrics

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -25,6 +25,7 @@ import (
 
 type Enclave struct {
 	host      string
+	modelName string
 	tlsKeyFP  string
 	hpkeKey   string
 	predicate attestation.PredicateType
@@ -200,6 +201,7 @@ func (em *EnclaveManager) addEnclave(
 	cb := newCircuitBreaker()
 	model.Enclaves[host] = &Enclave{
 		host:      host,
+		modelName: modelName,
 		predicate: verification.Measurement.Type,
 		tlsKeyFP:  verification.TLSPublicKeyFP,
 		hpkeKey:   verification.HPKEPublicKey,
@@ -366,7 +368,7 @@ func (e *Enclave) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Wrap the ResponseWriter to capture usage and write trailer
-	wrapper := &usageMetricsWriter{ResponseWriter: w}
+	wrapper := &usageMetricsWriter{ResponseWriter: w, model: e.modelName}
 
 	// Store wrapper in request context for ModifyResponse to access
 	ctx := context.WithValue(r.Context(), usageWriterKey{}, wrapper)

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -344,7 +344,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				usageHandler(jsonResp.Usage)
 
 				// Set usage header directly on response
-				resp.Header.Set(UsageMetricsResponseHeader, formatUsage(jsonResp.Usage))
+				resp.Header.Set(UsageMetricsResponseHeader, formatUsage(jsonResp.Usage, modelName))
 			} else if billingCollector != nil && apiKey != "" {
 				emitZeroTokenEvent()
 			}
@@ -391,7 +391,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 }
 
 // formatUsage formats token usage for the response header
-func formatUsage(usage *tokencount.Usage) string {
+func formatUsage(usage *tokencount.Usage, model string) string {
 	formatted := "prompt=" + strconv.Itoa(usage.PromptTokens) +
 		",completion=" + strconv.Itoa(usage.CompletionTokens) +
 		",total=" + strconv.Itoa(usage.TotalTokens)
@@ -403,6 +403,10 @@ func formatUsage(usage *tokencount.Usage) string {
 			formatted += ",cached_prompt_tokens=" + strconv.Itoa(cachedPromptTokens) +
 				",uncached_prompt_tokens=" + strconv.Itoa(uncachedPromptTokens)
 		}
+	}
+
+	if model != "" {
+		formatted += ",model=" + model
 	}
 
 	return formatted

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -82,7 +82,7 @@ func TestProxyUsageMetrics_NonKimiModelKeepsLegacyUsageFormat(t *testing.T) {
 	proxy.ServeHTTP(wrapper, req.WithContext(ctx))
 
 	got := rec.Header().Get(UsageMetricsResponseHeader)
-	want := "prompt=69,completion=20,total=89"
+	want := "prompt=69,completion=20,total=89,model=test-model"
 	if got != want {
 		t.Fatalf("usage header = %q, want %q", got, want)
 	}

--- a/manager/usage_writer.go
+++ b/manager/usage_writer.go
@@ -17,6 +17,7 @@ type usageWriterKey struct{}
 type usageMetricsWriter struct {
 	http.ResponseWriter
 	usage          *tokencount.Usage
+	model          string
 	trailerEnabled bool
 	mu             sync.Mutex
 }
@@ -49,7 +50,7 @@ func (w *usageMetricsWriter) FormatUsage() string {
 	if w.usage == nil {
 		return ""
 	}
-	return formatUsage(w.usage)
+	return formatUsage(w.usage, w.model)
 }
 
 // WriteTrailer writes the usage metrics as an HTTP trailer

--- a/manager/usage_writer_test.go
+++ b/manager/usage_writer_test.go
@@ -42,6 +42,7 @@ func TestUsageMetricsWriter_FormatUsage(t *testing.T) {
 	tests := []struct {
 		name     string
 		usage    *tokencount.Usage
+		model    string
 		expected string
 	}{
 		{
@@ -52,6 +53,28 @@ func TestUsageMetricsWriter_FormatUsage(t *testing.T) {
 				TotalTokens:      109,
 			},
 			expected: "prompt=67,completion=42,total=109",
+		},
+		{
+			name: "appends model when present",
+			usage: &tokencount.Usage{
+				PromptTokens:     67,
+				CompletionTokens: 42,
+				TotalTokens:      109,
+			},
+			model:    "kimi-k2-6",
+			expected: "prompt=67,completion=42,total=109,model=kimi-k2-6",
+		},
+		{
+			name: "appends model after cached prompt token details",
+			usage: &tokencount.Usage{
+				PromptTokens:             69,
+				CompletionTokens:         20,
+				TotalTokens:              89,
+				PromptTokensDetails:      &tokencount.PromptTokensDetails{CachedTokens: 64},
+				ExposePromptTokenDetails: true,
+			},
+			model:    "kimi-k2-6",
+			expected: "prompt=69,completion=20,total=89,cached_prompt_tokens=64,uncached_prompt_tokens=5,model=kimi-k2-6",
 		},
 		{
 			name: "zero values",
@@ -102,7 +125,7 @@ func TestUsageMetricsWriter_FormatUsage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			wrapper := &usageMetricsWriter{ResponseWriter: rec}
+			wrapper := &usageMetricsWriter{ResponseWriter: rec, model: tt.model}
 
 			if tt.usage != nil {
 				wrapper.SetUsage(tt.usage)
@@ -118,7 +141,7 @@ func TestUsageMetricsWriter_FormatUsage(t *testing.T) {
 
 func TestUsageMetricsWriter_WriteTrailer(t *testing.T) {
 	rec := httptest.NewRecorder()
-	wrapper := &usageMetricsWriter{ResponseWriter: rec}
+	wrapper := &usageMetricsWriter{ResponseWriter: rec, model: "kimi-k2-6"}
 
 	usage := &tokencount.Usage{
 		PromptTokens:     67,
@@ -132,7 +155,7 @@ func TestUsageMetricsWriter_WriteTrailer(t *testing.T) {
 
 	// Check that the header was set
 	headerValue := rec.Header().Get(UsageMetricsResponseHeader)
-	expected := "prompt=67,completion=42,total=109"
+	expected := "prompt=67,completion=42,total=109,model=kimi-k2-6"
 	if headerValue != expected {
 		t.Errorf("expected header %q, got %q", expected, headerValue)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add the served model name to usage metrics so clients and billing can attribute token usage to the correct model. The response header/trailer now appends model=<name>.

- **New Features**
  - `Enclave` stores `modelName` and passes it to the usage writer.
  - `formatUsage` accepts a `model` and appends ",model=<name>", including when cached prompt token details are present.
  - Proxy sets the usage header using the new format; tests updated to assert the appended model.

<sup>Written for commit 61f6accddef245dacba6860f86357cf59d4d75e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

