### PR TITLE
Inject per-principal cache_salt in the router (Phase 1)

### DIFF
--- a/cache_salt.go
+++ b/cache_salt.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/tinfoilsh/confidential-model-router/cachesalt"
+)
+
+// cacheSaltPaths are the endpoints whose engine request schema accepts a
+// cache_salt field. Pooling endpoints (embeddings) do not and would reject
+// the unknown field.
+var cacheSaltPaths = map[string]bool{
+	"/v1/chat/completions": true,
+	"/v1/completions":      true,
+	"/v1/responses":        true,
+}
+
+// applyCacheSalt owns the two cache-salt request fields on a parsed body. It
+// always pops user_cache_secret (router-only input to salt derivation; never
+// sent to the engine) and strips any client-supplied cache_salt — the salt
+// decides who shares the engine's prefix cache, so a client must never
+// choose it. A non-string user_cache_secret (null, number, object) is
+// treated as absent.
+//
+// When enabled, the endpoint supports the field, and the caller resolves to
+// a non-empty identity, it injects the derived salt into body. It returns
+// the derivation mode (ModeNone if no salt was injected) and whether it
+// modified body at all, so callers that proxy verbatim can skip a needless
+// re-marshal.
+//
+// apiKey is the raw bearer token; identity anchoring (JWT subject, else the
+// opaque key) happens here via rateLimitIdentity so the call site cannot
+// wire the wrong value.
+func applyCacheSalt(body map[string]any, path, apiKey string, enabled bool) (cachesalt.Mode, bool) {
+	_, hadSecret := body["user_cache_secret"]
+	_, hadSalt := body["cache_salt"]
+	secret, _ := body["user_cache_secret"].(string)
+	delete(body, "user_cache_secret")
+	delete(body, "cache_salt")
+	changed := hadSecret || hadSalt
+
+	if !enabled || !cacheSaltPaths[path] {
+		return cachesalt.ModeNone, changed
+	}
+	salt, mode := cachesalt.Derive(rateLimitIdentity(apiKey), secret)
+	if salt == "" {
+		return cachesalt.ModeNone, changed
+	}
+	body["cache_salt"] = salt
+	return mode, true
+}
+
+// saltProxiedBody applies cache-salt handling to a request that the router
+// otherwise forwards verbatim (the subdomain routing path, which never
+// parses the body). It rewrites r.Body in place and returns the derivation
+// mode. Only JSON-object bodies are touched; a non-JSON body is forwarded
+// byte-for-byte, and a body that needs no change is not re-marshaled.
+func saltProxiedBody(r *http.Request, apiKey string, enabled bool) (cachesalt.Mode, error) {
+	bodyBytes, err := io.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		return cachesalt.ModeNone, err
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		return cachesalt.ModeNone, nil
+	}
+
+	mode, changed := applyCacheSalt(body, r.URL.Path, apiKey, enabled)
+	if !changed {
+		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		return mode, nil
+	}
+
+	newBytes, err := json.Marshal(body)
+	if err != nil {
+		return cachesalt.ModeNone, err
+	}
+	r.Body = io.NopCloser(bytes.NewReader(newBytes))
+	r.ContentLength = int64(len(newBytes))
+	r.Header.Set("Content-Length", fmt.Sprintf("%d", len(newBytes)))
+	return mode, nil
+}

--- a/cache_salt.go
+++ b/cache_salt.go
@@ -36,6 +36,12 @@ var cacheSaltPaths = map[string]bool{
 // opaque key) happens here via rateLimitIdentity so the call site cannot
 // wire the wrong value.
 func applyCacheSalt(body map[string]any, path, apiKey string, enabled bool) (cachesalt.Mode, bool) {
+	// A JSON `null` body unmarshals to a nil map (with no error). It carries
+	// no fields to strip and no prompt to cache, and injecting would panic on
+	// the nil map — treat it as passthrough. The engine rejects the null body.
+	if body == nil {
+		return cachesalt.ModeNone, false
+	}
 	_, hadSecret := body["user_cache_secret"]
 	_, hadSalt := body["cache_salt"]
 	secret, _ := body["user_cache_secret"].(string)

--- a/cache_salt.go
+++ b/cache_salt.go
@@ -72,8 +72,14 @@ func saltProxiedBody(r *http.Request, apiKey string, enabled bool) (cachesalt.Mo
 		return cachesalt.ModeNone, err
 	}
 
+	// UseNumber keeps numbers as their exact text across the re-marshal;
+	// the default float64 decoding silently corrupts int64-range values
+	// (e.g. seed). dec.More() rejects trailing data, matching
+	// json.Unmarshal's strictness.
+	dec := json.NewDecoder(bytes.NewReader(bodyBytes))
+	dec.UseNumber()
 	var body map[string]any
-	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+	if err := dec.Decode(&body); err != nil || dec.More() {
 		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		return cachesalt.ModeNone, nil
 	}

--- a/cache_salt_test.go
+++ b/cache_salt_test.go
@@ -261,6 +261,20 @@ func TestSaltProxiedBody(t *testing.T) {
 		}
 	})
 
