### PR TITLE
Enable cache_salt injection on all routers (Option A: attested manifest)

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -10,6 +10,7 @@ containers:
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"
+      - CACHE_SALT_ENABLED: "true"
       - USAGE_REPORTER_ID: "model-router"
       - CONTROL_PLANE_URL: "https://api.tinfoil.sh"
     secrets:


### PR DESCRIPTION
Turns on per-principal prefix-cache salting **fleet-wide** by setting `CACHE_SALT_ENABLED=true` in the attested `tinfoil-config.yml`. Both routers (`inference.tinfoil.sh`, `router.inf6.tinfoil.sh`) deploy from this manifest, so both flip on together at the next release.

## The one-line change

```yaml
     env:
       - DOMAIN
       - REFRESH_INTERVAL: "1m"
+      - CACHE_SALT_ENABLED: "true"
       - USAGE_REPORTER_ID: "model-router"
       - CONTROL_PLANE_URL: "https://api.tinfoil.sh"
```

## What this does / doesn't do

- The injection code already shipped **flag-off** (the strip/inject path from the Phase 1 work is live in prod today, doing nothing but stripping client-supplied `cache_salt`/`user_cache_secret`). This flips the behavior on.
- **Merging this PR is inert.** `tinfoil-release.yml` is `workflow_dispatch` (manual, requires a version input) — it does not run on push. Salting goes live only when the release is cut and the CVMs redeploy to the new attested measurement. So this is safe to review/merge independently of when you flip prod.
- Baking it into the manifest (rather than a runtime env) means the salting behavior is part of the **verifiable measurement** — clients can attest that the deployed router salts.

## Rollback

Revert this line and cut a new release. Note it's asymmetric-safe: even flag-off, the router still *strips* any client-supplied `cache_salt`/`user_cache_secret`, so a rollback only restores cross-user cache sharing — it never reopens client-chosen namespaces. (If you want sub-minute rollback instead of a revert-release, that's the runtime-env variant — Option B — not this PR.)

## Validating the rollout after you cut the release

Full plan captured separately; the short version:
- **First minutes:** `sum by (model_name,mode)(rate(router_cache_salt_injections_total[5m]))` nonzero for all 7 chat models (`mode=tenant`; `user` ~0 until Phase 2); 4xx/5xx flat.
- **~1h:** isolation canary on a single-replica model (`deepseek-v4-pro`) — two distinct API keys, identical prompt → 2nd key must prefill **cold**, same key repeating still **warm**. Watch TTFT P95/P99 on **glm-5-2** (88% baseline sharing) and **gemma4-31b** (P99 already ~66s vs a customer's 30s timeout).
- **24h–7d:** re-run the baseline queries; per-model hit-rate drop = the cross-principal sharing now closed.

Baseline for comparison was captured 2026-07-07 (flag-off).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable per-principal prefix-cache salting across all routers by setting CACHE_SALT_ENABLED="true" in the attested `tinfoil-config.yml`. This closes cross-principal cache sharing while continuing to strip client-supplied `cache_salt`/`user_cache_secret`.

- **Migration**
  - Goes live only on the next manual release; merging is inert.
  - Roll back by removing the env var and cutting a new release.
  - Attested manifest makes salting part of the verifiable measurement.

<sup>Written for commit 855547165c4c2b52ef6ace718d9280044031f205. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

