### PR TITLE
chore: remove deepseek-v4-pro

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -44,11 +44,6 @@ models:
       - glm-5-2-inf7.tinfoil.containers.tinfoil.dev
       - glm-5-2-inf11.tinfoil.containers.tinfoil.dev
 
-  deepseek-v4-pro:
-    repo: tinfoilsh/confidential-deepseek-v4-pro
-    enclaves:
-      - deepseek-v4-pro-inf12.tinfoil.containers.tinfoil.dev
-
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
     enclaves:


### PR DESCRIPTION
Removed deepseek-v4-pro configuration from config.yml.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `deepseek-v4-pro` from config.yml to retire the model and prevent any traffic or deployments targeting its enclave.

<sup>Written for commit 9133b79d0b22ba6f35c72b39b10c1aa34081ab9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

