### PR TITLE
chore: add new glm-5-2 replica

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -43,6 +43,7 @@ models:
     enclaves:
       - glm-5-2-inf7.tinfoil.containers.tinfoil.dev
       - glm-5-2-inf11.tinfoil.containers.tinfoil.dev
+      - glm-5-2-inf12.tinfoil.containers.tinfoil.dev
 
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a new `glm-5-2` enclave replica to increase capacity and resilience. The config now includes `glm-5-2-inf12.tinfoil.containers.tinfoil.dev` in the `enclaves` list.

<sup>Written for commit 5e0b177a222613a78730fe9e57afbd359f50bd83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