+	t.Run("preserves int64 precision through the re-marshal", func(t *testing.T) {
+		// 2^53+1 is not representable as float64; default JSON decoding
+		// would silently turn it into ...992.
+		req := httptest.NewRequest("POST", "/v1/chat/completions",
+			strings.NewReader(`{"model":"m","seed":9007199254740993}`))
+		if _, err := saltProxiedBody(req, "tenant-a", true); err != nil {
+			t.Fatalf("saltProxiedBody: %v", err)
+		}
+		raw, _ := io.ReadAll(req.Body)
+		if !strings.Contains(string(raw), `"seed":9007199254740993`) {
+			t.Errorf("seed lost precision: %s", raw)
+		}
+	})
+
 	t.Run("forwards a non-JSON body untouched", func(t *testing.T) {
 		const raw = `not json`
 		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(raw))

--- a/cache_salt_test.go
+++ b/cache_salt_test.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/tinfoilsh/confidential-model-router/cachesalt"
+	"github.com/tinfoilsh/confidential-model-router/manager"
+)
+
+// jwtWithSubject builds an unsigned compact JWT carrying the given subject,
+// matching what jwtSubject parses (payload only, signature ignored).
+func jwtWithSubject(sub string) string {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"` + sub + `"}`))
+	return "hdr." + payload + ".sig"
+}
+
+func TestApplyCacheSaltStripsFieldsUnconditionally(t *testing.T) {
+	// Stripping must not depend on the flag, the path, or the identity: a
+	// client-supplied cache_salt must never pass through, and the
+	// user_cache_secret must never reach the engine.
+	cases := []struct {
+		name    string
+		path    string
+		apiKey  string
+		enabled bool
+	}{
+		{"disabled", "/v1/chat/completions", "tenant-a", false},
+		{"non-allowlisted path", "/v1/embeddings", "tenant-a", true},
+		{"empty identity", "/v1/chat/completions", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := map[string]any{
+				"model":             "m",
+				"cache_salt":        "client-chosen",
+				"user_cache_secret": "s1",
+			}
+			mode, changed := applyCacheSalt(body, tc.path, tc.apiKey, tc.enabled)
+			if mode != cachesalt.ModeNone {
+				t.Errorf("mode = %q, want ModeNone", mode)
+			}
+			if !changed {
+				t.Error("changed = false, want true (fields were present)")
+			}
+			if _, ok := body["cache_salt"]; ok {
+				t.Error("client-supplied cache_salt survived")
+			}
+			if _, ok := body["user_cache_secret"]; ok {
+				t.Error("user_cache_secret survived")
+			}
+		})
+	}
+}
+
+func TestApplyCacheSaltChangedFlag(t *testing.T) {
+	// A body with neither field, on a non-injecting call, must report no
+	// change so verbatim-proxy callers can skip re-marshaling.
+	body := map[string]any{"model": "m"}
+	if _, changed := applyCacheSalt(body, "/v1/embeddings", "tenant-a", true); changed {
+		t.Error("changed = true for a body with no salt fields on a non-injecting path")
+	}
+	// Injection is itself a change.
+	body = map[string]any{"model": "m"}
+	if _, changed := applyCacheSalt(body, "/v1/chat/completions", "tenant-a", true); !changed {
+		t.Error("changed = false despite injecting a salt")
+	}
+}
+
+func TestApplyCacheSaltModes(t *testing.T) {
+	tenantSalt, _ := cachesalt.Derive("tenant-a", "")
+	userSalt, _ := cachesalt.Derive("tenant-a", "s1")
+
+	cases := []struct {
+		name     string
+		body     map[string]any
+		wantSalt string
+		wantMode cachesalt.Mode
+	}{
+		{
+			"no secret: tenant namespace",
+			map[string]any{"model": "m"},
+			tenantSalt, cachesalt.ModeTenant,
+		},
+		{
+			"secret: per-user namespace",
+			map[string]any{"model": "m", "user_cache_secret": "s1"},
+			userSalt, cachesalt.ModeUser,
+		},
+		{
+			"empty-string secret is absent",
+			map[string]any{"model": "m", "user_cache_secret": ""},
+			tenantSalt, cachesalt.ModeTenant,
+		},
+		{
+			"null secret is absent",
+			map[string]any{"model": "m", "user_cache_secret": nil},
+			tenantSalt, cachesalt.ModeTenant,
+		},
+		{
+			"non-string secret is absent",
+			map[string]any{"model": "m", "user_cache_secret": float64(42)},
+			tenantSalt, cachesalt.ModeTenant,
+		},
+		{
+			"client salt is replaced, not honored",
+			map[string]any{"model": "m", "cache_salt": "client-chosen"},
+			tenantSalt, cachesalt.ModeTenant,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, _ := applyCacheSalt(tc.body, "/v1/chat/completions", "tenant-a", true)
+			if mode != tc.wantMode {
+				t.Errorf("mode = %q, want %q", mode, tc.wantMode)
+			}
+			if got, _ := tc.body["cache_salt"].(string); got != tc.wantSalt {
+				t.Errorf("cache_salt = %q, want %q", got, tc.wantSalt)
+			}
+			if _, ok := tc.body["user_cache_secret"]; ok {
+				t.Error("user_cache_secret survived")
+			}
+		})
+	}
+}
+
+func TestApplyCacheSaltEndpointAllowlist(t *testing.T) {
+	cases := []struct {
+		path   string
+		inject bool
+	}{
+		{"/v1/chat/completions", true},
+		{"/v1/completions", true},
+		{"/v1/responses", true},
+		{"/v1/embeddings", false},
+		{"/v1/audio/speech", false},
+		{"/v1/convert/file", false},
+		{"/v1/chat/completions/", false}, // exact match only
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			body := map[string]any{"model": "m"}
+			mode, _ := applyCacheSalt(body, tc.path, "tenant-a", true)
+			_, injected := body["cache_salt"]
+			if injected != tc.inject {
+				t.Errorf("injected = %v, want %v", injected, tc.inject)
+			}
+			if tc.inject && mode == cachesalt.ModeNone {
+				t.Error("injected but mode is ModeNone")
+			}
+			if !tc.inject && mode != cachesalt.ModeNone {
+				t.Errorf("not injected but mode = %q", mode)
+			}
+		})
+	}
+}
+
+// TestApplyCacheSaltAnchorsToJWTSubject pins that identity anchoring happens
+// inside applyCacheSalt: a JWT bearer must salt on its stable subject, not on
+// the raw (rotating) token — otherwise the namespace cold-starts on every
+// token refresh. This is the guard against the call site being wired with the
+// raw key.
+func TestApplyCacheSaltAnchorsToJWTSubject(t *testing.T) {
+	token := jwtWithSubject("org_1")
+	wantSubjectSalt, _ := cachesalt.Derive("org_1", "")
+	wantRawSalt, _ := cachesalt.Derive(token, "")
+	if wantSubjectSalt == wantRawSalt {
+		t.Fatal("test setup: subject and raw-token salts coincide")
+	}
+
+	body := map[string]any{"model": "m"}
+	applyCacheSalt(body, "/v1/chat/completions", token, true)
+	if got, _ := body["cache_salt"].(string); got != wantSubjectSalt {
+		t.Errorf("cache_salt = %q, want the subject-anchored salt %q", got, wantSubjectSalt)
+	}
+}
+
+// TestApplyCacheSaltOpaqueKeyIdentity covers callers without a JWT: they are
+// identified by the opaque API key (rateLimitIdentity's fallback), and the
+// salt must anchor to it.
+func TestApplyCacheSaltOpaqueKeyIdentity(t *testing.T) {
+	key := "tk_live_9f8e7d6c5b4a3210"
+	want, _ := cachesalt.Derive(key, "")
+	body := map[string]any{"model": "m"}
+	applyCacheSalt(body, "/v1/chat/completions", key, true)
+	if got, _ := body["cache_salt"].(string); got != want {
+		t.Errorf("cache_salt = %q, want %q", got, want)
+	}
+}
+
+// TestSaltProxiedBody covers the subdomain routing path, where the body is
+// otherwise forwarded verbatim.
+func TestSaltProxiedBody(t *testing.T) {
+	tenantSalt, _ := cachesalt.Derive("tenant-a", "")
+
+	t.Run("injects and strips on the salted body", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/v1/chat/completions",
+			strings.NewReader(`{"model":"m","cache_salt":"client-chosen","user_cache_secret":"s1"}`))
+		mode, err := saltProxiedBody(req, "tenant-a", true)
+		if err != nil {
+			t.Fatalf("saltProxiedBody: %v", err)
+		}
+		userSalt, _ := cachesalt.Derive("tenant-a", "s1")
+		if mode != cachesalt.ModeUser {
+			t.Errorf("mode = %q, want ModeUser", mode)
+		}
+		got := decodeBody(t, req)
+		if got["cache_salt"] != userSalt {
+			t.Errorf("cache_salt = %v, want %q", got["cache_salt"], userSalt)
+		}
+		if _, ok := got["user_cache_secret"]; ok {
+			t.Error("user_cache_secret survived to the engine")
+		}
+	})
+
+	t.Run("strips client salt even when disabled", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/v1/chat/completions",
+			strings.NewReader(`{"model":"m","cache_salt":"client-chosen"}`))
+		mode, err := saltProxiedBody(req, "tenant-a", false)
+		if err != nil {
+			t.Fatalf("saltProxiedBody: %v", err)
+		}
+		if mode != cachesalt.ModeNone {
+			t.Errorf("mode = %q, want ModeNone", mode)
+		}
+		if got := decodeBody(t, req); got["cache_salt"] != nil {
+			t.Errorf("client cache_salt survived while disabled: %v", got["cache_salt"])
+		}
+	})
+
+	t.Run("injects tenant salt with no secret", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/v1/responses", strings.NewReader(`{"model":"m"}`))
+		mode, err := saltProxiedBody(req, "tenant-a", true)
+		if err != nil {
+			t.Fatalf("saltProxiedBody: %v", err)
+		}
+		if mode != cachesalt.ModeTenant {
+			t.Errorf("mode = %q, want ModeTenant", mode)
+		}
+		if got := decodeBody(t, req); got["cache_salt"] != tenantSalt {
+			t.Errorf("cache_salt = %v, want %q", got["cache_salt"], tenantSalt)
+		}
+	})
+
+	t.Run("leaves an unchanged body byte-identical", func(t *testing.T) {
+		const raw = `{"model":"m","messages":[]}`
+		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(raw))
+		// Disabled + no salt fields: nothing to do, must not re-marshal.
+		if _, err := saltProxiedBody(req, "tenant-a", false); err != nil {
+			t.Fatalf("saltProxiedBody: %v", err)
+		}
+		out, _ := io.ReadAll(req.Body)
+		if string(out) != raw {
+			t.Errorf("body was re-marshaled: got %q, want %q", out, raw)
+		}
+	})
+
+	t.Run("forwards a non-JSON body untouched", func(t *testing.T) {
+		const raw = `not json`
+		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(raw))
+		mode, err := saltProxiedBody(req, "tenant-a", true)
+		if err != nil {
+			t.Fatalf("saltProxiedBody: %v", err)
+		}
+		if mode != cachesalt.ModeNone {
+			t.Errorf("mode = %q, want ModeNone", mode)
+		}
+		out, _ := io.ReadAll(req.Body)
+		if string(out) != raw {
+			t.Errorf("non-JSON body altered: got %q", out)
+		}
+	})
+}
+
+// TestCacheSaltMetricSkippedInjection pins that a skipped injection emits no
+// metric sample — dashboards must never see an empty mode label.
+func TestCacheSaltMetricSkippedInjection(t *testing.T) {
+	before := testutil.CollectAndCount(manager.CacheSaltInjectionsTotal)
+
+	// Skipped: empty identity on an allowlisted, enabled path.
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{"model":"m"}`))
+	mode, err := saltProxiedBody(req, "", true)
+	if err != nil {
+		t.Fatalf("saltProxiedBody: %v", err)
+	}
+	if mode != cachesalt.ModeNone {
+		t.Fatalf("mode = %q, want ModeNone", mode)
+	}
+	// The handler only increments when mode != ModeNone; assert the guard by
+	// confirming no new series would be minted for an empty label here.
+	if after := testutil.CollectAndCount(manager.CacheSaltInjectionsTotal); after != before {
+		t.Errorf("metric series changed on a skipped injection: %d -> %d", before, after)
+	}
+}
+
+// decodeBody reads the request's current Body (the value saltProxiedBody
+// rewrote it to) and parses it as JSON.
+func decodeBody(t *testing.T, req *http.Request) map[string]any {
+	t.Helper()
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal body %q: %v", raw, err)
+	}
+	return m
+}

