### PR TITLE
Stop cutting off long model responses after ten minutes

### DIFF
--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 
 	tinfoilClient "github.com/tinfoilsh/tinfoil-go/verifier/client"
 )
@@ -22,8 +21,12 @@ func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *ht
 		return "", nil, fmt.Errorf("model %s has no available enclave", modelName)
 	}
 
+	// No client-level Timeout: it would cover the entire exchange including
+	// reading the streamed response body, hard-killing long-running reasoning
+	// streams mid-flight. Requests are bounded by the caller's context (the
+	// incoming client request), matching the passive behavior of the public
+	// reverse proxy path.
 	client := &http.Client{
-		Timeout: 10 * time.Minute,
 		Transport: &slowHeaderTripper{
 			base: &tinfoilClient.TLSBoundRoundTripper{
 				ExpectedPublicKey: enclave.tlsKeyFP,
@@ -71,7 +74,7 @@ func (em *EnclaveManager) MCPServerEndpoint(modelName string) (string, *http.Cli
 	// by underscores; see localMCPEndpointEnvVar.
 	if em.debug {
 		if endpoint := os.Getenv(localMCPEndpointEnvVar(modelName)); endpoint != "" {
-			return endpoint, &http.Client{Timeout: 10 * time.Minute}, nil
+			return endpoint, &http.Client{}, nil
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stopped cutting off long model responses by removing the 10-minute HTTP client timeout; long streams now rely on the caller’s context and match the public reverse proxy behavior.

- **Bug Fixes**
  - Use `http.Client` without a client-level timeout in `boundHTTPClientForModel` and debug `MCPServerEndpoint`.
  - Streams are governed by the incoming request context, preventing mid-response termination.

<sup>Written for commit e6698b85254b1d4351cd16615b7bae25b4e9459a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

