### PR TITLE
Add trip/clear hysteresis to the backend overload flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,8 +34,10 @@ type Model struct {
 // is flagged overloaded. ClearRequestsWaiting is the hysteresis clear mark:
 // the flag clears only once the queue drains back down to it, so a backend
 // hovering around the trip mark doesn't flap in and out of overload on every
-// poll. Queue depths are integral, so setting the clear mark to
-// MaxRequestsWaiting-1 disables hysteresis.
+// poll. Zero deliberately means omitted (the default of half the trip mark
+// applies), so the smallest expressible clear mark is 1 — clear once at most
+// one request is waiting. Queue depths are integral, so setting the clear
+// mark to MaxRequestsWaiting-1 disables hysteresis.
 type OverloadConfig struct {
 	MaxRequestsWaiting   int `yaml:"max_requests_waiting"`
 	ClearRequestsWaiting int `yaml:"clear_requests_waiting,omitempty"`
@@ -43,9 +45,9 @@ type OverloadConfig struct {
 }
 
 // Marks returns the overload trip and clear thresholds. When
-// ClearRequestsWaiting is unset or out of range (it must sit below the trip
-// mark), the clear mark defaults to half the trip mark. Only meaningful when
-// MaxRequestsWaiting is positive.
+// ClearRequestsWaiting is zero (omitted) or out of range (it must sit below
+// the trip mark), the clear mark defaults to half the trip mark. Only
+// meaningful when MaxRequestsWaiting is positive.
 func (c *OverloadConfig) Marks() (trip, clear int) {
 	trip = c.MaxRequestsWaiting
 	clear = c.ClearRequestsWaiting

--- a/config/config.go
+++ b/config/config.go
@@ -29,9 +29,30 @@ type Model struct {
 }
 
 // OverloadConfig describes optional overload thresholds for a model.
+//
+// MaxRequestsWaiting is the trip mark: a backend whose queue depth reaches it
+// is flagged overloaded. ClearRequestsWaiting is the hysteresis clear mark:
+// the flag clears only once the queue drains back down to it, so a backend
+// hovering around the trip mark doesn't flap in and out of overload on every
+// poll. Queue depths are integral, so setting the clear mark to
+// MaxRequestsWaiting-1 disables hysteresis.
 type OverloadConfig struct {
-	MaxRequestsWaiting int `yaml:"max_requests_waiting"`
-	RetryAfterMinutes  int `yaml:"retry_after_minutes"`
+	MaxRequestsWaiting   int `yaml:"max_requests_waiting"`
+	ClearRequestsWaiting int `yaml:"clear_requests_waiting,omitempty"`
+	RetryAfterMinutes    int `yaml:"retry_after_minutes"`
+}
+
+// Marks returns the overload trip and clear thresholds. When
+// ClearRequestsWaiting is unset or out of range (it must sit below the trip
+// mark), the clear mark defaults to half the trip mark. Only meaningful when
+// MaxRequestsWaiting is positive.
+func (c *OverloadConfig) Marks() (trip, clear int) {
+	trip = c.MaxRequestsWaiting
+	clear = c.ClearRequestsWaiting
+	if clear <= 0 || clear >= trip {
+		clear = trip / 2
+	}
+	return trip, clear
 }
 
 // Config represents the configuration structure matching config.yml

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,53 @@
+package config
+
+import "testing"
+
+func TestOverloadConfigMarks(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       OverloadConfig
+		wantTrip  int
+		wantClear int
+	}{
+		{"unset clear defaults to half", OverloadConfig{MaxRequestsWaiting: 16}, 16, 8},
+		{"odd trip rounds down", OverloadConfig{MaxRequestsWaiting: 9}, 9, 4},
+		{"explicit clear honored", OverloadConfig{MaxRequestsWaiting: 16, ClearRequestsWaiting: 12}, 16, 12},
+		{"clear of trip-1 disables hysteresis", OverloadConfig{MaxRequestsWaiting: 16, ClearRequestsWaiting: 15}, 16, 15},
+		{"clear at trip falls back to default", OverloadConfig{MaxRequestsWaiting: 16, ClearRequestsWaiting: 16}, 16, 8},
+		{"clear above trip falls back to default", OverloadConfig{MaxRequestsWaiting: 16, ClearRequestsWaiting: 20}, 16, 8},
+		{"negative clear falls back to default", OverloadConfig{MaxRequestsWaiting: 16, ClearRequestsWaiting: -1}, 16, 8},
+		{"trip of one clears only when empty", OverloadConfig{MaxRequestsWaiting: 1}, 1, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trip, clear := tt.cfg.Marks()
+			if trip != tt.wantTrip || clear != tt.wantClear {
+				t.Fatalf("Marks() = (%d, %d), want (%d, %d)", trip, clear, tt.wantTrip, tt.wantClear)
+			}
+		})
+	}
+}
+
+func TestOverloadConfigParsesClearMark(t *testing.T) {
+	cfg, err := FromBytes([]byte(`
+models:
+  test-model:
+    repo: tinfoilsh/test
+    enclaves:
+      - test.example.com
+    overload:
+      max_requests_waiting: 16
+      clear_requests_waiting: 12
+      retry_after_minutes: 1
+`))
+	if err != nil {
+		t.Fatalf("FromBytes: %v", err)
+	}
+	overload := cfg.Models["test-model"].Overload
+	if overload == nil {
+		t.Fatal("overload config not parsed")
+	}
+	if overload.MaxRequestsWaiting != 16 || overload.ClearRequestsWaiting != 12 || overload.RetryAfterMinutes != 1 {
+		t.Fatalf("parsed overload = %+v", overload)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -719,12 +719,20 @@ func main() {
 				secs = 60
 			}
 			w.Header().Set("Retry-After", strconv.Itoa(secs))
-			log.WithFields(log.Fields{
+			fields := log.Fields{
 				"model":               modelName,
 				"enclave":             enclave.String(),
 				"requests_waiting":    waiting,
 				"retry_after_seconds": secs,
-			}).Warn("rejecting request due to backend overload")
+			}
+			// With hysteresis, requests_waiting can sit below the trip mark
+			// while the queue drains; log the marks so an in-band reject
+			// doesn't read as a contradiction.
+			if trip, clear, ok := enclave.OverloadMarks(); ok {
+				fields["max_requests_waiting"] = trip
+				fields["clear_requests_waiting"] = clear
+			}
+			log.WithFields(fields).Warn("rejecting request due to backend overload")
 
 			// Record rejection metrics
 			manager.RequestsRejectedTotal.WithLabelValues(modelName).Inc()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -676,3 +676,17 @@ func (e *Enclave) ShouldReject() (bool, time.Duration, float64) {
 	}
 	return e.metrics.shouldReject()
 }
+
+// OverloadMarks returns the resolved overload trip and clear marks for this
+// enclave, or ok=false when no usable overload thresholds are configured.
+func (e *Enclave) OverloadMarks() (trip, clear int, ok bool) {
+	if e == nil || e.metrics == nil {
+		return 0, 0, false
+	}
+	cfg := e.metrics.currentConfig()
+	if cfg == nil || cfg.MaxRequestsWaiting <= 0 {
+		return 0, 0, false
+	}
+	trip, clear = cfg.Marks()
+	return trip, clear, true
+}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/tinfoilsh/confidential-model-router/config"
 )
 
 func newTestEnclave(host string) *Enclave {
@@ -67,6 +69,28 @@ func TestNextEnclave_EmptyModel(t *testing.T) {
 	m := &Model{Enclaves: map[string]*Enclave{}}
 	if got := m.NextEnclave(nil); got != nil {
 		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestOverloadMarks(t *testing.T) {
+	var nilEnclave *Enclave
+	if _, _, ok := nilEnclave.OverloadMarks(); ok {
+		t.Fatal("expected ok=false for nil enclave")
+	}
+
+	e := newTestEnclave("marks-host")
+	if _, _, ok := e.OverloadMarks(); ok {
+		t.Fatal("expected ok=false without overload config")
+	}
+
+	e.metrics = newTestMetrics("marks-host", &config.OverloadConfig{MaxRequestsWaiting: 16, ClearRequestsWaiting: 12})
+	if trip, clear, ok := e.OverloadMarks(); !ok || trip != 16 || clear != 12 {
+		t.Fatalf("OverloadMarks() = (%d, %d, %v), want (16, 12, true)", trip, clear, ok)
+	}
+
+	e.metrics = newTestMetrics("marks-host", &config.OverloadConfig{MaxRequestsWaiting: 0})
+	if _, _, ok := e.OverloadMarks(); ok {
+		t.Fatal("expected ok=false with non-positive trip mark")
 	}
 }
 

--- a/manager/metrics.go
+++ b/manager/metrics.go
@@ -92,6 +92,17 @@ func (m *enclaveMetrics) setConfig(cfg *config.OverloadConfig) {
 		}).Warn("clear_requests_waiting out of range, using default")
 	}
 
+	// The flag may have been computed under the previous marks. If a fresh
+	// sample exists, re-evaluate it against the new marks now — before the
+	// poll goroutine starts, so there is no concurrent writer — rather than
+	// leaving the old decision driving shouldReject until the first scrape
+	// lands (which can take a while if the backend is unreachable). For an
+	// unchanged config the evaluation is a fixed point, so the per-sync
+	// config reinstall does not disturb hysteresis state.
+	if waiting, collected := m.latestSample(); !collected.IsZero() && time.Since(collected) <= sampleStalenessLimit {
+		m.evaluateThresholds(waiting)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
 	m.wg.Add(1)

--- a/manager/metrics.go
+++ b/manager/metrics.go
@@ -49,7 +49,8 @@ func newEnclaveMetrics(host, model string) *enclaveMetrics {
 	}
 }
 
-// setConfig starts or stops polling based on whether overload settings are provided.
+// setConfig starts or stops polling based on whether usable overload
+// thresholds are provided.
 func (m *enclaveMetrics) setConfig(cfg *config.OverloadConfig) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -64,7 +65,11 @@ func (m *enclaveMetrics) setConfig(cfg *config.OverloadConfig) {
 	m.cfg = cfg
 	m.cfgMu.Unlock()
 
-	if cfg == nil {
+	// A missing block and a non-positive trip mark both mean "no overload
+	// evaluation". The reset must cover both: leaving a previously tripped
+	// flag in place with evaluation stopped would de-prefer the enclave in
+	// NextEnclave forever.
+	if cfg == nil || cfg.MaxRequestsWaiting <= 0 {
 		m.overloaded.Store(false)
 		m.updateLatest(0, time.Time{})
 		BackendQueueDepth.WithLabelValues(m.model, m.host).Set(0)
@@ -72,18 +77,30 @@ func (m *enclaveMetrics) setConfig(cfg *config.OverloadConfig) {
 		log.WithFields(log.Fields{
 			"model":   m.model,
 			"enclave": m.host,
-		}).Debug("metrics polling disabled (no overload config)")
+		}).Debug("metrics polling disabled (no overload threshold)")
 		return
+	}
+
+	trip, clear := cfg.Marks()
+	if cfg.ClearRequestsWaiting != 0 && cfg.ClearRequestsWaiting != clear {
+		log.WithFields(log.Fields{
+			"model":                m.model,
+			"enclave":              m.host,
+			"configured_clear":     cfg.ClearRequestsWaiting,
+			"resolved_clear":       clear,
+			"max_requests_waiting": trip,
+		}).Warn("clear_requests_waiting out of range, using default")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
 	m.wg.Add(1)
 	log.WithFields(log.Fields{
-		"model":                m.model,
-		"enclave":              m.host,
-		"max_requests_waiting": cfg.MaxRequestsWaiting,
-		"retry_after_minutes":  cfg.RetryAfterMinutes,
+		"model":                  m.model,
+		"enclave":                m.host,
+		"max_requests_waiting":   trip,
+		"clear_requests_waiting": clear,
+		"retry_after_minutes":    cfg.RetryAfterMinutes,
 	}).Info("starting vLLM metrics polling")
 	go m.run(ctx, defaultMetricsPollInterval)
 }
@@ -144,9 +161,8 @@ func (m *enclaveMetrics) scrape(ctx context.Context) {
 
 	BackendQueueDepth.WithLabelValues(m.model, m.host).Set(waiting)
 
-	now := time.Now()
-	m.updateLatest(waiting, now)
-	m.evaluateThresholds(waiting, now)
+	m.updateLatest(waiting, time.Now())
+	m.evaluateThresholds(waiting)
 }
 
 func (m *enclaveMetrics) shutdown() {
@@ -208,40 +224,66 @@ func (m *enclaveMetrics) latestSample() (float64, time.Time) {
 
 const sampleStalenessLimit = 3 * defaultMetricsPollInterval
 
-func (m *enclaveMetrics) evaluateThresholds(waiting float64, collectedAt time.Time) {
+// evaluateThresholds updates the overload flag from the latest queue depth
+// with hysteresis: trip at the high mark, clear at the lower mark, hold the
+// previous state in between. Without the band, a queue hovering at a single
+// threshold would flap the flag on every poll — and with it the spill and
+// reject decisions that read the flag.
+func (m *enclaveMetrics) evaluateThresholds(waiting float64) {
 	cfg := m.currentConfig()
 	if cfg == nil || cfg.MaxRequestsWaiting <= 0 {
 		return
 	}
 
-	threshold := float64(cfg.MaxRequestsWaiting)
-	if waiting >= threshold {
-		if !m.overloaded.Load() {
-			log.WithFields(log.Fields{
-				"model":                m.model,
-				"enclave":              m.host,
-				"requests_waiting":     waiting,
-				"max_requests_waiting": cfg.MaxRequestsWaiting,
-				"retry_after_minutes":  cfg.RetryAfterMinutes,
-			}).Warn("overload threshold exceeded")
-			OverloadEventsTotal.WithLabelValues(m.model, m.host).Inc()
-		}
-		m.overloaded.Store(true)
+	trip, clear := cfg.Marks()
+	wasOverloaded := m.overloaded.Load()
+	overloaded := wasOverloaded
+	switch {
+	case waiting >= float64(trip):
+		overloaded = true
+	case waiting <= float64(clear):
+		overloaded = false
+	}
+
+	// The two message strings below predate hysteresis and are load-bearing:
+	// external log-based alerts may key on them, so keep them stable and
+	// evolve the structured fields instead.
+	switch {
+	case overloaded && !wasOverloaded:
+		log.WithFields(log.Fields{
+			"model":                  m.model,
+			"enclave":                m.host,
+			"requests_waiting":       waiting,
+			"max_requests_waiting":   trip,
+			"clear_requests_waiting": clear,
+			"retry_after_minutes":    cfg.RetryAfterMinutes,
+		}).Warn("overload threshold exceeded")
+		OverloadEventsTotal.WithLabelValues(m.model, m.host).Inc()
+	case !overloaded && wasOverloaded:
+		log.WithFields(log.Fields{
+			"model":                  m.model,
+			"enclave":                m.host,
+			"requests_waiting":       waiting,
+			"clear_requests_waiting": clear,
+		}).Info("queue depth back below overload threshold")
+		RecoveryEventsTotal.WithLabelValues(m.model, m.host).Inc()
+	}
+
+	m.overloaded.Store(overloaded)
+	if overloaded {
 		BackendOverloaded.WithLabelValues(m.model, m.host).Set(1)
 	} else {
-		if m.overloaded.Load() {
-			log.WithFields(log.Fields{
-				"model":            m.model,
-				"enclave":          m.host,
-				"requests_waiting": waiting,
-			}).Info("queue depth back below overload threshold")
-			RecoveryEventsTotal.WithLabelValues(m.model, m.host).Inc()
-		}
-		m.overloaded.Store(false)
 		BackendOverloaded.WithLabelValues(m.model, m.host).Set(0)
 	}
 }
 
+// shouldReject reports whether new requests to this enclave should be
+// rejected, along with the Retry-After hint and the latest queue depth. It
+// reads the hysteretic overload flag maintained by evaluateThresholds — the
+// same state NextEnclave's preference uses — rather than re-deriving a
+// single-threshold answer, so a tripped backend keeps shedding load until
+// its queue has genuinely drained to the clear mark. A missing or stale
+// sample fails open.
 func (m *enclaveMetrics) shouldReject() (bool, time.Duration, float64) {
 	cfg := m.currentConfig()
 	if cfg == nil || cfg.MaxRequestsWaiting <= 0 {
@@ -261,7 +303,7 @@ func (m *enclaveMetrics) shouldReject() (bool, time.Duration, float64) {
 		return false, 0, waiting
 	}
 
-	if waiting < float64(cfg.MaxRequestsWaiting) {
+	if !m.overloaded.Load() {
 		return false, 0, waiting
 	}
 

--- a/manager/metrics_test.go
+++ b/manager/metrics_test.go
@@ -219,6 +219,48 @@ func TestOverloadTransitionLogMessagesStable(t *testing.T) {
 	}
 }
 
+// TestSetConfig_ReevaluatesFlagAgainstNewMarks pins that a threshold change
+// takes effect at setConfig time, not at the next successful scrape: the
+// server 404s every scrape, so only the synchronous re-evaluation inside
+// setConfig can move the flag.
+func TestSetConfig_ReevaluatesFlagAgainstNewMarks(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	m := newEnclaveMetrics(strings.TrimPrefix(ts.URL, "https://"), "test-model")
+	m.client = ts.Client()
+	m.cfgMu.Lock()
+	m.cfg = &config.OverloadConfig{MaxRequestsWaiting: 8}
+	m.cfgMu.Unlock()
+
+	observe(m, 10) // trips under trip=8, and freshens the cached sample
+	if !m.overloaded.Load() {
+		t.Fatal("expected trip under the old thresholds")
+	}
+
+	// Raising the marks must clear the flag immediately (10 <= derived
+	// clear 50), so requests stop being rejected on the old threshold.
+	m.setConfig(&config.OverloadConfig{MaxRequestsWaiting: 100, RetryAfterMinutes: 1})
+	defer m.shutdown()
+	if m.overloaded.Load() {
+		t.Fatal("expected flag cleared against raised thresholds at setConfig time")
+	}
+	if reject, _, _ := m.shouldReject(); reject {
+		t.Fatal("expected allow immediately after the threshold raise")
+	}
+
+	// Lowering the marks below the cached sample must trip immediately.
+	m.setConfig(&config.OverloadConfig{MaxRequestsWaiting: 8, RetryAfterMinutes: 1})
+	if !m.overloaded.Load() {
+		t.Fatal("expected trip against lowered thresholds at setConfig time")
+	}
+	if reject, _, _ := m.shouldReject(); !reject {
+		t.Fatal("expected reject immediately after the threshold cut")
+	}
+}
+
 func TestSetConfig_WarnsOnOutOfRangeClearMark(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "vllm:num_requests_waiting 0.0")

--- a/manager/metrics_test.go
+++ b/manager/metrics_test.go
@@ -1,0 +1,322 @@
+package manager
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+
+	"github.com/tinfoilsh/confidential-model-router/config"
+)
+
+// newTestMetrics returns an enclaveMetrics with the given overload config
+// installed directly, without starting the polling goroutine.
+func newTestMetrics(host string, cfg *config.OverloadConfig) *enclaveMetrics {
+	m := newEnclaveMetrics(host, "test-model")
+	m.cfgMu.Lock()
+	m.cfg = cfg
+	m.cfgMu.Unlock()
+	return m
+}
+
+// observe simulates one scrape: record the sample as fresh and evaluate.
+func observe(m *enclaveMetrics, waiting float64) {
+	m.updateLatest(waiting, time.Now())
+	m.evaluateThresholds(waiting)
+}
+
+func TestEvaluateThresholds_Hysteresis(t *testing.T) {
+	m := newTestMetrics("hysteresis-host", &config.OverloadConfig{MaxRequestsWaiting: 16})
+
+	steps := []struct {
+		waiting    float64
+		overloaded bool
+		desc       string
+	}{
+		{15, false, "below trip mark, never tripped"},
+		{9, false, "inside band from below holds clear"},
+		{16, true, "trip mark reached"},
+		{15, true, "inside band holds overloaded"},
+		{9, true, "just above clear mark still holds"},
+		{8, false, "clear mark (trip/2) reached"},
+		{15, false, "inside band from below holds clear again"},
+		{20, true, "re-trips above trip mark"},
+		{0, false, "empty queue clears"},
+	}
+	for _, step := range steps {
+		observe(m, step.waiting)
+		if got := m.overloaded.Load(); got != step.overloaded {
+			t.Fatalf("waiting=%v (%s): overloaded=%v, want %v", step.waiting, step.desc, got, step.overloaded)
+		}
+	}
+}
+
+func TestEvaluateThresholds_ExplicitClearMark(t *testing.T) {
+	m := newTestMetrics("explicit-clear-host", &config.OverloadConfig{
+		MaxRequestsWaiting:   16,
+		ClearRequestsWaiting: 12,
+	})
+
+	observe(m, 16)
+	if !m.overloaded.Load() {
+		t.Fatal("expected trip at 16")
+	}
+	observe(m, 13)
+	if !m.overloaded.Load() {
+		t.Fatal("expected 13 to hold overloaded with clear mark 12")
+	}
+	observe(m, 12)
+	if m.overloaded.Load() {
+		t.Fatal("expected clear at 12")
+	}
+}
+
+func TestEvaluateThresholds_TransitionCountersOncePerEpisode(t *testing.T) {
+	// Unique labels so the shared counters are zero-valued for this test.
+	m := newTestMetrics("transition-count-host", &config.OverloadConfig{MaxRequestsWaiting: 16})
+	trips := OverloadEventsTotal.WithLabelValues("test-model", "transition-count-host")
+	recoveries := RecoveryEventsTotal.WithLabelValues("test-model", "transition-count-host")
+
+	// One episode: trip once, oscillate inside the band, then drain.
+	for _, waiting := range []float64{16, 12, 15, 9, 14, 16, 12} {
+		observe(m, waiting)
+	}
+	if got := testutil.ToFloat64(trips); got != 1 {
+		t.Fatalf("trip events during episode = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(recoveries); got != 0 {
+		t.Fatalf("recovery events during episode = %v, want 0", got)
+	}
+
+	observe(m, 8)
+	observe(m, 3)
+	if got := testutil.ToFloat64(recoveries); got != 1 {
+		t.Fatalf("recovery events after drain = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(trips); got != 1 {
+		t.Fatalf("trip events after drain = %v, want 1", got)
+	}
+}
+
+func TestEvaluateThresholds_NoConfigLeavesFlagAlone(t *testing.T) {
+	m := newTestMetrics("no-config-host", nil)
+	observe(m, 100)
+	if m.overloaded.Load() {
+		t.Fatal("expected no overload evaluation without config")
+	}
+
+	m = newTestMetrics("zero-threshold-host", &config.OverloadConfig{MaxRequestsWaiting: 0})
+	observe(m, 100)
+	if m.overloaded.Load() {
+		t.Fatal("expected no overload evaluation with non-positive trip mark")
+	}
+}
+
+func TestShouldReject_UsesHystereticFlag(t *testing.T) {
+	m := newTestMetrics("reject-host", &config.OverloadConfig{
+		MaxRequestsWaiting: 16,
+		RetryAfterMinutes:  2,
+	})
+
+	observe(m, 12)
+	if reject, _, _ := m.shouldReject(); reject {
+		t.Fatal("expected allow below trip mark before any episode")
+	}
+
+	observe(m, 16)
+	reject, retryAfter, waiting := m.shouldReject()
+	if !reject {
+		t.Fatal("expected reject at trip mark")
+	}
+	if retryAfter != 2*time.Minute {
+		t.Fatalf("retryAfter = %v, want 2m", retryAfter)
+	}
+	if waiting != 16 {
+		t.Fatalf("waiting = %v, want 16", waiting)
+	}
+
+	// Inside the band the flag holds, so the reject decision holds too:
+	// a tripped backend keeps shedding load until the queue drains.
+	observe(m, 12)
+	if reject, _, _ := m.shouldReject(); !reject {
+		t.Fatal("expected reject to hold inside hysteresis band")
+	}
+
+	observe(m, 8)
+	if reject, _, _ := m.shouldReject(); reject {
+		t.Fatal("expected allow once drained to clear mark")
+	}
+}
+
+func TestShouldReject_DefaultRetryAfter(t *testing.T) {
+	m := newTestMetrics("default-retry-host", &config.OverloadConfig{MaxRequestsWaiting: 16})
+	observe(m, 16)
+	reject, retryAfter, _ := m.shouldReject()
+	if !reject {
+		t.Fatal("expected reject at trip mark")
+	}
+	if retryAfter != time.Minute {
+		t.Fatalf("retryAfter = %v, want 1m default", retryAfter)
+	}
+}
+
+func TestSetConfig_DisabledThresholdResetsFlag(t *testing.T) {
+	m := newTestMetrics("disable-reset-host", &config.OverloadConfig{MaxRequestsWaiting: 16})
+	observe(m, 16)
+	if !m.overloaded.Load() {
+		t.Fatal("expected trip at 16")
+	}
+
+	// Zeroing the trip mark while keeping the overload block must reset the
+	// flag rather than freeze it true with evaluation stopped — a frozen
+	// flag would de-prefer the enclave in NextEnclave forever.
+	m.setConfig(&config.OverloadConfig{MaxRequestsWaiting: 0, RetryAfterMinutes: 1})
+	if m.overloaded.Load() {
+		t.Fatal("expected overload flag reset when trip mark is unset")
+	}
+	if reject, _, _ := m.shouldReject(); reject {
+		t.Fatal("expected allow once thresholds are disabled")
+	}
+	if got := testutil.ToFloat64(BackendOverloaded.WithLabelValues("test-model", "disable-reset-host")); got != 0 {
+		t.Fatalf("overloaded gauge = %v, want 0", got)
+	}
+
+	// Removing the overload block entirely resets as well.
+	m.overloaded.Store(true)
+	m.setConfig(nil)
+	if m.overloaded.Load() {
+		t.Fatal("expected overload flag reset when overload config removed")
+	}
+}
+
+// TestOverloadTransitionLogMessagesStable pins the transition log message
+// strings: they predate hysteresis and external log-based alerts may key on
+// them, so renaming them would silently orphan those alerts.
+func TestOverloadTransitionLogMessagesStable(t *testing.T) {
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	m := newTestMetrics("log-stable-host", &config.OverloadConfig{MaxRequestsWaiting: 16})
+	observe(m, 16)
+	observe(m, 8)
+
+	var messages []string
+	for _, entry := range hook.AllEntries() {
+		messages = append(messages, entry.Message)
+	}
+	if !slices.Contains(messages, "overload threshold exceeded") {
+		t.Fatalf("trip log message missing or renamed; got %q", messages)
+	}
+	if !slices.Contains(messages, "queue depth back below overload threshold") {
+		t.Fatalf("recovery log message missing or renamed; got %q", messages)
+	}
+}
+
+func TestSetConfig_WarnsOnOutOfRangeClearMark(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "vllm:num_requests_waiting 0.0")
+	}))
+	defer ts.Close()
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	m := newEnclaveMetrics(strings.TrimPrefix(ts.URL, "https://"), "test-model")
+	m.client = ts.Client()
+	m.setConfig(&config.OverloadConfig{
+		MaxRequestsWaiting:   16,
+		ClearRequestsWaiting: 20, // >= trip: invalid, resolves to the default 8
+		RetryAfterMinutes:    1,
+	})
+	defer m.shutdown()
+
+	for _, entry := range hook.AllEntries() {
+		if entry.Message == "clear_requests_waiting out of range, using default" {
+			if got := entry.Data["resolved_clear"]; got != 8 {
+				t.Fatalf("resolved_clear = %v, want 8", got)
+			}
+			return
+		}
+	}
+	t.Fatal("expected out-of-range clear mark warning")
+}
+
+// TestScrape_EndToEndHysteresis drives the real scrape pipeline — HTTP fetch,
+// vLLM exposition parsing, threshold evaluation — against a fake metrics
+// endpoint and observes the reject decision across a full overload episode.
+func TestScrape_EndToEndHysteresis(t *testing.T) {
+	var depth atomic.Int64
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/metrics" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprintf(w, "# HELP vllm:num_requests_waiting Number of requests waiting.\n")
+		fmt.Fprintf(w, "vllm:num_requests_waiting{model_name=\"test\"} %d.0\n", depth.Load())
+	}))
+	defer ts.Close()
+
+	m := newTestMetrics(strings.TrimPrefix(ts.URL, "https://"), &config.OverloadConfig{
+		MaxRequestsWaiting: 16,
+		RetryAfterMinutes:  1,
+	})
+	m.client = ts.Client()
+
+	poll := func(d int64) {
+		depth.Store(d)
+		m.scrape(t.Context())
+	}
+
+	poll(12)
+	if reject, _, _ := m.shouldReject(); reject {
+		t.Fatal("expected allow below trip mark")
+	}
+
+	poll(16)
+	reject, retryAfter, waiting := m.shouldReject()
+	if !reject || retryAfter != time.Minute || waiting != 16 {
+		t.Fatalf("at trip mark: reject=%v retryAfter=%v waiting=%v, want true 1m 16", reject, retryAfter, waiting)
+	}
+
+	poll(12)
+	if reject, _, _ := m.shouldReject(); !reject {
+		t.Fatal("expected reject to hold inside hysteresis band")
+	}
+
+	poll(8)
+	if reject, _, _ := m.shouldReject(); reject {
+		t.Fatal("expected allow once drained to clear mark")
+	}
+}
+
+func TestShouldReject_FailsOpen(t *testing.T) {
+	// No config.
+	m := newTestMetrics("open-nil-host", nil)
+	if reject, _, _ := m.shouldReject(); reject {
+		t.Fatal("expected allow without config")
+	}
+
+	// Config but no sample yet.
+	m = newTestMetrics("open-nosample-host", &config.OverloadConfig{MaxRequestsWaiting: 16})
+	if reject, _, _ := m.shouldReject(); reject {
+		t.Fatal("expected allow without a sample")
+	}
+
+	// Tripped flag but stale sample: fail open.
+	m = newTestMetrics("open-stale-host", &config.OverloadConfig{MaxRequestsWaiting: 16})
+	observe(m, 16)
+	m.updateLatest(16, time.Now().Add(-sampleStalenessLimit-time.Second))
+	if reject, _, _ := m.shouldReject(); reject {
+		t.Fatal("expected allow with a stale sample even while flagged overloaded")
+	}
+	if !m.overloaded.Load() {
+		t.Fatal("staleness must not clear the overload flag itself")
+	}
+}


### PR DESCRIPTION
The per-enclave overload flag was a single threshold re-evaluated on every 15s poll, so a backend hovering at `max_requests_waiting` flipped in and out of overload each poll — flapping both replica preference and 429 decisions. The planned cache-aware routing work leans on this flag being stable, and shipping hysteresis on its own keeps any change in reject rates attributable to it.

- Trip at `max_requests_waiting`; clear at the new optional `clear_requests_waiting` (default: half the trip mark); hold state in between. Setting the clear mark to `trip - 1` restores the old single-threshold behavior exactly.
- One overload state: `shouldReject` (429s) now reads the same hysteretic flag as `NextEnclave`'s preference instead of re-deriving a single-threshold answer, so a tripped backend keeps shedding load until its queue genuinely drains. Stale-sample fail-open is unchanged.
- Config lifecycle: zeroing or omitting `max_requests_waiting` now resets a tripped flag instead of freezing it true (which would de-prefer the enclave forever); an out-of-range clear mark warns and falls back to the default.
- Observability: the existing overload/recovery transition counters now count episodes rather than poll-to-poll flaps (no new metrics); transition log strings are kept stable for existing alerts (pinned by test); the 429 log includes the resolved marks so an in-band reject doesn't read as a contradiction.

No config changes needed to roll out — existing overload blocks derive their clear mark (8→4 for gpt-oss-120b, 16→8 for kimi-k2-6 and gemma4-31b). Watch `router_overload_events_total` / `router_recovery_events_total`: transition rates should drop to a boring level with reject totals unchanged beyond noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trip/clear hysteresis to the per-enclave overload flag to stop flapping and stabilize routing and 429 decisions. New thresholds apply immediately on config reload, so routing and rejects update without waiting for the next scrape.

- **New Features**
  - One overload state drives both `shouldReject` (429s) and `NextEnclave` preference.
  - Config: optional `clear_requests_waiting`; `0` means “use default” (half the trip), smallest expressible clear is `1`; set to `trip-1` to match old single-threshold behavior; out-of-range values warn and fall back to default.
  - Lifecycle: zero or omit `max_requests_waiting` resets any tripped flag and disables evaluation; `setConfig` re-evaluates the cached fresh sample so raises/cuts take effect even if scrapes fail.
  - Observability: transition counters count episodes (not poll flaps); transition log messages unchanged; 429 logs include resolved trip/clear marks.

- **Migration**
  - No config changes required. Existing blocks auto-derive a clear mark. Monitor overload/recovery transition rates; rejects should remain steady while flapping drops.

<sup>Written for commit c2b472874a72dcbd34a91fcc8b49dbd42542ba79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