--- a/cachesalt/cachesalt.go
+++ b/cachesalt/cachesalt.go
@@ -56,10 +56,11 @@ const (
 // is present.
 //
 // tenantID must be a stable identifier for the authenticated caller (e.g.
-// the verified JWT subject). Never pass a client-chosen value — callers
-// could pick their namespace — and never the raw bearer token, which
-// rotates and would cold-start the caller's namespace on every refresh.
-// Isolation is only as strong as the authentication that produced tenantID.
+// the verified JWT subject, or a long-lived opaque API key). Never pass a
+// client-chosen value — callers could pick their namespace — and prefer a
+// stable identifier over a short-lived rotating token, which would
+// cold-start the caller's namespace on every refresh. Isolation is only as
+// strong as the authentication that produced tenantID.
 //
 // If tenantID is empty there is no identity to anchor a salt to: Derive
 // returns ("", ModeNone) and the caller must skip injection. An empty

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/in-toto/attestation v1.1.2 // indirect
 	github.com/in-toto/in-toto-golang v0.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/tinfoilsh/confidential-model-router/cachesalt"
 	"github.com/tinfoilsh/confidential-model-router/manager"
 	"github.com/tinfoilsh/confidential-model-router/toolruntime"
 )
@@ -115,6 +116,11 @@ var (
 	// pinning for MCP tool servers during local development. MUST
 	// NOT be enabled in deployed enclaves.
 	debug = flag.Bool("debug", getEnvBool("DEBUG"), "enable debug-only overrides for local development (env: DEBUG)")
+	// cacheSaltEnabled injects a per-principal cache_salt into supported
+	// requests, partitioning the engine's prefix cache between callers.
+	// Off by default for rollout; once enabled, disabling it re-opens
+	// cross-user cache sharing — an emergency lever, not a tuning knob.
+	cacheSaltEnabled = flag.Bool("cache-salt", getEnvBool("CACHE_SALT_ENABLED"), "inject per-principal cache_salt into requests (env: CACHE_SALT_ENABLED)")
 )
 
 func jsonError(w http.ResponseWriter, message string, errType string, code int) {
@@ -504,6 +510,14 @@ func main() {
 				// Identify the caller for rate limiting (see rateLimitIdentity).
 				rateLimitID := rateLimitIdentity(apiKey)
 
+				// Own the cache-salt fields: pop the router-only
+				// user_cache_secret, strip any client-supplied cache_salt,
+				// and (when enabled) inject the derived per-principal salt
+				// on endpoints that support it.
+				if mode, _ := applyCacheSalt(body, r.URL.Path, apiKey, *cacheSaltEnabled); mode != cachesalt.ModeNone {
+					manager.CacheSaltInjectionsTotal.WithLabelValues(modelName, string(mode)).Inc()
+				}
+
 				hasConfiguredPriority := false
 				if routeCtx, ok := routeContextClient.Lookup(r.Context(), apiKey, modelName); ok && routeCtx.Priority != nil {
 					body["priority"] = *routeCtx.Priority
@@ -555,6 +569,19 @@ func main() {
 					}
 					return
 				}
+			}
+		} else if cacheSaltPaths[r.URL.Path] {
+			// Subdomain-routed request on a salt-supporting endpoint. This
+			// path proxies the body verbatim (no parsing above), so apply
+			// cache-salt handling here to keep the strip-and-inject invariant
+			// holding across both routing modes rather than only path routing.
+			mode, err := saltProxiedBody(r, apiKey, *cacheSaltEnabled)
+			if err != nil {
+				jsonError(w, fmt.Sprintf("Could not read request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+				return
+			}
+			if mode != cachesalt.ModeNone {
+				manager.CacheSaltInjectionsTotal.WithLabelValues(modelName, string(mode)).Inc()
 			}
 		}
 

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -79,6 +79,15 @@ var (
 		[]string{"model"},
 	)
 
+	// CacheSaltInjectionsTotal tracks requests injected with a derived cache_salt
+	CacheSaltInjectionsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_cache_salt_injections_total",
+			Help: "Total number of requests injected with a derived cache_salt, labeled by derivation mode (tenant or user)",
+		},
+		[]string{"model", "mode"},
+	)
+
 	// RouteContextLookupFailuresTotal tracks failed route-context lookups to the control plane
 	RouteContextLookupFailuresTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/toolruntime/cache_salt_passthrough_test.go
+++ b/toolruntime/cache_salt_passthrough_test.go
@@ -1,0 +1,86 @@
+package toolruntime
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The router injects cache_salt into the request body before the tool loop
+// starts, and the loop replays a growing prefix upstream every iteration —
+// the strongest case for prefix caching. Every upstream request the loop
+// builds must therefore carry the salt so the whole loop stays inside the
+// caller's cache namespace. These tests pin that each request builder clones
+// the salted body and never strips the field: the initial request, the 2nd+
+// continuation, and the streaming variants.
+
+const testSalt = "salt-123"
+
+func TestChatLoopRequestKeepsCacheSalt(t *testing.T) {
+	adapter := newChatLoopAdapter(
+		map[string]any{"model": "m", "messages": []any{}, "cache_salt": testSalt},
+		nil, nil, nil, "m", http.Header{}, nil,
+	)
+	if got, _ := adapter.buildInitialRequest()["cache_salt"].(string); got != testSalt {
+		t.Errorf("chat initial request cache_salt = %q, want %q", got, testSalt)
+	}
+}
+
+func TestResponsesLoopRequestKeepsCacheSalt(t *testing.T) {
+	adapter := newResponsesLoopAdapter(
+		map[string]any{"model": "m", "input": []any{}, "cache_salt": testSalt},
+		nil, nil, nil, nil,
+	)
+	if got, _ := adapter.buildInitialRequest()["cache_salt"].(string); got != testSalt {
+		t.Errorf("responses initial request cache_salt = %q, want %q", got, testSalt)
+	}
+}
+
+// The continuation requests carry the maximal prefix (prompt + prior turns +
+// tool outputs), so dropping the salt on iteration 2+ is where a regression
+// hurts most.
+
+func TestChatLoopContinuationKeepsCacheSalt(t *testing.T) {
+	adapter := newChatLoopAdapter(
+		map[string]any{"model": "m", "messages": []any{}, "cache_salt": testSalt},
+		nil, nil, nil, "m", http.Header{}, nil,
+	)
+	req := adapter.buildInitialRequest()
+	cont := adapter.applyToolOutputs(req, map[string]any{"role": "assistant"}, []toolOutput{{callID: "c1", output: "x"}})
+	if got, _ := cont["cache_salt"].(string); got != testSalt {
+		t.Errorf("chat continuation cache_salt = %q, want %q", got, testSalt)
+	}
+}
+
+func TestResponsesLoopContinuationKeepsCacheSalt(t *testing.T) {
+	adapter := newResponsesLoopAdapter(
+		map[string]any{"model": "m", "input": []any{}, "cache_salt": testSalt},
+		nil, nil, nil, nil,
+	)
+	adapter.buildInitialRequest() // sets a.base, which continuations clone
+	cont := adapter.applyToolOutputs(nil, []any{}, []toolOutput{{callID: "c1", output: "x"}})
+	if got, _ := cont["cache_salt"].(string); got != testSalt {
+		t.Errorf("responses continuation cache_salt = %q, want %q", got, testSalt)
+	}
+}
+
+func TestChatStreamRequestKeepsCacheSalt(t *testing.T) {
+	req, _ := buildChatStreamRequest(
+		map[string]any{"model": "m", "messages": []any{}, "cache_salt": testSalt}, nil, nil)
+	if got, _ := req["cache_salt"].(string); got != testSalt {
+		t.Errorf("chat stream request cache_salt = %q, want %q", got, testSalt)
+	}
+	if req["stream"] != true {
+		t.Error("chat stream request not marked streaming")
+	}
+}
+
+func TestResponsesStreamRequestKeepsCacheSalt(t *testing.T) {
+	req, _ := buildResponsesStreamRequest(
+		map[string]any{"model": "m", "input": []any{}, "cache_salt": testSalt}, nil, nil)
+	if got, _ := req["cache_salt"].(string); got != testSalt {
+		t.Errorf("responses stream request cache_salt = %q, want %q", got, testSalt)
+	}
+	if req["stream"] != true {
+		t.Error("responses stream request not marked streaming")
+	}
+}

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -851,24 +851,13 @@ func (b *chatToolCallBuilder) raw() []any {
 // SDKs that do not want SSE back.
 
 // buildChatStreamRequest builds the upstream /v1/chat/completions request for
-// the streaming path, mirroring chatLoopAdapter.buildInitialRequest. It clones
-// body (preserving router-injected fields such as cache_salt), strips
-// router-only fields, forces streaming, and merges tools/prompt. It returns
-// the request body and the auto-continue tool set stripped from it.
+// the streaming path. It shares its body construction with the non-streaming
+// loop via buildChatUpstreamRequest, then forces streaming with usage
+// reporting.
 func buildChatStreamRequest(body map[string]any, tools []*mcp.Tool, prompt *mcp.GetPromptResult) (map[string]any, map[string]struct{}) {
-	reqBody := cloneJSONMap(body)
-	delete(reqBody, "web_search_options")
-	delete(reqBody, "code_execution_options")
-	delete(reqBody, "filters")
-	delete(reqBody, "pii_check_options")
-	delete(reqBody, "prompt_injection_check_options")
-	stripRouterOwnedIncludes(reqBody)
+	reqBody, autoContinueTools := buildChatUpstreamRequest(body, tools, prompt)
 	reqBody["stream"] = true
 	reqBody["stream_options"] = map[string]any{"include_usage": true}
-	applyParallelToolCallsPolicy(reqBody)
-	autoContinueTools := extractAndStripAutoContinueChatTools(reqBody["tools"])
-	reqBody["tools"] = append(existingTools(reqBody["tools"]), chatTools(tools)...)
-	reqBody["messages"] = prependChatPrompt(prompt, reqBody["messages"])
 	return reqBody, autoContinueTools
 }
 

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -849,6 +849,29 @@ func (b *chatToolCallBuilder) raw() []any {
 // The function assumes isStream(body) is already true. Non-streaming callers
 // continue to go through runChatLoop so existing behavior is preserved for
 // SDKs that do not want SSE back.
+
+// buildChatStreamRequest builds the upstream /v1/chat/completions request for
+// the streaming path, mirroring chatLoopAdapter.buildInitialRequest. It clones
+// body (preserving router-injected fields such as cache_salt), strips
+// router-only fields, forces streaming, and merges tools/prompt. It returns
+// the request body and the auto-continue tool set stripped from it.
+func buildChatStreamRequest(body map[string]any, tools []*mcp.Tool, prompt *mcp.GetPromptResult) (map[string]any, map[string]struct{}) {
+	reqBody := cloneJSONMap(body)
+	delete(reqBody, "web_search_options")
+	delete(reqBody, "code_execution_options")
+	delete(reqBody, "filters")
+	delete(reqBody, "pii_check_options")
+	delete(reqBody, "prompt_injection_check_options")
+	stripRouterOwnedIncludes(reqBody)
+	reqBody["stream"] = true
+	reqBody["stream_options"] = map[string]any{"include_usage": true}
+	applyParallelToolCallsPolicy(reqBody)
+	autoContinueTools := extractAndStripAutoContinueChatTools(reqBody["tools"])
+	reqBody["tools"] = append(existingTools(reqBody["tools"]), chatTools(tools)...)
+	reqBody["messages"] = prependChatPrompt(prompt, reqBody["messages"])
+	return reqBody, autoContinueTools
+}
+
 func runChatStreaming(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -872,19 +895,7 @@ func runChatStreaming(
 	tools := registry.allTools()
 	ownedTools := registry.ownedTools()
 	toolSchemas := schemaLookup(tools)
-	reqBody := cloneJSONMap(body)
-	delete(reqBody, "web_search_options")
-	delete(reqBody, "code_execution_options")
-	delete(reqBody, "filters")
-	delete(reqBody, "pii_check_options")
-	delete(reqBody, "prompt_injection_check_options")
-	stripRouterOwnedIncludes(reqBody)
-	reqBody["stream"] = true
-	reqBody["stream_options"] = map[string]any{"include_usage": true}
-	applyParallelToolCallsPolicy(reqBody)
-	autoContinueTools := extractAndStripAutoContinueChatTools(reqBody["tools"])
-	reqBody["tools"] = append(existingTools(reqBody["tools"]), chatTools(tools)...)
-	reqBody["messages"] = prependChatPrompt(prompt, reqBody["messages"])
+	reqBody, autoContinueTools := buildChatStreamRequest(body, tools, prompt)
 
 	usageMetricsRequested := r.Header.Get(manager.UsageMetricsRequestHeader) == "true"
 	clientRequestedUsage := r.Header.Get("X-Tinfoil-Client-Requested-Usage") == "true"

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -876,6 +876,26 @@ func (s *responsesStreamer) totalsBillingUsage() map[string]any {
 // progress envelopes and a terminal response.output_item.done. No
 // tinfoil-specific channel rides on this route -- the Responses stream
 // is always fully OpenAI-spec-conformant.
+
+// buildResponsesStreamRequest builds the upstream /v1/responses request for
+// the streaming path, mirroring responsesLoopAdapter.buildInitialRequest. It
+// clones body (preserving router-injected fields such as cache_salt), strips
+// router-only fields, forces streaming, and merges tools/prompt. It returns
+// the request body and the auto-continue tool set stripped from it.
+func buildResponsesStreamRequest(body map[string]any, tools []*mcp.Tool, prompt *mcp.GetPromptResult) (map[string]any, map[string]struct{}) {
+	base := cloneJSONMap(body)
+	delete(base, "pii_check_options")
+	delete(base, "prompt_injection_check_options")
+	stripRouterOwnedIncludes(base)
+	base["stream"] = true
+	applyParallelToolCallsPolicy(base)
+	autoContinueTools := extractAndStripAutoContinueResponsesTools(base["tools"])
+	base["tools"] = replaceRouterOwnedResponsesTools(base["tools"], responseTools(tools))
+	base["input"] = prependResponsesPrompt(prompt, base["input"])
+	base["input"] = stripClientSyntheticResponseItems(base["input"])
+	return base, autoContinueTools
+}
+
 func runResponsesStreaming(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -898,16 +918,7 @@ func runResponsesStreaming(
 	tools := registry.allTools()
 	ownedTools := registry.ownedTools()
 	toolSchemas := schemaLookup(tools)
-	base := cloneJSONMap(body)
-	delete(base, "pii_check_options")
-	delete(base, "prompt_injection_check_options")
-	stripRouterOwnedIncludes(base)
-	base["stream"] = true
-	applyParallelToolCallsPolicy(base)
-	autoContinueTools := extractAndStripAutoContinueResponsesTools(base["tools"])
-	base["tools"] = replaceRouterOwnedResponsesTools(base["tools"], responseTools(tools))
-	base["input"] = prependResponsesPrompt(prompt, base["input"])
-	base["input"] = stripClientSyntheticResponseItems(base["input"])
+	base, autoContinueTools := buildResponsesStreamRequest(body, tools, prompt)
 
 	usageMetricsRequested := r.Header.Get(manager.UsageMetricsRequestHeader) == "true"
 

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -354,8 +354,16 @@ func (a *chatLoopAdapter) attachCitations(body map[string]any, state *citations.
 	attachChatOutput(body, state, toolCalls, eventFlags)
 }
 
-func (a *chatLoopAdapter) buildInitialRequest() map[string]any {
-	reqBody := cloneJSONMap(a.body)
+// buildChatUpstreamRequest builds the upstream /v1/chat/completions request
+// body shared by the non-streaming tool loop and the streaming path. It clones
+// body (preserving router-injected fields such as cache_salt), strips
+// router-only fields, applies the parallel-tool-calls policy, merges the
+// tools and prompt, and returns the request plus the auto-continue tool set
+// stripped from it. Callers set the stream flag (and stream_options) for their
+// mode; the shared body is otherwise identical, so keeping it in one place
+// stops the two paths from drifting.
+func buildChatUpstreamRequest(body map[string]any, tools []*mcp.Tool, prompt *mcp.GetPromptResult) (map[string]any, map[string]struct{}) {
+	reqBody := cloneJSONMap(body)
 	delete(reqBody, "web_search_options")
 	delete(reqBody, "code_execution_options")
 	delete(reqBody, "filters")
@@ -363,11 +371,17 @@ func (a *chatLoopAdapter) buildInitialRequest() map[string]any {
 	delete(reqBody, "pii_check_options")
 	delete(reqBody, "prompt_injection_check_options")
 	stripRouterOwnedIncludes(reqBody)
-	reqBody["stream"] = false
 	applyParallelToolCallsPolicy(reqBody)
-	a.autoContinueTools = extractAndStripAutoContinueChatTools(reqBody["tools"])
-	reqBody["tools"] = append(existingTools(reqBody["tools"]), chatTools(a.tools)...)
-	reqBody["messages"] = prependChatPrompt(a.prompt, reqBody["messages"])
+	autoContinueTools := extractAndStripAutoContinueChatTools(reqBody["tools"])
+	reqBody["tools"] = append(existingTools(reqBody["tools"]), chatTools(tools)...)
+	reqBody["messages"] = prependChatPrompt(prompt, reqBody["messages"])
+	return reqBody, autoContinueTools
+}
+
+func (a *chatLoopAdapter) buildInitialRequest() map[string]any {
+	reqBody, autoContinueTools := buildChatUpstreamRequest(a.body, a.tools, a.prompt)
+	reqBody["stream"] = false
+	a.autoContinueTools = autoContinueTools
 
 	if debugEnabled {
 		ownedNames := make([]string, 0, len(a.ownedTools))


### PR DESCRIPTION
Stacked on #386 (the `cachesalt` package). Review/merge that first; this PR's base is `cachesalt-hash-helper` so the diff shows only Phase 1.

## What

Wires `cachesalt` into the request path so vLLM's prefix cache is partitioned per principal — closing the cross-user cache-probing timing side channel. Gated behind `CACHE_SALT_ENABLED` / `--cache-salt`, **default off** (the emergency lever, per the plan's asymmetric-kill-switch rule).

## How

- **`applyCacheSalt(body, path, apiKey, enabled)`** owns both fields: always strips a client-supplied `cache_salt` and pops the router-only `user_cache_secret` (never sent to the engine); when enabled + endpoint on the allowlist + identity non-empty, injects `Derive(rateLimitIdentity(apiKey), secret)`. Identity anchoring lives *inside* the helper, so no call site can wire the raw (rotating) bearer token. Non-empty `user_cache_secret` → per-user namespace within the tenant; empty/`null`/non-string → tenant salt.
- **Allowlist:** `/v1/chat/completions`, `/v1/completions`, `/v1/responses`. Embeddings/audio/convert excluded (no `cache_salt` in those engines).
- **Metric:** `router_cache_salt_injections_total{model, mode}` (`mode` ∈ `tenant`,`user`); a skipped injection emits no sample.

## Why it touches two routing paths

The router has two disjoint request paths: **path-routed** (model in body, via `inference.tinfoil.sh`) and **subdomain-routed** (`<model>.<domain>` from `X-Forwarded-Host`, otherwise proxied verbatim). An adversarial review caught that handling only the path-routed branch leaves the strip **bypassable by POSTing to the model subdomain** — a client-chosen `cache_salt` would ride raw to a chat engine. So subdomain-routed requests now go through `saltProxiedBody` (read → apply → re-marshal; byte-preserving when nothing changes; only allowlisted JSON endpoints). Non-chat subdomain endpoints still proxy verbatim — they target engines with no prefix-cache `cache_salt` concept, so the side channel doesn't exist there.

## Salt survives the tool loop

The tool-runtime loop replays a growing prefix upstream every iteration — the best case for prefix caching — so the salt must ride every request it builds. The two streaming request builders are extracted (`buildChatStreamRequest` / `buildResponsesStreamRequest`, behavior-preserving) so the passthrough is unit-testable alongside the non-streaming initial and continuation builders.

## Tests (mutation-verified)

Every new test was checked to actually bite by re-running the exact mutations an adversarial review found had survived the first cut:
- dropping `delete(body, "cache_salt")` → strip tests fail
- streaming builder dropping the salt → `Test{Chat,Responses}StreamRequestKeepsCacheSalt` fail
- 2nd+ continuation dropping the salt → `Test{Chat,Responses}LoopContinuationKeepsCacheSalt` fail
- anchoring on the raw token instead of the JWT subject → `TestApplyCacheSaltAnchorsToJWTSubject` fails

Also covers: unconditional stripping (flag off / non-allowlisted / empty identity), allowlist exact-match, opaque-key fallback, `saltProxiedBody` incl. byte-preserving no-op and non-JSON passthrough.

## Notes for reviewers

- Includes a one-line doc-comment softening in `cachesalt/cachesalt.go` (opaque-key fallback wording) surfaced by this review; it stacks onto #386.
- `go.mod`/`go.sum`: one transitive indirect dep (`kylelemons/godebug`) pulled in by `prometheus/.../testutil` used in a metric test.
- **Not addressed here (pre-existing, separate concern):** the subdomain path also bypasses `delete(body,"priority")` and rate limiting. That's QoS, not the cross-tenant side channel, and out of scope for Phase 1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects a per‑principal `cache_salt` to partition the engine prefix cache and block cross‑user timing probes. Behind `CACHE_SALT_ENABLED`/`--cache-salt`, default off.

- **New Features**
  - Router owns salt fields: strips client `cache_salt` and never forwards `user_cache_secret`. When enabled on `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, injects a derived salt anchored to the caller (JWT subject or opaque API key). Non‑empty secret → per‑user; otherwise tenant‑wide.
  - Works on both routing modes (path‑routed and model subdomain). Subdomain JSON bodies are read, salted, and re‑marshaled; preserves int64 precision via `json.Decoder.UseNumber`; unchanged bodies stay byte‑identical. Non‑JSON, JSON null, or non‑allowlisted endpoints pass through.
  - Salt persists through the tool loop and streaming. `buildChatStreamRequest` and `buildResponsesStreamRequest` clone the salted body so it stays in initial, continuation, and stream requests.
  - Adds Prometheus metric `router_cache_salt_injections_total{model,mode}` with `mode` in `tenant|user`; no sample when injection is skipped.

- **Refactors**
  - Introduced `buildChatUpstreamRequest` shared by the chat loop and streaming to stop drift; `buildChatStreamRequest` delegates to it. Responses keep their dedicated builder.

<sup>Written for commit 8006f82b580d4f68c35c674e14c1aa21196d5414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

