### PR TITLE
feat: add cache-aware routing shadow mode

### DIFF
--- a/cacheroute/cacheroute.go
+++ b/cacheroute/cacheroute.go
@@ -1,0 +1,421 @@
+// Package cacheroute implements cache-aware replica routing (design doc §5)
+// in shadow mode: it derives a routing key from the parsed request body,
+// ranks a model's replicas with rendezvous hashing, and measures — via
+// aggregate Prometheus metrics only — what cache-aware routing would have
+// done and whether it would have helped. It never influences which replica
+// serves a request.
+//
+// The router runs inside an enclave with no log sink, so /metrics is the only
+// telemetry channel out. All per-key state (the shadow table in shadow.go)
+// stays in process memory; nothing exported can be tied to a single request,
+// key, or user. Metric labels are closed enum sets — a routing key or any
+// value derived from one must never appear as a label.
+//
+// Like cachesalt, key derivation is a pure function of the request and pinned
+// by tests: changing the domain tag, framing, field order, or the window
+// flattening re-homes every key (a fleet-wide cache cold-start once routing
+// acts on keys), so treat the construction as frozen.
+package cacheroute
+
+import (
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/tinfoilsh/confidential-model-router/cachesalt"
+	"github.com/tinfoilsh/confidential-model-router/config"
+)
+
+// KeyDomainTag namespaces routing-key derivation. Like cachesalt's tags it is
+// hashed unframed, so it must be a fixed constant and no tag anywhere in the
+// router may be a prefix of another.
+const KeyDomainTag = "tinfoil/route-key/v1"
+
+// prefixWindowCap bounds the bytes of prompt prefix that feed the routing
+// key: ~1KB ≈ 256 tokens, mirroring OpenAI's prefix-hash window (§5.1). The
+// cap is a routing-hint tradeoff, not a correctness bound — cache_salt and
+// the engine's byte-exact prefix cache remain the security and correctness
+// boundaries.
+const prefixWindowCap = 1024
+
+// Defaults for the per-model Settings knobs (design doc §5.2, §5.4, and the
+// implementation plan's Phase 4).
+const (
+	// DefaultRetention is W, the assumed KV-retention window: a replica
+	// that served a key within W is assumed still warm for it.
+	DefaultRetention = 10 * time.Minute
+	// DefaultMinPromptBytes is the eligibility floor: prompts below it
+	// aren't worth pinning (§5.2; ~1,000 tokens, OpenAI's cache floor).
+	DefaultMinPromptBytes = 4096
+	// DefaultSplitThresholdRPM is the per-key request rate that adds one
+	// replica to a key's warm set (§5.4; OpenAI's figure is ~15 rpm).
+	DefaultSplitThresholdRPM = 15
+)
+
+// Mode is the per-model rollout state of cache-aware routing.
+type Mode string
+
+const (
+	// ModeOff disables the shadow pipeline entirely.
+	ModeOff Mode = "off"
+	// ModeShadow computes and meters routing decisions without acting.
+	ModeShadow Mode = "shadow"
+	// ModeEnforced acts on routing decisions. Not implemented until
+	// Phase 5: resolveMode clamps it to ModeShadow so an early config
+	// flip cannot silently claim behavior the build doesn't have.
+	ModeEnforced Mode = "enforced"
+)
+
+// resolveMode maps a raw config mode string to the mode this build actually
+// runs. It reports clamped=true when the config asked for enforcement, which
+// this Phase 4 build downgrades to shadow; the mode metric must report the
+// effective mode so dashboards never lie. Unknown values resolve to off.
+func resolveMode(raw string) (mode Mode, clamped bool) {
+	switch Mode(raw) {
+	case ModeShadow:
+		return ModeShadow, false
+	case ModeEnforced:
+		return ModeShadow, true
+	default:
+		return ModeOff, false
+	}
+}
+
+// Settings are the resolved per-model cache-route knobs.
+type Settings struct {
+	Mode              Mode
+	Retention         time.Duration // W: how long a replica is assumed warm for a key
+	MinPromptBytes    int           // eligibility floor on whole-prompt bytes
+	SplitThresholdRPM float64       // per-key rpm per replica of warm set
+}
+
+// SettingsFrom resolves a config block (nil means unconfigured) to concrete
+// settings, applying package defaults for zero fields.
+func SettingsFrom(c *config.CacheRouteConfig) Settings {
+	s := Settings{
+		Mode:              ModeOff,
+		Retention:         DefaultRetention,
+		MinPromptBytes:    DefaultMinPromptBytes,
+		SplitThresholdRPM: DefaultSplitThresholdRPM,
+	}
+	if c == nil {
+		return s
+	}
+	s.Mode, _ = resolveMode(c.Mode)
+	if c.RetentionWindowMinutes > 0 {
+		s.Retention = time.Duration(c.RetentionWindowMinutes) * time.Minute
+	}
+	if c.MinPromptBytes > 0 {
+		s.MinPromptBytes = c.MinPromptBytes
+	}
+	if c.SplitThresholdRPM > 0 {
+		s.SplitThresholdRPM = c.SplitThresholdRPM
+	}
+	return s
+}
+
+// Outcome is the eligibility-funnel classification of a request, used as the
+// outcome label of router_cache_route_requests_total. Values form a closed
+// set; dashboards depend on them.
+type Outcome string
+
+const (
+	// OutcomeKeyed means a routing key was derived and the full shadow
+	// pipeline ran.
+	OutcomeKeyed Outcome = "keyed"
+	// OutcomeNoSalt means the request carries no injected cache_salt. The
+	// salt is a routing-key component (§5.1) and the rollout invariant is
+	// no salt ⇒ no cache-aware routing.
+	OutcomeNoSalt Outcome = "no_salt"
+	// OutcomeNoPrefix means no prompt fields could be extracted, so there
+	// is nothing to key on.
+	OutcomeNoPrefix Outcome = "no_prefix"
+	// OutcomeBelowFloor means the prompt is under the eligibility floor
+	// and carries no prompt_cache_key (§5.2: short prompts aren't worth
+	// pinning).
+	OutcomeBelowFloor Outcome = "below_floor"
+	// OutcomePoolTooSmall means the model has fewer than two configured
+	// replicas, so routing can't move anything.
+	OutcomePoolTooSmall Outcome = "pool_too_small"
+	// OutcomeError means the shadow path panicked and was recovered. Must
+	// stay ≈ 0; it exists to prove shadow never fails a request.
+	OutcomeError Outcome = "error"
+)
+
+// Key is a derived routing key: a domain-tagged SHA-256 over the cache salt,
+// client prompt_cache_key, and prompt prefix window. Internal to the router,
+// never sent downstream, never logged, never a metric label.
+type Key [32]byte
+
+// Request is the shadow pipeline's view of one request, produced by
+// ExtractRequest at body-parse time and consumed by Shadow.Observe after the
+// production selector has picked a replica.
+type Request struct {
+	// Outcome is the funnel classification. Key is only meaningful when
+	// Outcome == OutcomeKeyed.
+	Outcome Outcome
+	Key     Key
+	// PromptBytes approximates the whole-prompt size (tools + all message
+	// contents), the prefill-cost weight for the byte-weighted reuse
+	// metrics and the eligibility floor input.
+	PromptBytes int
+
+	elapsed time.Duration // extraction cost, folded into compute_seconds by Observe
+}
+
+// ExtractRequest classifies a parsed OpenAI-compatible request body and, when
+// eligible, derives its routing key. salt is the encoded cache_salt string
+// the router injected ("" when none). It never fails: any panic is recovered
+// into OutcomeError, and malformed shapes simply classify as ineligible.
+//
+// Call it only on endpoints that support cache_salt and only after the body
+// is final (post file-input rewriting, post salt injection), so the window is
+// built from what the engine will actually see.
+func ExtractRequest(body map[string]any, path, salt string, s Settings) (req *Request) {
+	start := time.Now()
+	req = &Request{Outcome: OutcomeError}
+	defer func() {
+		if r := recover(); r != nil {
+			req.Outcome = OutcomeError
+		}
+		req.elapsed = time.Since(start)
+	}()
+
+	promptCacheKey, _ := body["prompt_cache_key"].(string)
+	tools, system, user := promptFields(body, path)
+	req.PromptBytes = promptLen(body, path, tools)
+
+	switch {
+	case salt == "":
+		req.Outcome = OutcomeNoSalt
+	case tools == nil && system == nil && user == nil && promptCacheKey == "":
+		req.Outcome = OutcomeNoPrefix
+	case req.PromptBytes < s.MinPromptBytes && promptCacheKey == "":
+		// A request carrying prompt_cache_key is always eligible: an
+		// explicit client grouping is honored as stated (§5.2).
+		req.Outcome = OutcomeBelowFloor
+	default:
+		req.Outcome = OutcomeKeyed
+		req.Key = deriveKey(salt, promptCacheKey, tools, system, user)
+	}
+	return req
+}
+
+// deriveKey computes the routing key (§5.1):
+//
+//	routing_key = hash(cache_salt ‖ prompt_cache_key ‖ prefix_window)
+//	prefix_window = lp(tools) ‖ lp(system) ‖ lp(first user message), 1KB cap
+//
+// using cachesalt.Sum's domain-tagged, length-prefixed framing (§6), with the
+// three window fields passed as separate lp()-framed fields and the cap
+// applied across their total. The salt input is the encoded 43-char salt
+// string the router injects, exactly as the design doc pins it. Missing
+// fields contribute lp("") via their nil flattening, keeping the encoding
+// deterministic.
+func deriveKey(salt, promptCacheKey string, tools, system, user any) Key {
+	budget := prefixWindowCap
+	toolsB := flattenValue(tools, budget)
+	budget -= len(toolsB)
+	systemB := flattenValue(system, budget)
+	budget -= len(systemB)
+	userB := flattenValue(user, budget)
+	return Key(cachesalt.Sum(KeyDomainTag, salt, promptCacheKey, string(toolsB), string(systemB), string(userB)))
+}
+
+// promptFields pulls the three prefix-window fields out of the parsed body in
+// prompt-render order (tools → system → first user message), per endpoint
+// shape. These are the extracted fields that become the engine's cached
+// prefix — never raw body bytes, whose leading content is sampling params and
+// marshaler field order (§5.1's mis-keying argument). A missing field is nil.
+func promptFields(body map[string]any, path string) (tools, system, user any) {
+	tools = body["tools"]
+
+	switch path {
+	case "/v1/responses":
+		// The Responses API carries the system prompt in `instructions`
+		// and the conversation in `input` (a string, or a list of
+		// role-tagged items).
+		system = body["instructions"]
+		switch input := body["input"].(type) {
+		case string:
+			user = input
+		case []any:
+			user = firstMessageContent(input, "user")
+		}
+	case "/v1/completions":
+		user = body["prompt"]
+	default: // /v1/chat/completions and anything chat-shaped
+		if messages, ok := body["messages"].([]any); ok {
+			// OpenAI-compatible clients use either role for the
+			// system prompt; take whichever appears first.
+			system = firstMessageContent(messages, "system", "developer")
+			user = firstMessageContent(messages, "user")
+		}
+	}
+	return tools, system, user
+}
+
+// firstMessageContent returns the content of the first message whose role is
+// one of roles, or nil.
+func firstMessageContent(messages []any, roles ...string) any {
+	for _, m := range messages {
+		msg, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		for _, want := range roles {
+			if role == want {
+				return msg["content"]
+			}
+		}
+	}
+	return nil
+}
+
+// promptLen approximates §5.2's prompt_len — the total byte length of tools
+// plus all message contents (the parsed fields, not the raw body) — by
+// summing the string content reachable from those fields. It is the
+// eligibility-floor input and the prefill-cost weight; a size proxy, not an
+// exact token count.
+func promptLen(body map[string]any, path string, tools any) int {
+	n := valueLen(tools)
+	switch path {
+	case "/v1/responses":
+		n += valueLen(body["instructions"])
+		n += messageContentLen(body["input"])
+	case "/v1/completions":
+		n += valueLen(body["prompt"])
+	default:
+		n += messageContentLen(body["messages"])
+	}
+	return n
+}
+
+// messageContentLen sums valueLen over the content field of each message in
+// a messages/input list. Non-list shapes (e.g. a string input) are measured
+// directly.
+func messageContentLen(v any) int {
+	list, ok := v.([]any)
+	if !ok {
+		return valueLen(v)
+	}
+	n := 0
+	for _, m := range list {
+		if msg, ok := m.(map[string]any); ok {
+			n += valueLen(msg["content"])
+		}
+	}
+	return n
+}
+
+// valueLen is the length counterpart of flattenValue: the total bytes its
+// string leaves would contribute, computed without building anything. Only
+// string lengths count — structure, numbers, and bools are size noise for a
+// floor threshold.
+func valueLen(v any) int {
+	switch x := v.(type) {
+	case string:
+		return len(x)
+	case []any:
+		n := 0
+		for _, e := range x {
+			n += valueLen(e)
+		}
+		return n
+	case map[string]any:
+		n := 0
+		for _, e := range x {
+			n += valueLen(e)
+		}
+		return n
+	default:
+		return 0
+	}
+}
+
+// flattenValue renders a parsed JSON value into deterministic bytes for the
+// prefix window, spending at most budget bytes. It exists instead of
+// json.Marshal for one reason: boundedness. A multimodal first user message
+// can carry megabytes of inline image data, and marshaling it whole to keep
+// ≤1KB would put an unbounded allocation on every request the shadow
+// observes. Traversal stops the moment the budget is spent.
+//
+// Determinism is what the routing key needs (every router must derive the
+// same bytes from the same parsed value), and three choices provide it: map
+// keys are visited in sorted order, every field is lp()-framed so boundaries
+// can't shift (§6), and scalars render via strconv. The encoding is pinned by
+// test vectors; changing it re-homes every key.
+func flattenValue(v any, budget int) []byte {
+	if budget <= 0 {
+		return nil
+	}
+	buf := make([]byte, 0, min(budget, 256))
+	buf = appendFlattened(buf, v, budget)
+	return buf
+}
+
+// appendFlattened appends v's flattening to buf, never growing it past
+// budget. Strings are lp-framed; containers frame each element (and each
+// sorted map key) so distinct structures can't collide. The final append may
+// overshoot mid-token; the tail is truncated to the budget, which is safe
+// because a truncated window is still deterministic — both routers truncate
+// identically.
+func appendFlattened(buf []byte, v any, budget int) []byte {
+	if len(buf) >= budget {
+		return buf[:budget]
+	}
+	switch x := v.(type) {
+	case nil:
+		// Contributes nothing: a missing field is lp("") at the Sum
+		// layer.
+	case string:
+		buf = appendFramed(buf, x)
+	case bool:
+		buf = appendFramed(buf, strconv.FormatBool(x))
+	case float64:
+		buf = appendFramed(buf, strconv.FormatFloat(x, 'g', -1, 64))
+	case []any:
+		for _, e := range x {
+			if len(buf) >= budget {
+				break
+			}
+			buf = appendFlattened(buf, e, budget)
+		}
+	case map[string]any:
+		for _, k := range sortedKeys(x) {
+			if len(buf) >= budget {
+				break
+			}
+			buf = appendFramed(buf, k)
+			buf = appendFlattened(buf, x[k], budget)
+		}
+	default:
+		// json.Number and exotic shapes: render via their string form
+		// when available; otherwise contribute nothing.
+		if s, ok := v.(interface{ String() string }); ok {
+			buf = appendFramed(buf, s.String())
+		}
+	}
+	if len(buf) > budget {
+		buf = buf[:budget]
+	}
+	return buf
+}
+
+// appendFramed appends lp(s) = uint32_be(len(s)) ‖ s.
+func appendFramed(buf []byte, s string) []byte {
+	n := uint32(len(s))
+	buf = append(buf, byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+	return append(buf, s...)
+}
+
+// sortedKeys returns m's keys in sorted order for deterministic traversal.
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/cacheroute/cacheroute.go
+++ b/cacheroute/cacheroute.go
@@ -314,21 +314,20 @@ func flattenValue(v any, budget int) []byte {
 // appendFlattened appends v's flattening to buf, never growing past budget.
 // Determinism is load-bearing: map keys visit in sorted order, every
 // element is length-prefixed so boundaries can't shift, and scalars render
-// via strconv. Truncating mid-token at the budget is fine — every router
-// truncates identically.
+// via strconv.
 func appendFlattened(buf []byte, v any, budget int) []byte {
 	if len(buf) >= budget {
-		return buf[:budget]
+		return buf
 	}
 	switch x := v.(type) {
 	case nil:
 		// A missing field contributes nothing.
 	case string:
-		buf = appendFramed(buf, x)
+		buf = appendFramed(buf, x, budget)
 	case bool:
-		buf = appendFramed(buf, strconv.FormatBool(x))
+		buf = appendFramed(buf, strconv.FormatBool(x), budget)
 	case float64:
-		buf = appendFramed(buf, strconv.FormatFloat(x, 'g', -1, 64))
+		buf = appendFramed(buf, strconv.FormatFloat(x, 'g', -1, 64), budget)
 	case []any:
 		for _, e := range x {
 			if len(buf) >= budget {
@@ -341,24 +340,33 @@ func appendFlattened(buf []byte, v any, budget int) []byte {
 			if len(buf) >= budget {
 				break
 			}
-			buf = appendFramed(buf, k)
+			buf = appendFramed(buf, k, budget)
 			buf = appendFlattened(buf, x[k], budget)
 		}
 	default:
 		// json.Number renders via String(); anything else contributes
 		// nothing.
 		if s, ok := v.(interface{ String() string }); ok {
-			buf = appendFramed(buf, s.String())
+			buf = appendFramed(buf, s.String(), budget)
 		}
-	}
-	if len(buf) > budget {
-		buf = buf[:budget]
 	}
 	return buf
 }
 
-// appendFramed appends lp(s) = uint32_be(len(s)) ‖ s.
-func appendFramed(buf []byte, s string) []byte {
+// appendFramed appends lp(s) = uint32_be(len(s)) ‖ s, truncating s so the
+// frame fits the budget. Truncating BEFORE framing is load-bearing twice:
+// the header encodes the window-visible length, so bytes beyond the window
+// can never influence the key (a growing prompt with a stable prefix must
+// keep its key), and a multi-megabyte leaf costs at most the window, never a
+// full copy.
+func appendFramed(buf []byte, s string, budget int) []byte {
+	room := budget - len(buf) - 4
+	if room <= 0 {
+		return buf
+	}
+	if len(s) > room {
+		s = s[:room]
+	}
 	n := uint32(len(s))
 	buf = append(buf, byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
 	return append(buf, s...)

--- a/cacheroute/cacheroute.go
+++ b/cacheroute/cacheroute.go
@@ -1,20 +1,12 @@
-// Package cacheroute implements cache-aware replica routing (design doc §5)
-// in shadow mode: it derives a routing key from the parsed request body,
-// ranks a model's replicas with rendezvous hashing, and measures — via
-// aggregate Prometheus metrics only — what cache-aware routing would have
-// done and whether it would have helped. It never influences which replica
-// serves a request.
+// Package cacheroute implements cache-aware replica routing in shadow mode:
+// it derives a routing key from the parsed request body, ranks a model's
+// replicas with rendezvous hashing, and measures what cache-aware routing
+// would have done — without influencing which replica serves a request.
 //
-// The router runs inside an enclave with no log sink, so /metrics is the only
-// telemetry channel out. All per-key state (the shadow table in shadow.go)
-// stays in process memory; nothing exported can be tied to a single request,
-// key, or user. Metric labels are closed enum sets — a routing key or any
-// value derived from one must never appear as a label.
-//
-// Like cachesalt, key derivation is a pure function of the request and pinned
-// by tests: changing the domain tag, framing, field order, or the window
-// flattening re-homes every key (a fleet-wide cache cold-start once routing
-// acts on keys), so treat the construction as frozen.
+// The router's only telemetry channel is Prometheus, so everything the
+// shadow learns is exported as aggregate metrics over closed label sets.
+// Per-key state stays in process memory; a routing key, or anything derived
+// from one, must never appear in a label or log line.
 package cacheroute
 
 import (
@@ -26,50 +18,43 @@ import (
 	"github.com/tinfoilsh/confidential-model-router/config"
 )
 
-// KeyDomainTag namespaces routing-key derivation. Like cachesalt's tags it is
-// hashed unframed, so it must be a fixed constant and no tag anywhere in the
-// router may be a prefix of another.
+// KeyDomainTag namespaces routing-key derivation. Tags are hashed unframed,
+// so no tag in the router may be a prefix of another.
 const KeyDomainTag = "tinfoil/route-key/v1"
 
-// prefixWindowCap bounds the bytes of prompt prefix that feed the routing
-// key: ~1KB ≈ 256 tokens, mirroring OpenAI's prefix-hash window (§5.1). The
-// cap is a routing-hint tradeoff, not a correctness bound — cache_salt and
-// the engine's byte-exact prefix cache remain the security and correctness
-// boundaries.
+// prefixWindowCap bounds how much prompt prefix feeds the routing key
+// (~256 tokens). A routing hint only: the engine's byte-exact prefix cache
+// remains the correctness boundary.
 const prefixWindowCap = 1024
 
-// Defaults for the per-model Settings knobs (design doc §5.2, §5.4, and the
-// implementation plan's Phase 4).
 const (
-	// DefaultRetention is W, the assumed KV-retention window: a replica
-	// that served a key within W is assumed still warm for it.
+	// DefaultRetention is the assumed KV-retention window: a replica that
+	// served a key within it is assumed still warm for that key.
 	DefaultRetention = 10 * time.Minute
-	// DefaultMinPromptBytes is the eligibility floor: prompts below it
-	// aren't worth pinning (§5.2; ~1,000 tokens, OpenAI's cache floor).
+	// DefaultMinPromptBytes is the eligibility floor: shorter prompts
+	// aren't worth pinning to a replica.
 	DefaultMinPromptBytes = 4096
 	// DefaultSplitThresholdRPM is the per-key request rate that adds one
-	// replica to a key's warm set (§5.4; OpenAI's figure is ~15 rpm).
+	// replica to a hot key's warm set (OpenAI splits at ~15 rpm).
 	DefaultSplitThresholdRPM = 15
 )
 
-// Mode is the per-model rollout state of cache-aware routing.
+// Mode is a model's cache-route rollout state.
 type Mode string
 
 const (
-	// ModeOff disables the shadow pipeline entirely.
+	// ModeOff disables the pipeline entirely.
 	ModeOff Mode = "off"
 	// ModeShadow computes and meters routing decisions without acting.
 	ModeShadow Mode = "shadow"
-	// ModeEnforced acts on routing decisions. Not implemented until
-	// Phase 5: resolveMode clamps it to ModeShadow so an early config
-	// flip cannot silently claim behavior the build doesn't have.
+	// ModeEnforced acts on routing decisions. Not implemented yet;
+	// resolveMode clamps it to ModeShadow.
 	ModeEnforced Mode = "enforced"
 )
 
-// resolveMode maps a raw config mode string to the mode this build actually
-// runs. It reports clamped=true when the config asked for enforcement, which
-// this Phase 4 build downgrades to shadow; the mode metric must report the
-// effective mode so dashboards never lie. Unknown values resolve to off.
+// resolveMode maps a raw config string to the mode this build runs,
+// reporting clamped=true when enforcement was requested but isn't
+// available. Unknown values resolve to off.
 func resolveMode(raw string) (mode Mode, clamped bool) {
 	switch Mode(raw) {
 	case ModeShadow:
@@ -81,16 +66,16 @@ func resolveMode(raw string) (mode Mode, clamped bool) {
 	}
 }
 
-// Settings are the resolved per-model cache-route knobs.
+// Settings are a model's resolved cache-route knobs.
 type Settings struct {
 	Mode              Mode
-	Retention         time.Duration // W: how long a replica is assumed warm for a key
+	Retention         time.Duration // how long a replica stays warm for a key
 	MinPromptBytes    int           // eligibility floor on whole-prompt bytes
 	SplitThresholdRPM float64       // per-key rpm per replica of warm set
 }
 
-// SettingsFrom resolves a config block (nil means unconfigured) to concrete
-// settings, applying package defaults for zero fields.
+// SettingsFrom resolves a config block (nil means unconfigured), applying
+// defaults for zero fields.
 func SettingsFrom(c *config.CacheRouteConfig) Settings {
 	s := Settings{
 		Mode:              ModeOff,
@@ -114,63 +99,53 @@ func SettingsFrom(c *config.CacheRouteConfig) Settings {
 	return s
 }
 
-// Outcome is the eligibility-funnel classification of a request, used as the
-// outcome label of router_cache_route_requests_total. Values form a closed
-// set; dashboards depend on them.
+// Outcome classifies a request for the eligibility funnel
+// (router_cache_route_requests_total). Closed set; dashboards depend on it.
 type Outcome string
 
 const (
-	// OutcomeKeyed means a routing key was derived and the full shadow
-	// pipeline ran.
+	// OutcomeKeyed: a routing key was derived and the full pipeline ran.
 	OutcomeKeyed Outcome = "keyed"
-	// OutcomeNoSalt means the request carries no injected cache_salt. The
-	// salt is a routing-key component (§5.1) and the rollout invariant is
-	// no salt ⇒ no cache-aware routing.
+	// OutcomeNoSalt: no injected cache_salt, which is a routing-key
+	// component — no salt means no cache-aware routing.
 	OutcomeNoSalt Outcome = "no_salt"
-	// OutcomeNoPrefix means no prompt fields could be extracted, so there
-	// is nothing to key on.
+	// OutcomeNoPrefix: no prompt fields to key on.
 	OutcomeNoPrefix Outcome = "no_prefix"
-	// OutcomeBelowFloor means the prompt is under the eligibility floor
-	// and carries no prompt_cache_key (§5.2: short prompts aren't worth
-	// pinning).
+	// OutcomeBelowFloor: prompt under the floor with no prompt_cache_key.
 	OutcomeBelowFloor Outcome = "below_floor"
-	// OutcomePoolTooSmall means the model has fewer than two configured
-	// replicas, so routing can't move anything.
+	// OutcomePoolTooSmall: fewer than two configured replicas.
 	OutcomePoolTooSmall Outcome = "pool_too_small"
-	// OutcomeError means the shadow path panicked and was recovered. Must
-	// stay ≈ 0; it exists to prove shadow never fails a request.
+	// OutcomeError: the shadow path panicked and was recovered. Must stay
+	// ≈ 0.
 	OutcomeError Outcome = "error"
 )
 
-// Key is a derived routing key: a domain-tagged SHA-256 over the cache salt,
-// client prompt_cache_key, and prompt prefix window. Internal to the router,
-// never sent downstream, never logged, never a metric label.
+// Key is a derived routing key. Internal to the router: never sent
+// downstream, logged, or used as a metric label.
 type Key [32]byte
 
 // Request is the shadow pipeline's view of one request, produced by
-// ExtractRequest at body-parse time and consumed by Shadow.Observe after the
-// production selector has picked a replica.
+// ExtractRequest at body-parse time and consumed by Shadow.Observe after
+// replica selection.
 type Request struct {
-	// Outcome is the funnel classification. Key is only meaningful when
-	// Outcome == OutcomeKeyed.
+	// Outcome is the funnel classification; Key is meaningful only when
+	// Outcome is OutcomeKeyed.
 	Outcome Outcome
 	Key     Key
-	// PromptBytes approximates the whole-prompt size (tools + all message
-	// contents), the prefill-cost weight for the byte-weighted reuse
-	// metrics and the eligibility floor input.
+	// PromptBytes approximates whole-prompt size (tools + all message
+	// contents): the eligibility-floor input and the weight for the
+	// byte-weighted reuse metrics.
 	PromptBytes int
 
-	elapsed time.Duration // extraction cost, folded into compute_seconds by Observe
+	elapsed time.Duration // extraction cost, folded into ComputeSeconds
 }
 
-// ExtractRequest classifies a parsed OpenAI-compatible request body and, when
-// eligible, derives its routing key. salt is the encoded cache_salt string
-// the router injected ("" when none). It never fails: any panic is recovered
-// into OutcomeError, and malformed shapes simply classify as ineligible.
-//
-// Call it only on endpoints that support cache_salt and only after the body
-// is final (post file-input rewriting, post salt injection), so the window is
-// built from what the engine will actually see.
+// ExtractRequest classifies a parsed OpenAI-compatible body and, when
+// eligible, derives its routing key. salt is the cache_salt string the
+// router injected ("" when none). It never fails: panics are recovered into
+// OutcomeError and malformed shapes classify as ineligible. Call it after
+// the body is final (post file-input rewriting, post salt injection) so the
+// window reflects what the engine will see.
 func ExtractRequest(body map[string]any, path, salt string, s Settings) (req *Request) {
 	start := time.Now()
 	req = &Request{Outcome: OutcomeError}
@@ -191,8 +166,8 @@ func ExtractRequest(body map[string]any, path, salt string, s Settings) (req *Re
 	case tools == nil && system == nil && user == nil && promptCacheKey == "":
 		req.Outcome = OutcomeNoPrefix
 	case req.PromptBytes < s.MinPromptBytes && promptCacheKey == "":
-		// A request carrying prompt_cache_key is always eligible: an
-		// explicit client grouping is honored as stated (§5.2).
+		// An explicit prompt_cache_key makes a request eligible
+		// regardless of size.
 		req.Outcome = OutcomeBelowFloor
 	default:
 		req.Outcome = OutcomeKeyed
@@ -201,17 +176,14 @@ func ExtractRequest(body map[string]any, path, salt string, s Settings) (req *Re
 	return req
 }
 
-// deriveKey computes the routing key (§5.1):
+// deriveKey computes
 //
-//	routing_key = hash(cache_salt ‖ prompt_cache_key ‖ prefix_window)
-//	prefix_window = lp(tools) ‖ lp(system) ‖ lp(first user message), 1KB cap
+//	Sum(tag, salt, prompt_cache_key, tools, system, first user message)
 //
-// using cachesalt.Sum's domain-tagged, length-prefixed framing (§6), with the
-// three window fields passed as separate lp()-framed fields and the cap
-// applied across their total. The salt input is the encoded 43-char salt
-// string the router injects, exactly as the design doc pins it. Missing
-// fields contribute lp("") via their nil flattening, keeping the encoding
-// deterministic.
+// with the three prompt fields flattened and capped to prefixWindowCap
+// across their total. Sum length-prefixes every field, so boundaries can't
+// shift. The construction is pinned by test vectors: changing any detail
+// re-homes every key, a fleet-wide cache cold-start once routing acts.
 func deriveKey(salt, promptCacheKey string, tools, system, user any) Key {
 	budget := prefixWindowCap
 	toolsB := flattenValue(tools, budget)
@@ -222,19 +194,16 @@ func deriveKey(salt, promptCacheKey string, tools, system, user any) Key {
 	return Key(cachesalt.Sum(KeyDomainTag, salt, promptCacheKey, string(toolsB), string(systemB), string(userB)))
 }
 
-// promptFields pulls the three prefix-window fields out of the parsed body in
+// promptFields pulls the routing-relevant fields out of the parsed body in
 // prompt-render order (tools → system → first user message), per endpoint
-// shape. These are the extracted fields that become the engine's cached
-// prefix — never raw body bytes, whose leading content is sampling params and
-// marshaler field order (§5.1's mis-keying argument). A missing field is nil.
+// shape. Keying on parsed fields rather than raw body bytes keeps volatile
+// non-prompt content (sampling params, marshaler field order) out of the
+// key. A missing field is nil.
 func promptFields(body map[string]any, path string) (tools, system, user any) {
 	tools = body["tools"]
 
 	switch path {
 	case "/v1/responses":
-		// The Responses API carries the system prompt in `instructions`
-		// and the conversation in `input` (a string, or a list of
-		// role-tagged items).
 		system = body["instructions"]
 		switch input := body["input"].(type) {
 		case string:
@@ -246,8 +215,7 @@ func promptFields(body map[string]any, path string) (tools, system, user any) {
 		user = body["prompt"]
 	default: // /v1/chat/completions and anything chat-shaped
 		if messages, ok := body["messages"].([]any); ok {
-			// OpenAI-compatible clients use either role for the
-			// system prompt; take whichever appears first.
+			// Clients use either role for the system prompt.
 			system = firstMessageContent(messages, "system", "developer")
 			user = firstMessageContent(messages, "user")
 		}
@@ -273,11 +241,9 @@ func firstMessageContent(messages []any, roles ...string) any {
 	return nil
 }
 
-// promptLen approximates §5.2's prompt_len — the total byte length of tools
-// plus all message contents (the parsed fields, not the raw body) — by
-// summing the string content reachable from those fields. It is the
-// eligibility-floor input and the prefill-cost weight; a size proxy, not an
-// exact token count.
+// promptLen approximates whole-prompt size — tools plus all message
+// contents — by summing reachable string bytes. A size proxy for the floor
+// threshold, not a token count.
 func promptLen(body map[string]any, path string, tools any) int {
 	n := valueLen(tools)
 	switch path {
@@ -292,9 +258,8 @@ func promptLen(body map[string]any, path string, tools any) int {
 	return n
 }
 
-// messageContentLen sums valueLen over the content field of each message in
-// a messages/input list. Non-list shapes (e.g. a string input) are measured
-// directly.
+// messageContentLen sums valueLen over each message's content field;
+// non-list shapes are measured directly.
 func messageContentLen(v any) int {
 	list, ok := v.([]any)
 	if !ok {
@@ -309,10 +274,8 @@ func messageContentLen(v any) int {
 	return n
 }
 
-// valueLen is the length counterpart of flattenValue: the total bytes its
-// string leaves would contribute, computed without building anything. Only
-// string lengths count — structure, numbers, and bools are size noise for a
-// floor threshold.
+// valueLen sums the string bytes reachable from v without building
+// anything.
 func valueLen(v any) int {
 	switch x := v.(type) {
 	case string:
@@ -335,17 +298,10 @@ func valueLen(v any) int {
 }
 
 // flattenValue renders a parsed JSON value into deterministic bytes for the
-// prefix window, spending at most budget bytes. It exists instead of
-// json.Marshal for one reason: boundedness. A multimodal first user message
-// can carry megabytes of inline image data, and marshaling it whole to keep
-// ≤1KB would put an unbounded allocation on every request the shadow
-// observes. Traversal stops the moment the budget is spent.
-//
-// Determinism is what the routing key needs (every router must derive the
-// same bytes from the same parsed value), and three choices provide it: map
-// keys are visited in sorted order, every field is lp()-framed so boundaries
-// can't shift (§6), and scalars render via strconv. The encoding is pinned by
-// test vectors; changing it re-homes every key.
+// prefix window, spending at most budget. It replaces json.Marshal for one
+// reason: boundedness — a multimodal message can carry megabytes of inline
+// image data, and the walk must stop at the budget rather than marshal the
+// whole value first.
 func flattenValue(v any, budget int) []byte {
 	if budget <= 0 {
 		return nil
@@ -355,20 +311,18 @@ func flattenValue(v any, budget int) []byte {
 	return buf
 }
 
-// appendFlattened appends v's flattening to buf, never growing it past
-// budget. Strings are lp-framed; containers frame each element (and each
-// sorted map key) so distinct structures can't collide. The final append may
-// overshoot mid-token; the tail is truncated to the budget, which is safe
-// because a truncated window is still deterministic — both routers truncate
-// identically.
+// appendFlattened appends v's flattening to buf, never growing past budget.
+// Determinism is load-bearing: map keys visit in sorted order, every
+// element is length-prefixed so boundaries can't shift, and scalars render
+// via strconv. Truncating mid-token at the budget is fine — every router
+// truncates identically.
 func appendFlattened(buf []byte, v any, budget int) []byte {
 	if len(buf) >= budget {
 		return buf[:budget]
 	}
 	switch x := v.(type) {
 	case nil:
-		// Contributes nothing: a missing field is lp("") at the Sum
-		// layer.
+		// A missing field contributes nothing.
 	case string:
 		buf = appendFramed(buf, x)
 	case bool:
@@ -391,8 +345,8 @@ func appendFlattened(buf []byte, v any, budget int) []byte {
 			buf = appendFlattened(buf, x[k], budget)
 		}
 	default:
-		// json.Number and exotic shapes: render via their string form
-		// when available; otherwise contribute nothing.
+		// json.Number renders via String(); anything else contributes
+		// nothing.
 		if s, ok := v.(interface{ String() string }); ok {
 			buf = appendFramed(buf, s.String())
 		}
@@ -410,7 +364,7 @@ func appendFramed(buf []byte, s string) []byte {
 	return append(buf, s...)
 }
 
-// sortedKeys returns m's keys in sorted order for deterministic traversal.
+// sortedKeys returns m's keys sorted, for deterministic traversal.
 func sortedKeys(m map[string]any) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {

--- a/cacheroute/cacheroute_test.go
+++ b/cacheroute/cacheroute_test.go
@@ -184,6 +184,31 @@ func TestExtractRequestWindowCap(t *testing.T) {
 	if c == d {
 		t.Error("divergence inside the window must change the key")
 	}
+
+	// Total field length beyond the window must not move the key either: a
+	// growing prompt with a stable prefix keeps its key.
+	g := extract(t, chatBody("sys", prefix), "/v1/chat/completions", testSalt).Key
+	h := extract(t, chatBody("sys", prefix+strings.Repeat("q", 1000)), "/v1/chat/completions", testSalt).Key
+	if g != h {
+		t.Error("field length beyond the window must not change the key")
+	}
+	i := extract(t, map[string]any{"prompt": prefix}, "/v1/completions", testSalt).Key
+	j := extract(t, map[string]any{"prompt": prefix + strings.Repeat("q", 1000)}, "/v1/completions", testSalt).Key
+	if i != j {
+		t.Error("growing completions prompt with a stable prefix must keep its key")
+	}
+}
+
+// TestFlattenLeafBounded pins the flattener's cost bound: a multi-megabyte
+// leaf must cost at most the window, never a full copy.
+func TestFlattenLeafBounded(t *testing.T) {
+	out := flattenValue(strings.Repeat("x", 8<<20), prefixWindowCap)
+	if len(out) > prefixWindowCap {
+		t.Fatalf("flattened %d bytes, cap %d", len(out), prefixWindowCap)
+	}
+	if cap(out) > 4*prefixWindowCap {
+		t.Fatalf("flatten buffer capacity %d betrays a full-leaf copy", cap(out))
+	}
 }
 
 // TestExtractRequestMultimodalBounded exercises structured (multimodal)

--- a/cacheroute/cacheroute_test.go
+++ b/cacheroute/cacheroute_test.go
@@ -1,0 +1,298 @@
+package cacheroute
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tinfoilsh/confidential-model-router/cachesalt"
+	"github.com/tinfoilsh/confidential-model-router/config"
+)
+
+const testSalt = "0000000000000000000000000000000000000000000" // 43 chars, like a real salt
+
+// chatBody builds a chat-completions body whose prompt clears the default
+// eligibility floor.
+func chatBody(system, user string) map[string]any {
+	return map[string]any{
+		"model": "test",
+		"messages": []any{
+			map[string]any{"role": "system", "content": system},
+			map[string]any{"role": "user", "content": user},
+		},
+	}
+}
+
+func bigChatBody() map[string]any {
+	return chatBody(strings.Repeat("s", 3000), strings.Repeat("u", 3000))
+}
+
+func defaultSettings() Settings {
+	return SettingsFrom(nil)
+}
+
+func extract(t *testing.T, body map[string]any, path, salt string) *Request {
+	t.Helper()
+	req := ExtractRequest(body, path, salt, defaultSettings())
+	if req.Outcome != OutcomeKeyed {
+		t.Fatalf("fixture not keyed: %s (prompt too small for the floor?)", req.Outcome)
+	}
+	return req
+}
+
+func TestExtractRequestFunnel(t *testing.T) {
+	small := chatBody("sys", "hi")
+
+	tests := []struct {
+		name    string
+		body    map[string]any
+		salt    string
+		outcome Outcome
+	}{
+		{"no salt", bigChatBody(), "", OutcomeNoSalt},
+		{"no prompt fields", map[string]any{"model": "test"}, testSalt, OutcomeNoPrefix},
+		{"below floor", small, testSalt, OutcomeBelowFloor},
+		{"prompt_cache_key overrides floor", withCacheKey(small, "grp"), testSalt, OutcomeKeyed},
+		{"eligible", bigChatBody(), testSalt, OutcomeKeyed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := ExtractRequest(tt.body, "/v1/chat/completions", tt.salt, defaultSettings())
+			if req.Outcome != tt.outcome {
+				t.Fatalf("outcome = %s, want %s", req.Outcome, tt.outcome)
+			}
+		})
+	}
+}
+
+func withCacheKey(body map[string]any, key string) map[string]any {
+	out := make(map[string]any, len(body)+1)
+	for k, v := range body {
+		out[k] = v
+	}
+	out["prompt_cache_key"] = key
+	return out
+}
+
+// TestExtractRequestKeyComponents verifies each §5.1 key input moves the key
+// and that non-prompt fields do not.
+func TestExtractRequestKeyComponents(t *testing.T) {
+	base := extract(t, bigChatBody(), "/v1/chat/completions", testSalt).Key
+
+	// Each input changes the key.
+	otherSalt := extract(t, bigChatBody(), "/v1/chat/completions", strings.Repeat("1", 43)).Key
+	if otherSalt == base {
+		t.Error("different salt must change the key")
+	}
+	withKey := extract(t, withCacheKey(bigChatBody(), "grp"), "/v1/chat/completions", testSalt).Key
+	if withKey == base {
+		t.Error("prompt_cache_key must change the key")
+	}
+	otherSystem := bigChatBody()
+	otherSystem["messages"].([]any)[0].(map[string]any)["content"] = strings.Repeat("S", 3000)
+	if extract(t, otherSystem, "/v1/chat/completions", testSalt).Key == base {
+		t.Error("different system prompt must change the key")
+	}
+	withTools := bigChatBody()
+	withTools["tools"] = []any{map[string]any{"type": "function", "function": map[string]any{"name": "f"}}}
+	if extract(t, withTools, "/v1/chat/completions", testSalt).Key == base {
+		t.Error("tools must change the key")
+	}
+
+	// Sampling params and appended turns must not: the key has to stay
+	// stable across a conversation so multi-turn replays keep homing to
+	// the same replica.
+	perturbed := bigChatBody()
+	perturbed["temperature"] = 0.9
+	perturbed["max_tokens"] = 123
+	perturbed["messages"] = append(perturbed["messages"].([]any),
+		map[string]any{"role": "assistant", "content": "answer"},
+		map[string]any{"role": "user", "content": "follow-up"},
+	)
+	got := extract(t, perturbed, "/v1/chat/completions", testSalt)
+	if got.Key != base {
+		t.Error("sampling params and appended turns must not change the key")
+	}
+	if got.PromptBytes <= 6000 {
+		t.Errorf("PromptBytes = %d, must include appended turns", got.PromptBytes)
+	}
+}
+
+// TestExtractRequestDeterminism re-decodes the same JSON (fresh map iteration
+// order) and expects an identical key.
+func TestExtractRequestDeterminism(t *testing.T) {
+	raw := `{"model":"m","tools":[{"type":"function","function":{"name":"f","description":"d","parameters":{"a":1,"b":2,"c":3,"d":4,"e":5}}}],"messages":[{"role":"system","content":"` + strings.Repeat("s", 5000) + `"},{"role":"user","content":"hello"}]}`
+	var keys []Key
+	for range 5 {
+		var body map[string]any
+		if err := json.Unmarshal([]byte(raw), &body); err != nil {
+			t.Fatal(err)
+		}
+		keys = append(keys, extract(t, body, "/v1/chat/completions", testSalt).Key)
+	}
+	for _, k := range keys[1:] {
+		if k != keys[0] {
+			t.Fatal("same JSON must derive the same key across decodes")
+		}
+	}
+}
+
+func TestExtractRequestEndpointShapes(t *testing.T) {
+	long := strings.Repeat("x", 5000)
+
+	responses := map[string]any{"instructions": "sys", "input": long}
+	if req := extract(t, responses, "/v1/responses", testSalt); req.Outcome != OutcomeKeyed {
+		t.Errorf("responses string input: outcome = %s, want keyed", req.Outcome)
+	}
+
+	responsesList := map[string]any{
+		"instructions": "sys",
+		"input": []any{
+			map[string]any{"role": "user", "content": long},
+		},
+	}
+	if req := extract(t, responsesList, "/v1/responses", testSalt); req.Outcome != OutcomeKeyed {
+		t.Errorf("responses list input: outcome = %s, want keyed", req.Outcome)
+	}
+
+	completions := map[string]any{"prompt": long}
+	if req := extract(t, completions, "/v1/completions", testSalt); req.Outcome != OutcomeKeyed {
+		t.Errorf("completions: outcome = %s, want keyed", req.Outcome)
+	}
+
+	// The instructions field must feed the key on /v1/responses.
+	a := extract(t, map[string]any{"instructions": "one", "input": long}, "/v1/responses", testSalt).Key
+	b := extract(t, map[string]any{"instructions": "two", "input": long}, "/v1/responses", testSalt).Key
+	if a == b {
+		t.Error("instructions must change the key on /v1/responses")
+	}
+}
+
+// TestExtractRequestWindowCap verifies the 1KB prefix window: divergence
+// beyond it must not move the key, divergence inside it must.
+func TestExtractRequestWindowCap(t *testing.T) {
+	prefix := strings.Repeat("p", 5000) // clears the 4KB floor, exceeds the 1KB window
+	a := extract(t, chatBody(prefix+"AAAA", "user"), "/v1/chat/completions", testSalt).Key
+	b := extract(t, chatBody(prefix+"BBBB", "user"), "/v1/chat/completions", testSalt).Key
+	if a != b {
+		t.Error("divergence beyond the window cap must not change the key")
+	}
+
+	c := extract(t, chatBody("A"+prefix, "user"), "/v1/chat/completions", testSalt).Key
+	d := extract(t, chatBody("B"+prefix, "user"), "/v1/chat/completions", testSalt).Key
+	if c == d {
+		t.Error("divergence inside the window must change the key")
+	}
+}
+
+// TestExtractRequestMultimodalBounded exercises structured (multimodal)
+// content: parts beyond the window cap must not affect the key, and
+// PromptBytes must still count them.
+func TestExtractRequestMultimodalBounded(t *testing.T) {
+	multimodal := func(payload string) map[string]any {
+		return map[string]any{
+			"messages": []any{
+				map[string]any{"role": "system", "content": strings.Repeat("s", 5000)},
+				map[string]any{"role": "user", "content": []any{
+					map[string]any{"type": "text", "text": "describe this"},
+					map[string]any{"type": "image_url", "image_url": map[string]any{"url": payload}},
+				}},
+			},
+		}
+	}
+	small := multimodal("data:image/png;base64," + strings.Repeat("A", 100))
+	big := multimodal("data:image/png;base64," + strings.Repeat("B", 1<<20))
+
+	reqSmall := extract(t, small, "/v1/chat/completions", testSalt)
+	reqBig := extract(t, big, "/v1/chat/completions", testSalt)
+	if reqSmall.Key != reqBig.Key {
+		t.Error("content beyond the window cap must not change the key")
+	}
+	if reqBig.PromptBytes < 1<<20 {
+		t.Errorf("PromptBytes = %d, must count the full multimodal payload", reqBig.PromptBytes)
+	}
+}
+
+// TestExtractRequestMalformedShapes feeds hostile/degenerate bodies; nothing
+// may panic out and outcomes must stay sensible.
+func TestExtractRequestMalformedShapes(t *testing.T) {
+	bodies := []map[string]any{
+		nil,
+		{"messages": "not a list"},
+		{"messages": []any{"not a map", 42, nil}},
+		{"messages": []any{map[string]any{"role": 7, "content": []any{nil}}}},
+		{"tools": map[string]any{"weird": "shape"}, "prompt_cache_key": 42},
+		{"input": []any{map[string]any{"role": "user"}}, "instructions": 9.5},
+	}
+	for i, body := range bodies {
+		req := ExtractRequest(body, "/v1/chat/completions", testSalt, defaultSettings())
+		if req.Outcome == OutcomeError {
+			t.Errorf("body %d: unexpected error outcome", i)
+		}
+		if req.Outcome == OutcomeKeyed && req.Key == (Key{}) {
+			t.Errorf("body %d: keyed with zero key", i)
+		}
+	}
+}
+
+// TestDeriveKeyPinned pins the key construction two ways: against a
+// hand-framed reference for a case simple enough to build byte-by-byte
+// (catching drift in the flattening or Sum wiring), and against a golden
+// value (catching any change at all — changing the construction re-homes
+// every key once routing acts, so it must be deliberate).
+func TestDeriveKeyPinned(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "system", "content": "sys prompt"},
+			map[string]any{"role": "user", "content": "user prompt"},
+		},
+		"prompt_cache_key": "group-1",
+	}
+	got := ExtractRequest(body, "/v1/chat/completions", testSalt, Settings{Mode: ModeShadow, MinPromptBytes: 1, Retention: DefaultRetention, SplitThresholdRPM: DefaultSplitThresholdRPM})
+	if got.Outcome != OutcomeKeyed {
+		t.Fatalf("outcome = %s, want keyed", got.Outcome)
+	}
+
+	// Hand-framed reference: string contents flatten to lp(content); the
+	// window fields are Sum'd as separate lp() fields after salt and
+	// prompt_cache_key, under the routing-key domain tag.
+	lp := func(s string) string {
+		n := len(s)
+		return string([]byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}) + s
+	}
+	want := Key(cachesalt.Sum(KeyDomainTag, testSalt, "group-1", "", lp("sys prompt"), lp("user prompt")))
+	if got.Key != want {
+		t.Fatalf("key = %x, want hand-framed %x", got.Key, want)
+	}
+
+	const golden = "fac9e3d0f3dda00695b7ecab7dd7dc7a4d569d49cc5145b71bfcc1eae53978e4"
+	if h := hex.EncodeToString(got.Key[:]); h != golden {
+		t.Fatalf("key = %s, want golden %s (changing the construction re-homes every key)", h, golden)
+	}
+}
+
+func TestSettingsFrom(t *testing.T) {
+	def := SettingsFrom(nil)
+	if def.Mode != ModeOff || def.Retention != DefaultRetention || def.MinPromptBytes != DefaultMinPromptBytes || def.SplitThresholdRPM != DefaultSplitThresholdRPM {
+		t.Fatalf("nil config must resolve to off + defaults, got %+v", def)
+	}
+
+	s := SettingsFrom(&config.CacheRouteConfig{
+		Mode:                   "shadow",
+		RetentionWindowMinutes: 5,
+		MinPromptBytes:         1024,
+		SplitThresholdRPM:      30,
+	})
+	if s.Mode != ModeShadow || s.Retention.Minutes() != 5 || s.MinPromptBytes != 1024 || s.SplitThresholdRPM != 30 {
+		t.Fatalf("explicit config not applied: %+v", s)
+	}
+
+	// Phase 4 clamps enforced to shadow: the build measures, it does not act.
+	if s := SettingsFrom(&config.CacheRouteConfig{Mode: "enforced"}); s.Mode != ModeShadow {
+		t.Fatalf("enforced must clamp to shadow in this build, got %s", s.Mode)
+	}
+	if s := SettingsFrom(&config.CacheRouteConfig{Mode: "bogus"}); s.Mode != ModeOff {
+		t.Fatalf("unknown mode must resolve to off, got %s", s.Mode)
+	}
+}

--- a/cacheroute/cacheroute_test.go
+++ b/cacheroute/cacheroute_test.go
@@ -75,7 +75,7 @@ func withCacheKey(body map[string]any, key string) map[string]any {
 	return out
 }
 
-// TestExtractRequestKeyComponents verifies each §5.1 key input moves the key
+// TestExtractRequestKeyComponents verifies that each key input moves the key
 // and that non-prompt fields do not.
 func TestExtractRequestKeyComponents(t *testing.T) {
 	base := extract(t, bigChatBody(), "/v1/chat/completions", testSalt).Key
@@ -288,7 +288,8 @@ func TestSettingsFrom(t *testing.T) {
 		t.Fatalf("explicit config not applied: %+v", s)
 	}
 
-	// Phase 4 clamps enforced to shadow: the build measures, it does not act.
+	// Enforcement is not implemented: the config value is accepted but
+	// clamped to shadow.
 	if s := SettingsFrom(&config.CacheRouteConfig{Mode: "enforced"}); s.Mode != ModeShadow {
 		t.Fatalf("enforced must clamp to shadow in this build, got %s", s.Mode)
 	}

--- a/cacheroute/hrw.go
+++ b/cacheroute/hrw.go
@@ -8,34 +8,27 @@ import (
 	"github.com/cespare/xxhash/v2"
 )
 
-// Candidate is one replica the selector could pick: its stable enclave
-// hostname (the HRW identity — it must survive redeploys, §5.2) and its
-// current router-local in-flight request count (the live load signal for
-// splitting hot keys, §5.4/§5.5).
+// Candidate is a replica the selector could pick: its stable enclave
+// hostname (the HRW identity, which must survive redeploys or keys re-home
+// on every release) and its live in-flight request count.
 type Candidate struct {
 	Host     string
 	InFlight int
 }
 
-// Pool is a model's replica set as seen at selection time. Size is the
-// configured replica count (a pool of one can't route anywhere).
-// Candidates are the breaker-closed replicas — the stable HRW membership of
-// §5.3 — falling back to all replicas when every breaker is open, mirroring
-// the degraded fallback of the production selector and §5.5's select().
+// Pool is a model's replica set at selection time. Size is the configured
+// replica count. Candidates are the breaker-closed replicas, falling back
+// to all replicas when every breaker is open.
 type Pool struct {
 	Size       int
 	Candidates []Candidate
 }
 
 // rank orders candidates by rendezvous (HRW) score for key, highest first:
-//
-//	score(replica) = xxhash64(routing_key ‖ replica.host)
-//
-// No framing is needed inside the score: the key is fixed-width, so the
-// field boundary can't shift, and xxhash only has to spread an
-// already-uniform input (§6). Ties — vanishingly rare with 64-bit scores —
-// break to the lexicographically smaller host so every router breaks them
-// identically. rank sorts a copy; the caller's slice is untouched.
+// score = xxhash64(key ‖ host). The key is fixed-width and already
+// uniformly distributed, so no framing or cryptographic hash is needed.
+// Ties break to the lexicographically smaller host so every router agrees.
+// The caller's slice is not modified.
 func rank(key Key, candidates []Candidate) []Candidate {
 	ranked := slices.Clone(candidates)
 	scores := make(map[string]uint64, len(ranked))
@@ -59,9 +52,8 @@ func rank(key Key, candidates []Candidate) []Candidate {
 	return ranked
 }
 
-// replicationFactor is R, the size of a key's warm set (§5.4): roughly one
-// replica per replica's-worth of traffic, at least the home, at most the
-// whole pool. Below the threshold R = 1 and nothing changes for normal keys.
+// replicationFactor is the size of a key's warm set: roughly one replica
+// per replica's-worth of traffic, at least 1, at most the pool.
 func replicationFactor(rpm, thresholdRPM float64, poolSize int) int {
 	if thresholdRPM <= 0 || poolSize <= 1 {
 		return 1
@@ -76,10 +68,8 @@ func replicationFactor(rpm, thresholdRPM float64, poolSize int) int {
 	return r
 }
 
-// leastLoaded picks the candidate with the fewest in-flight requests,
-// breaking ties toward the earlier (higher-ranked) entry so the pick is
-// deterministic and favors the key's home. Callers pass the top R of an HRW
-// ranking; with R = 1 this is simply the home.
+// leastLoaded picks the candidate with the fewest in-flight requests; ties
+// go to the earlier (higher-ranked) entry, favoring the key's home.
 func leastLoaded(ranked []Candidate) Candidate {
 	best := ranked[0]
 	for _, c := range ranked[1:] {

--- a/cacheroute/hrw.go
+++ b/cacheroute/hrw.go
@@ -1,0 +1,91 @@
+package cacheroute
+
+import (
+	"math"
+	"slices"
+	"strings"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+// Candidate is one replica the selector could pick: its stable enclave
+// hostname (the HRW identity — it must survive redeploys, §5.2) and its
+// current router-local in-flight request count (the live load signal for
+// splitting hot keys, §5.4/§5.5).
+type Candidate struct {
+	Host     string
+	InFlight int
+}
+
+// Pool is a model's replica set as seen at selection time. Size is the
+// configured replica count (a pool of one can't route anywhere).
+// Candidates are the breaker-closed replicas — the stable HRW membership of
+// §5.3 — falling back to all replicas when every breaker is open, mirroring
+// the degraded fallback of the production selector and §5.5's select().
+type Pool struct {
+	Size       int
+	Candidates []Candidate
+}
+
+// rank orders candidates by rendezvous (HRW) score for key, highest first:
+//
+//	score(replica) = xxhash64(routing_key ‖ replica.host)
+//
+// No framing is needed inside the score: the key is fixed-width, so the
+// field boundary can't shift, and xxhash only has to spread an
+// already-uniform input (§6). Ties — vanishingly rare with 64-bit scores —
+// break to the lexicographically smaller host so every router breaks them
+// identically. rank sorts a copy; the caller's slice is untouched.
+func rank(key Key, candidates []Candidate) []Candidate {
+	ranked := slices.Clone(candidates)
+	scores := make(map[string]uint64, len(ranked))
+	var d xxhash.Digest
+	for _, c := range ranked {
+		d.Reset()
+		d.Write(key[:])
+		d.WriteString(c.Host)
+		scores[c.Host] = d.Sum64()
+	}
+	slices.SortFunc(ranked, func(a, b Candidate) int {
+		switch sa, sb := scores[a.Host], scores[b.Host]; {
+		case sa > sb:
+			return -1
+		case sa < sb:
+			return 1
+		default:
+			return strings.Compare(a.Host, b.Host)
+		}
+	})
+	return ranked
+}
+
+// replicationFactor is R, the size of a key's warm set (§5.4): roughly one
+// replica per replica's-worth of traffic, at least the home, at most the
+// whole pool. Below the threshold R = 1 and nothing changes for normal keys.
+func replicationFactor(rpm, thresholdRPM float64, poolSize int) int {
+	if thresholdRPM <= 0 || poolSize <= 1 {
+		return 1
+	}
+	r := int(math.Ceil(rpm / thresholdRPM))
+	if r < 1 {
+		r = 1
+	}
+	if r > poolSize {
+		r = poolSize
+	}
+	return r
+}
+
+// leastLoaded picks the candidate with the fewest in-flight requests,
+// breaking ties toward the earlier (higher-ranked) entry so the pick is
+// deterministic and favors the key's home. Callers pass the top R of an HRW
+// ranking; with R = 1 this is simply the home.
+func leastLoaded(ranked []Candidate) Candidate {
+	best := ranked[0]
+	for _, c := range ranked[1:] {
+		if c.InFlight < best.InFlight {
+			best = c
+		}
+	}
+	return best
+}

--- a/cacheroute/hrw_test.go
+++ b/cacheroute/hrw_test.go
@@ -1,0 +1,133 @@
+package cacheroute
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tinfoilsh/confidential-model-router/cachesalt"
+)
+
+func testKey(i int) Key {
+	return Key(cachesalt.Sum("tinfoil/test/v1", fmt.Sprintf("key-%d", i)))
+}
+
+func hosts(names ...string) []Candidate {
+	c := make([]Candidate, len(names))
+	for i, n := range names {
+		c[i] = Candidate{Host: n}
+	}
+	return c
+}
+
+func rankedHosts(key Key, candidates []Candidate) []string {
+	ranked := rank(key, candidates)
+	out := make([]string, len(ranked))
+	for i, c := range ranked {
+		out[i] = c.Host
+	}
+	return out
+}
+
+func TestRankDeterministicAndNonMutating(t *testing.T) {
+	candidates := hosts("c", "a", "d", "b")
+	key := testKey(1)
+
+	first := rankedHosts(key, candidates)
+	for range 10 {
+		if got := rankedHosts(key, candidates); fmt.Sprint(got) != fmt.Sprint(first) {
+			t.Fatalf("ranking not deterministic: %v vs %v", got, first)
+		}
+	}
+	// Input order must not matter (the score is order-free), and the input
+	// slice must not be reordered.
+	if got := rankedHosts(key, hosts("a", "b", "c", "d")); fmt.Sprint(got) != fmt.Sprint(first) {
+		t.Fatalf("ranking depends on input order: %v vs %v", got, first)
+	}
+	if candidates[0].Host != "c" || candidates[3].Host != "b" {
+		t.Fatal("rank mutated the caller's slice")
+	}
+}
+
+// TestRankSubsetStability is HRW's defining property: removing a replica
+// re-homes only the keys that ranked it first.
+func TestRankSubsetStability(t *testing.T) {
+	full := hosts("h1", "h2", "h3", "h4")
+	for i := range 300 {
+		key := testKey(i)
+		ranked := rankedHosts(key, full)
+		home, second := ranked[0], ranked[1]
+
+		// Drop a non-home replica: home must not move.
+		var withoutOther []Candidate
+		for _, c := range full {
+			if c.Host != ranked[3] {
+				withoutOther = append(withoutOther, c)
+			}
+		}
+		if got := rankedHosts(key, withoutOther)[0]; got != home {
+			t.Fatalf("key %d re-homed from %s to %s when a non-home replica left", i, home, got)
+		}
+
+		// Drop the home: the new home must be the old second choice.
+		var withoutHome []Candidate
+		for _, c := range full {
+			if c.Host != home {
+				withoutHome = append(withoutHome, c)
+			}
+		}
+		if got := rankedHosts(key, withoutHome)[0]; got != second {
+			t.Fatalf("key %d: home fell to %s, want old rank-1 %s", i, got, second)
+		}
+	}
+}
+
+func TestRankDistribution(t *testing.T) {
+	full := hosts("h1", "h2", "h3", "h4")
+	counts := map[string]int{}
+	const n = 4000
+	for i := range n {
+		counts[rankedHosts(testKey(i), full)[0]]++
+	}
+	for host, c := range counts {
+		share := float64(c) / n
+		if share < 0.18 || share > 0.32 {
+			t.Errorf("host %s owns %.1f%% of homes, want ≈25%%", host, share*100)
+		}
+	}
+}
+
+func TestReplicationFactor(t *testing.T) {
+	tests := []struct {
+		rpm       float64
+		threshold float64
+		pool      int
+		want      int
+	}{
+		{1, 15, 4, 1},
+		{15, 15, 4, 1},
+		{16, 15, 4, 2},
+		{31, 15, 4, 3},
+		{1000, 15, 4, 4}, // clamped to pool
+		{1000, 15, 1, 1}, // single replica: nothing to split across
+		{10, 0, 4, 1},    // degenerate threshold: never split
+	}
+	for _, tt := range tests {
+		if got := replicationFactor(tt.rpm, tt.threshold, tt.pool); got != tt.want {
+			t.Errorf("replicationFactor(%v, %v, %d) = %d, want %d", tt.rpm, tt.threshold, tt.pool, got, tt.want)
+		}
+	}
+}
+
+func TestLeastLoaded(t *testing.T) {
+	ranked := []Candidate{{Host: "home", InFlight: 5}, {Host: "second", InFlight: 2}, {Host: "third", InFlight: 2}}
+	if got := leastLoaded(ranked); got.Host != "second" {
+		t.Errorf("leastLoaded = %s, want second (fewest in-flight, earliest rank on tie)", got.Host)
+	}
+	if got := leastLoaded(ranked[:1]); got.Host != "home" {
+		t.Errorf("leastLoaded of one = %s, want home", got.Host)
+	}
+	even := []Candidate{{Host: "home", InFlight: 1}, {Host: "second", InFlight: 1}}
+	if got := leastLoaded(even); got.Host != "home" {
+		t.Errorf("tie must favor the higher-ranked candidate, got %s", got.Host)
+	}
+}

--- a/cacheroute/metrics.go
+++ b/cacheroute/metrics.go
@@ -1,0 +1,242 @@
+package cacheroute
+
+import (
+	"encoding/hex"
+	"slices"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/tinfoilsh/confidential-model-router/cachesalt"
+	"github.com/tinfoilsh/confidential-model-router/config"
+)
+
+// The Phase 4 metric contract (implementation plan, Phase 4). Names are
+// phase-neutral — the same pipeline keeps emitting them when Phase 5 flips to
+// acting, so the flip is verified on the same Grafana panels. Every label is
+// a closed enum; per-key values must never appear as labels (a key-derived
+// label would be a stable pseudonymous user identifier and unbounded
+// cardinality). Per-enclave counters are the same exposure class as the
+// existing router_proxy_success_total{model, enclave}.
+var (
+	// RequestsTotal is the eligibility funnel — the denominator for every
+	// other panel, and (via outcome="error") proof the shadow path never
+	// fails a request.
+	RequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_cache_route_requests_total",
+			Help: "Requests seen by the cache-route pipeline, by eligibility outcome (keyed, no_salt, no_prefix, below_floor, pool_too_small, error)",
+		},
+		[]string{"model", "outcome"},
+	)
+
+	// ReuseTotal classifies each keyed request against where the actual
+	// pick landed: first_seen, repeat_warm (the pick was already warm for
+	// this key), repeat_cold (the key was warm somewhere else — the prize
+	// shadow mode exists to size; under enforcement it collapsing toward
+	// zero is the success signal).
+	ReuseTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_cache_route_reuse_total",
+			Help: "Keyed requests by prefix-reuse classification against the actual pick (first_seen, repeat_warm, repeat_cold)",
+		},
+		[]string{"model", "outcome"},
+	)
+
+	// ReusePromptBytesTotal is ReuseTotal weighted by prompt bytes, the
+	// prefill-cost proxy: read the prize byte-weighted first.
+	ReusePromptBytesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_cache_route_reuse_prompt_bytes_total",
+			Help: "Prompt bytes of keyed requests by prefix-reuse classification (first_seen, repeat_warm, repeat_cold)",
+		},
+		[]string{"model", "outcome"},
+	)
+
+	// PicksTotal is the would-be pick per keyed request with the key's
+	// replication factor at pick time. Balance across enclaves answers
+	// exit question 2; the r split answers question 3.
+	PicksTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_cache_route_picks_total",
+			Help: "Would-be cache-aware picks by enclave and replication factor at pick time",
+		},
+		[]string{"model", "enclave", "r"},
+	)
+
+	// RandomMatchTotal counts keyed requests where the would-be pick
+	// equals the production random pick: ≈ 1/N is the pipeline sanity
+	// check, and 1 − match rate sizes how much traffic moves at the
+	// Phase 5 flip. Goes quiet under enforcement.
+	RandomMatchTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_cache_route_random_match_total",
+			Help: "Keyed requests whose would-be cache-aware pick equals the actual random pick",
+		},
+		[]string{"model"},
+	)
+
+	// RepeatIntervalSeconds validates W against real re-arrival spacing.
+	// Buckets must straddle every candidate W (1 s – 30 min); the shadow
+	// table retains keys past W so mass beyond the window is visible
+	// rather than truncated at it.
+	RepeatIntervalSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "router_cache_route_repeat_interval_seconds",
+			Help:    "Time since a routing key was last seen, observed on repeats",
+			Buckets: []float64{1, 5, 15, 60, 300, 900, 1800, 3600},
+		},
+		[]string{"model"},
+	)
+
+	// KeyRPM places the hot-key split threshold before anything acts.
+	// Buckets must straddle the candidate threshold (1 – 300 rpm;
+	// OpenAI's figure is ~15).
+	KeyRPM = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "router_cache_route_key_rpm",
+			Help:    "Observed per-key request rate (requests/minute) at request time",
+			Buckets: []float64{1, 2, 5, 10, 15, 30, 60, 120, 300},
+		},
+		[]string{"model"},
+	)
+
+	// KeyEvictionsTotal separates normal turnover (ttl) from classification
+	// bias (capacity): a table at capacity misclassifies genuine repeats
+	// as first-seen and understates the prize, so capacity must sit ≈ 0.
+	KeyEvictionsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_cache_route_key_evictions_total",
+			Help: "Shadow-table key evictions by reason (ttl, capacity)",
+		},
+		[]string{"model", "reason"},
+	)
+
+	// ComputeSeconds is the full shadow-path cost per request (extraction
+	// + observation) — the "shadow is free" proof, needed because there is
+	// no profiler in the enclave either. p99 must stay well under 1 ms.
+	ComputeSeconds = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "router_cache_route_compute_seconds",
+			Help:    "Wall time spent in the cache-route shadow path per request",
+			Buckets: []float64{1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3, 5e-3, 1e-2},
+		},
+	)
+
+	// PoolInfo pins each model's configured replica-set view. Equal
+	// pool_hash across router instances ⇒ identical HRW views, and with
+	// keyless derivation (§6) identical views ⇒ identical homes by
+	// construction — the continuous replacement for a cross-router
+	// spot-check.
+	PoolInfo = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "router_cache_route_pool_info",
+			Help: "Constant 1, labeled with a short hash of the model's sorted configured replica hostnames",
+		},
+		[]string{"model", "pool_hash"},
+	)
+
+	// ModeInfo exposes the per-pool rollout state (off, shadow, enforced)
+	// so dashboards read the phase from data, not deploy folklore. It
+	// reports the effective mode this build runs, after any clamping.
+	ModeInfo = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "router_cache_route_mode",
+			Help: "Constant 1, labeled with the effective cache-route mode for the model (off, shadow, enforced)",
+		},
+		[]string{"model", "mode"},
+	)
+
+	// trackedKeysDesc describes the router_cache_route_tracked_keys gauge,
+	// emitted by Shadow's Collect: live shadow-table keys by current HRW
+	// home and replication factor — the distinct-key view for exit
+	// questions 2 and 3. It is a custom collector because the values are
+	// walked from the table at scrape time.
+	trackedKeysDesc = prometheus.NewDesc(
+		"router_cache_route_tracked_keys",
+		"Live shadow-table routing keys by HRW home enclave and current replication factor",
+		[]string{"model", "enclave", "r"},
+		nil,
+	)
+)
+
+// poolInfoDomainTag namespaces the pool_hash derivation. Same constraint as
+// every other tag: fixed constant, no tag a prefix of another.
+const poolInfoDomainTag = "tinfoil/route-pool/v1"
+
+// infoMu guards lastPoolHash and lastMode, which remember each model's
+// current info-label values so a change replaces the old series instead of
+// leaving a stale one alongside it.
+var (
+	infoMu       sync.Mutex
+	lastPoolHash = map[string]string{}
+	lastMode     = map[string]Mode{}
+)
+
+// SetPoolInfo publishes the pool_info series for a model from its configured
+// enclave hostnames (order-insensitive), replacing any previous series. Empty
+// hostnames delete the series — the model has no pool to agree on.
+func SetPoolInfo(model string, hostnames []string) {
+	sorted := make([]string, len(hostnames))
+	copy(sorted, hostnames)
+	slices.Sort(sorted)
+	hash := ""
+	if len(sorted) > 0 {
+		sum := cachesalt.Sum(poolInfoDomainTag, sorted...)
+		hash = hex.EncodeToString(sum[:4])
+	}
+
+	infoMu.Lock()
+	defer infoMu.Unlock()
+	if prev, ok := lastPoolHash[model]; ok && prev != hash {
+		PoolInfo.DeleteLabelValues(model, prev)
+	}
+	if hash == "" {
+		delete(lastPoolHash, model)
+		return
+	}
+	lastPoolHash[model] = hash
+	PoolInfo.WithLabelValues(model, hash).Set(1)
+}
+
+// SetMode publishes the mode series for a model from its raw config block,
+// replacing any previous series. It logs when it clamps a configured
+// "enforced" down to shadow (this build measures only; Phase 5 acts), so the
+// config's intent and the router's behavior can't silently diverge.
+func SetMode(model string, cfg *config.CacheRouteConfig) {
+	raw := ""
+	if cfg != nil {
+		raw = cfg.Mode
+	}
+	mode, clamped := resolveMode(raw)
+	if clamped {
+		log.WithFields(log.Fields{
+			"model": model,
+			"mode":  raw,
+		}).Warn("cache_route mode 'enforced' is not implemented in this build; running shadow")
+	}
+
+	infoMu.Lock()
+	defer infoMu.Unlock()
+	if prev, ok := lastMode[model]; ok && prev != mode {
+		ModeInfo.DeleteLabelValues(model, string(prev))
+	}
+	lastMode[model] = mode
+	ModeInfo.WithLabelValues(model, string(mode)).Set(1)
+}
+
+// DropModel removes a model's info series when it leaves the config.
+func DropModel(model string) {
+	infoMu.Lock()
+	defer infoMu.Unlock()
+	if prev, ok := lastPoolHash[model]; ok {
+		PoolInfo.DeleteLabelValues(model, prev)
+		delete(lastPoolHash, model)
+	}
+	if prev, ok := lastMode[model]; ok {
+		ModeInfo.DeleteLabelValues(model, string(prev))
+		delete(lastMode, model)
+	}
+}

--- a/cacheroute/metrics.go
+++ b/cacheroute/metrics.go
@@ -13,17 +13,12 @@ import (
 	"github.com/tinfoilsh/confidential-model-router/config"
 )
 
-// The Phase 4 metric contract (implementation plan, Phase 4). Names are
-// phase-neutral — the same pipeline keeps emitting them when Phase 5 flips to
-// acting, so the flip is verified on the same Grafana panels. Every label is
-// a closed enum; per-key values must never appear as labels (a key-derived
-// label would be a stable pseudonymous user identifier and unbounded
-// cardinality). Per-enclave counters are the same exposure class as the
-// existing router_proxy_success_total{model, enclave}.
+// Every label below is a closed enum. A routing key, or anything derived
+// from one, must never appear as a label value: it would be unbounded
+// cardinality and a stable pseudonymous user identifier.
 var (
-	// RequestsTotal is the eligibility funnel — the denominator for every
-	// other panel, and (via outcome="error") proof the shadow path never
-	// fails a request.
+	// RequestsTotal is the eligibility funnel. outcome="error" counts
+	// recovered panics and must stay ≈ 0.
 	RequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_cache_route_requests_total",
@@ -32,11 +27,9 @@ var (
 		[]string{"model", "outcome"},
 	)
 
-	// ReuseTotal classifies each keyed request against where the actual
-	// pick landed: first_seen, repeat_warm (the pick was already warm for
-	// this key), repeat_cold (the key was warm somewhere else — the prize
-	// shadow mode exists to size; under enforcement it collapsing toward
-	// zero is the success signal).
+	// ReuseTotal classifies keyed requests against where the actual pick
+	// landed. repeat_cold = the prefix was warm on a replica the pick
+	// missed, i.e. the reuse cache-aware routing would have captured.
 	ReuseTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_cache_route_reuse_total",
@@ -45,8 +38,8 @@ var (
 		[]string{"model", "outcome"},
 	)
 
-	// ReusePromptBytesTotal is ReuseTotal weighted by prompt bytes, the
-	// prefill-cost proxy: read the prize byte-weighted first.
+	// ReusePromptBytesTotal weights ReuseTotal by prompt bytes, since
+	// prefill cost scales with prompt size.
 	ReusePromptBytesTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_cache_route_reuse_prompt_bytes_total",
@@ -55,9 +48,8 @@ var (
 		[]string{"model", "outcome"},
 	)
 
-	// PicksTotal is the would-be pick per keyed request with the key's
-	// replication factor at pick time. Balance across enclaves answers
-	// exit question 2; the r split answers question 3.
+	// PicksTotal counts the would-be pick per enclave, with the key's
+	// replication factor at pick time.
 	PicksTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_cache_route_picks_total",
@@ -66,10 +58,8 @@ var (
 		[]string{"model", "enclave", "r"},
 	)
 
-	// RandomMatchTotal counts keyed requests where the would-be pick
-	// equals the production random pick: ≈ 1/N is the pipeline sanity
-	// check, and 1 − match rate sizes how much traffic moves at the
-	// Phase 5 flip. Goes quiet under enforcement.
+	// RandomMatchTotal counts keyed requests whose would-be pick equals
+	// the actual random pick; expect ≈ 1/pool-size.
 	RandomMatchTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_cache_route_random_match_total",
@@ -78,10 +68,8 @@ var (
 		[]string{"model"},
 	)
 
-	// RepeatIntervalSeconds validates W against real re-arrival spacing.
-	// Buckets must straddle every candidate W (1 s – 30 min); the shadow
-	// table retains keys past W so mass beyond the window is visible
-	// rather than truncated at it.
+	// RepeatIntervalSeconds measures time between sightings of a key.
+	// Buckets straddle every plausible retention window.
 	RepeatIntervalSeconds = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "router_cache_route_repeat_interval_seconds",
@@ -91,9 +79,8 @@ var (
 		[]string{"model"},
 	)
 
-	// KeyRPM places the hot-key split threshold before anything acts.
-	// Buckets must straddle the candidate threshold (1 – 300 rpm;
-	// OpenAI's figure is ~15).
+	// KeyRPM is the per-key request rate observed at request time.
+	// Buckets straddle every plausible split threshold.
 	KeyRPM = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "router_cache_route_key_rpm",
@@ -103,9 +90,9 @@ var (
 		[]string{"model"},
 	)
 
-	// KeyEvictionsTotal separates normal turnover (ttl) from classification
-	// bias (capacity): a table at capacity misclassifies genuine repeats
-	// as first-seen and understates the prize, so capacity must sit ≈ 0.
+	// KeyEvictionsTotal separates normal turnover (ttl) from table
+	// pressure (capacity). Capacity evictions make genuine repeats look
+	// first-seen and bias reuse counts low — keep ≈ 0 by sizing the table.
 	KeyEvictionsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_cache_route_key_evictions_total",
@@ -114,9 +101,8 @@ var (
 		[]string{"model", "reason"},
 	)
 
-	// ComputeSeconds is the full shadow-path cost per request (extraction
-	// + observation) — the "shadow is free" proof, needed because there is
-	// no profiler in the enclave either. p99 must stay well under 1 ms.
+	// ComputeSeconds is the shadow path's per-request cost; p99 should
+	// stay well under 1ms.
 	ComputeSeconds = promauto.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "router_cache_route_compute_seconds",
@@ -125,11 +111,9 @@ var (
 		},
 	)
 
-	// PoolInfo pins each model's configured replica-set view. Equal
-	// pool_hash across router instances ⇒ identical HRW views, and with
-	// keyless derivation (§6) identical views ⇒ identical homes by
-	// construction — the continuous replacement for a cross-router
-	// spot-check.
+	// PoolInfo pins each model's configured replica-set view. Router
+	// instances that disagree on pool_hash compute different HRW rankings
+	// for the same key.
 	PoolInfo = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "router_cache_route_pool_info",
@@ -138,9 +122,8 @@ var (
 		[]string{"model", "pool_hash"},
 	)
 
-	// ModeInfo exposes the per-pool rollout state (off, shadow, enforced)
-	// so dashboards read the phase from data, not deploy folklore. It
-	// reports the effective mode this build runs, after any clamping.
+	// ModeInfo reports the effective cache-route mode per model, after any
+	// clamping.
 	ModeInfo = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "router_cache_route_mode",
@@ -149,11 +132,8 @@ var (
 		[]string{"model", "mode"},
 	)
 
-	// trackedKeysDesc describes the router_cache_route_tracked_keys gauge,
-	// emitted by Shadow's Collect: live shadow-table keys by current HRW
-	// home and replication factor — the distinct-key view for exit
-	// questions 2 and 3. It is a custom collector because the values are
-	// walked from the table at scrape time.
+	// trackedKeysDesc describes the gauge Shadow.Collect emits at scrape
+	// time: live table keys by HRW home and replication factor.
 	trackedKeysDesc = prometheus.NewDesc(
 		"router_cache_route_tracked_keys",
 		"Live shadow-table routing keys by HRW home enclave and current replication factor",
@@ -162,13 +142,12 @@ var (
 	)
 )
 
-// poolInfoDomainTag namespaces the pool_hash derivation. Same constraint as
-// every other tag: fixed constant, no tag a prefix of another.
+// poolInfoDomainTag namespaces the pool_hash derivation; no tag in the
+// router may be a prefix of another.
 const poolInfoDomainTag = "tinfoil/route-pool/v1"
 
-// infoMu guards lastPoolHash and lastMode, which remember each model's
-// current info-label values so a change replaces the old series instead of
-// leaving a stale one alongside it.
+// infoMu guards the last-published info labels so a change replaces the old
+// series instead of leaving a stale one beside it.
 var (
 	infoMu       sync.Mutex
 	lastPoolHash = map[string]string{}
@@ -176,8 +155,7 @@ var (
 )
 
 // SetPoolInfo publishes the pool_info series for a model from its configured
-// enclave hostnames (order-insensitive), replacing any previous series. Empty
-// hostnames delete the series — the model has no pool to agree on.
+// enclave hostnames (order-insensitive). Empty hostnames delete the series.
 func SetPoolInfo(model string, hostnames []string) {
 	sorted := make([]string, len(hostnames))
 	copy(sorted, hostnames)
@@ -201,10 +179,9 @@ func SetPoolInfo(model string, hostnames []string) {
 	PoolInfo.WithLabelValues(model, hash).Set(1)
 }
 
-// SetMode publishes the mode series for a model from its raw config block,
-// replacing any previous series. It logs when it clamps a configured
-// "enforced" down to shadow (this build measures only; Phase 5 acts), so the
-// config's intent and the router's behavior can't silently diverge.
+// SetMode publishes the effective mode for a model, logging when it clamps
+// a configured "enforced" down to shadow so config intent and router
+// behavior can't silently diverge.
 func SetMode(model string, cfg *config.CacheRouteConfig) {
 	raw := ""
 	if cfg != nil {

--- a/cacheroute/metrics.go
+++ b/cacheroute/metrics.go
@@ -49,7 +49,9 @@ var (
 	)
 
 	// PicksTotal counts the would-be pick per enclave, with the key's
-	// replication factor at pick time.
+	// replication factor at pick time. Requests served from outside the
+	// ranked membership (breaker probes) are excluded, so this is also the
+	// denominator for the match rate.
 	PicksTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_cache_route_picks_total",
@@ -59,7 +61,8 @@ var (
 	)
 
 	// RandomMatchTotal counts keyed requests whose would-be pick equals
-	// the actual random pick; expect ≈ 1/pool-size.
+	// the actual random pick; expect RandomMatchTotal/PicksTotal ≈
+	// 1/pool-size.
 	RandomMatchTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_cache_route_random_match_total",

--- a/cacheroute/metrics_test.go
+++ b/cacheroute/metrics_test.go
@@ -7,10 +7,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// TestMetricContract pins the Phase 4 metric contract: every metric name and
-// label set the implementation plan documents (and Grafana panels are built
-// on) must appear in the exposition exactly as specified. A rename or label
-// change here is a dashboard-breaking change and must be deliberate.
+// TestMetricContract pins the metric surface Grafana panels are built on:
+// every name and label set must appear in the exposition exactly as listed.
+// A rename or label change here breaks dashboards and must be deliberate.
 func TestMetricContract(t *testing.T) {
 	s, clock, reg := newTestShadow(t)
 	model := "contract-" + t.Name()

--- a/cacheroute/metrics_test.go
+++ b/cacheroute/metrics_test.go
@@ -1,0 +1,102 @@
+package cacheroute
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestMetricContract pins the Phase 4 metric contract: every metric name and
+// label set the implementation plan documents (and Grafana panels are built
+// on) must appear in the exposition exactly as specified. A rename or label
+// change here is a dashboard-breaking change and must be deliberate.
+func TestMetricContract(t *testing.T) {
+	s, clock, reg := newTestShadow(t)
+	model := "contract-" + t.Name()
+	cfg := defaultSettings()
+
+	// Touch every metric: one ineligible request, several keyed ones
+	// (repeat + hot enough to exist), one recovered panic, one capacity
+	// path via the info setters.
+	s.Observe(model, &Request{Outcome: OutcomeNoSalt}, pool2(), "enclave-a", cfg)
+	req := keyedRequest(t, "contract", 1)
+	for range 3 {
+		clock.advance(time.Second)
+		s.Observe(model, req, pool2(), "enclave-a", cfg)
+	}
+	s.Observe(model, nil, pool2(), "enclave-a", cfg) // recovered panic
+	SetPoolInfo(model, []string{"enclave-a", "enclave-b"})
+	SetMode(model, nil)
+	t.Cleanup(func() { DropModel(model) })
+
+	// Materialize zero-valued children for counters whose samples depend
+	// on traffic specifics (an eviction happening, a pick agreeing with
+	// random) — the contract under test is names and label sets, not
+	// values.
+	KeyEvictionsTotal.WithLabelValues(model, "ttl")
+	RandomMatchTotal.WithLabelValues(model)
+
+	want := map[string][]string{
+		"router_cache_route_requests_total":           {"model", "outcome"},
+		"router_cache_route_reuse_total":              {"model", "outcome"},
+		"router_cache_route_reuse_prompt_bytes_total": {"model", "outcome"},
+		"router_cache_route_picks_total":              {"model", "enclave", "r"},
+		"router_cache_route_random_match_total":       {"model"},
+		"router_cache_route_repeat_interval_seconds":  {"model"},
+		"router_cache_route_key_rpm":                  {"model"},
+		"router_cache_route_key_evictions_total":      {"model", "reason"},
+		"router_cache_route_compute_seconds":          {},
+		"router_cache_route_pool_info":                {"model", "pool_hash"},
+		"router_cache_route_mode":                     {"model", "mode"},
+		"router_cache_route_tracked_keys":             {"model", "enclave", "r"},
+	}
+
+	// The static metrics live on the default registerer (promauto); the
+	// tracked-keys collector lives on the Shadow's registry.
+	found := map[string][]string{}
+	for _, g := range []prometheus.Gatherer{prometheus.DefaultGatherer, reg} {
+		families, err := g.Gather()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, mf := range families {
+			name := mf.GetName()
+			if _, wanted := want[name]; !wanted {
+				continue
+			}
+			var labels []string
+			for _, lp := range mf.GetMetric()[0].GetLabel() {
+				labels = append(labels, lp.GetName())
+			}
+			found[name] = labels
+		}
+	}
+
+	for name, wantLabels := range want {
+		gotLabels, ok := found[name]
+		if !ok {
+			t.Errorf("contract metric %s missing from exposition", name)
+			continue
+		}
+		got := map[string]bool{}
+		for _, l := range gotLabels {
+			got[l] = true
+		}
+		if len(got) != len(wantLabels) {
+			t.Errorf("%s labels = %v, want %v", name, gotLabels, wantLabels)
+			continue
+		}
+		for _, l := range wantLabels {
+			if !got[l] {
+				t.Errorf("%s labels = %v, want %v", name, gotLabels, wantLabels)
+			}
+		}
+	}
+	// The eviction counter has no samples in this scenario (nothing
+	// evicted), so it is exercised separately: it must at least be
+	// registered under the contract name via its vec type.
+	if _, err := KeyEvictionsTotal.GetMetricWithLabelValues(model, "capacity"); err != nil {
+		t.Errorf("key_evictions_total unusable: %v", err)
+	}
+}

--- a/cacheroute/shadow.go
+++ b/cacheroute/shadow.go
@@ -9,52 +9,40 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// DefaultMaxKeys bounds the shadow table. At a few hundred bytes per entry
-// this costs tens of MB. Size it so capacity evictions stay ≈ 0 — a table at
-// capacity misclassifies genuine repeats as first-seen and understates the
-// prize (watch router_cache_route_key_evictions_total{reason="capacity"}).
+// DefaultMaxKeys bounds the shadow table (a few hundred bytes per entry).
+// Size it so capacity evictions stay ≈ 0; see KeyEvictionsTotal.
 const DefaultMaxKeys = 100_000
 
-// retentionFactor extends entry lifetime past the classification window W.
-// Classification only trusts warmth within W, but the repeat-interval
-// histogram exists to validate W against real re-arrival spacing — which
-// requires seeing re-arrivals *beyond* W. Expiring entries exactly at W would
-// truncate the histogram at the window boundary and make the measurement an
-// artifact of itself.
+// retentionFactor keeps entries alive past the classification window so
+// RepeatIntervalSeconds can see re-arrivals beyond it. Expiring at exactly
+// the window would truncate the histogram at the very boundary the data is
+// meant to tune.
 const retentionFactor = 4
 
-// sweepInterval is how often the background sweeper drains expired entries.
-// Expiry is also enforced at touch time (stale warmth classifies as
-// first-seen), so the sweeper is purely a memory bound, not a correctness
-// one.
-const sweepInterval = 30 * time.Second
-
-// sweepChunk caps evictions per lock acquisition so a large expired backlog
-// (e.g. after an idle night) can't stall the request path behind one long
-// sweep.
-const sweepChunk = 1024
-
-// Reuse classifications, the outcome label values of ReuseTotal and
-// ReusePromptBytesTotal. Closed set; dashboards depend on them.
+// sweepInterval and sweepChunk bound the background eviction of expired
+// entries. Stale warmth is also handled at touch time, so sweeping is a
+// memory bound, not a correctness one.
 const (
-	// ReuseFirstSeen: the key is not in the table, or nothing is warm for
-	// it anymore.
+	sweepInterval = 30 * time.Second
+	sweepChunk    = 1024
+)
+
+// Reuse classifications for ReuseTotal and ReusePromptBytesTotal.
+const (
+	// ReuseFirstSeen: key not in the table, or nothing warm for it
+	// anymore.
 	ReuseFirstSeen = "first_seen"
-	// ReuseRepeatWarm: the actual pick was already warm for this key —
-	// random routing got the hit anyway.
+	// ReuseRepeatWarm: the actual pick was already warm for this key.
 	ReuseRepeatWarm = "repeat_warm"
-	// ReuseRepeatCold: the key is warm somewhere, but not where the pick
-	// landed. This is the prize shadow mode exists to size.
+	// ReuseRepeatCold: the key was warm somewhere other than the pick —
+	// the reuse cache-aware routing would have captured.
 	ReuseRepeatCold = "repeat_cold"
 )
 
-// Shadow is the cache-aware routing shadow tracker: one bounded, evicting
-// table keyed by routing key that answers, at request time, "have we seen
-// this key recently, and where did it land?" — the join a per-request
-// decision log would have enabled offline, done in-enclave because metrics
-// are the only telemetry channel out. Nothing in it is exported except the
-// aggregates in metrics.go and the tracked-keys gauge it emits as a
-// prometheus.Collector.
+// Shadow measures what cache-aware routing would do without acting: a
+// bounded, evicting table keyed by routing key records where each key's
+// requests actually landed, and Observe turns that into the aggregate
+// metrics in metrics.go. Per-key state never leaves this process.
 type Shadow struct {
 	mu      sync.Mutex
 	entries map[string]*entry // table key: model \x00 routing key
@@ -65,27 +53,23 @@ type Shadow struct {
 	done chan struct{}
 }
 
-// entry is the per-key shadow state. It never leaves the enclave.
+// entry is the per-key state.
 type entry struct {
 	model    string
 	lastSeen time.Time
 	expiry   time.Time
 
-	// warm records, per replica hostname, when this key last landed there
-	// — under random routing, "where this prefix is warm". Entries older
-	// than W are pruned on touch, so the map stays bounded by the pool
-	// size plus briefly-stale hosts.
+	// warm maps replica hostname → when this key last landed there.
+	// Entries older than the retention window are pruned on touch.
 	warm map[string]time.Time
 
-	// Sliding-window request rate (two fixed one-minute buckets,
-	// interpolated), modeled on ratelimit.RequestTracker.
+	// Two-bucket sliding-window request rate.
 	windowStart time.Time
 	prevCount   int
 	curCount    int
 
-	// home and r are the key's HRW rank-0 replica and replication factor
-	// as of the last observation, aggregated at scrape time into the
-	// tracked-keys gauge.
+	// Last observed HRW home and replication factor, aggregated into the
+	// tracked-keys gauge at scrape time.
 	home string
 	r    int
 
@@ -106,8 +90,8 @@ func WithMaxKeys(n int) Option {
 }
 
 // NewShadow creates a shadow tracker, registers its tracked-keys gauge with
-// reg (nil means the default registerer), and starts the background sweeper.
-// Callers own its lifetime: Close stops the sweeper.
+// reg (nil means the default registerer), and starts the background
+// sweeper. Close stops the sweeper.
 func NewShadow(reg prometheus.Registerer, opts ...Option) *Shadow {
 	s := &Shadow{
 		entries: make(map[string]*entry),
@@ -133,11 +117,9 @@ func (s *Shadow) Close() {
 }
 
 // Observe runs the shadow pipeline for one request after the production
-// selector has made its (still random) pick. It classifies the request
-// against the table, computes the would-be cache-aware pick, updates the
-// table, and increments metrics. It must never affect the request: any panic
-// is recovered into the error outcome, and its full cost is metered into
-// ComputeSeconds.
+// selector has picked a replica: classify the request against the table,
+// compute the would-be pick, update state, increment metrics. It must never
+// affect the request — panics are recovered into OutcomeError.
 func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost string, cfg Settings) {
 	start := time.Now()
 	defer func() {
@@ -160,9 +142,8 @@ func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost strin
 		return
 	}
 	if len(pool.Candidates) == 0 {
-		// Can't happen while the pool snapshot falls back to all
-		// replicas, but a ranking over nothing must not panic into the
-		// error counter for a shape difference.
+		// Unreachable while the pool snapshot falls back to all
+		// replicas, but never rank over nothing.
 		RequestsTotal.WithLabelValues(model, string(OutcomePoolTooSmall)).Inc()
 		return
 	}
@@ -182,25 +163,24 @@ func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost strin
 	}
 }
 
-// keyedResult carries everything observeKeyed computes under the lock so the
-// metric increments can happen outside it.
+// keyedResult is what observeKeyed computes under the lock, so the metric
+// increments can happen outside it.
 type keyedResult struct {
-	reuse    string        // ReuseTotal outcome label
-	repeat   bool          // whether the key was in the table (interval is meaningful)
-	interval time.Duration // time since the key was last seen
-	rpm      float64       // sliding-window request rate, including this request
-	pick     string        // would-be pick: least-loaded of the top-R ranking
-	r        int           // replication factor at pick time
+	reuse    string
+	repeat   bool // the key was already in the table
+	interval time.Duration
+	rpm      float64
+	pick     string // least-loaded of the top-R ranking
+	r        int
 }
 
-// observeKeyed does the table touch, classification, ranking, and state
-// update for one keyed request under a single lock acquisition.
+// observeKeyed does the table touch, classification, and ranking for one
+// keyed request under a single lock acquisition.
 func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, actualHost string, cfg Settings) keyedResult {
 	now := s.now()
-	// The table key is model-scoped: the routing key itself contains no
-	// model (§5.1), so the same salted prompt sent to two models derives
-	// the same key — but warm hostnames are per-model replicas, and
-	// cross-model hits must not pollute each other's classification.
+	// Scope the table key by model: the routing key contains no model id,
+	// so the same salted prompt sent to two models collides — but warmth
+	// is per-model replicas.
 	tableKey := model + "\x00" + string(key[:])
 
 	s.mu.Lock()
@@ -216,8 +196,6 @@ func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, act
 		res.interval = now.Sub(e.lastSeen)
 		s.lru.MoveToFront(e.elem)
 
-		// Prune warmth beyond the classification window; what's left is
-		// where the engine plausibly still holds this prefix.
 		for host, seen := range e.warm {
 			if now.Sub(seen) > cfg.Retention {
 				delete(e.warm, host)
@@ -225,8 +203,7 @@ func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, act
 		}
 		switch {
 		case len(e.warm) == 0:
-			// The key is back, but nothing is warm anymore —
-			// equivalent to a first sighting for cache purposes.
+			// Everything went stale: cache-wise a first sighting.
 			res.reuse = ReuseFirstSeen
 		case !e.warm[actualHost].IsZero():
 			res.reuse = ReuseRepeatWarm
@@ -249,8 +226,8 @@ func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, act
 	return res
 }
 
-// insertLocked adds a fresh entry, evicting the least-recently-used one when
-// the table is full. Must be called with s.mu held.
+// insertLocked adds a fresh entry, evicting the least-recently-used one at
+// capacity. Caller holds s.mu.
 func (s *Shadow) insertLocked(model, tableKey string, now time.Time) *entry {
 	if len(s.entries) >= s.maxKeys {
 		if back := s.lru.Back(); back != nil {
@@ -269,11 +246,9 @@ func (s *Shadow) insertLocked(model, tableKey string, now time.Time) *entry {
 	return e
 }
 
-// bumpRate records one request in the entry's rate window and returns the
-// sliding-window rate in requests/minute, including this request. Two fixed
-// one-minute buckets are interpolated by position within the current minute —
-// cheap, and smooth enough that the key_rpm histogram and R don't sawtooth at
-// minute boundaries.
+// bumpRate records one request and returns the sliding-window rate in
+// requests/minute: two fixed one-minute buckets, interpolated by position
+// within the current minute so the rate doesn't sawtooth at boundaries.
 func (e *entry) bumpRate(now time.Time) float64 {
 	minute := now.Truncate(time.Minute)
 	switch {
@@ -292,10 +267,7 @@ func (e *entry) bumpRate(now time.Time) float64 {
 	return float64(e.prevCount)*(1-frac) + float64(e.curCount)
 }
 
-// sweeper periodically drops expired entries from the cold end of the LRU.
-// Because a touch moves an entry to the front and pushes its expiry forward,
-// LRU order is expiry order, so sweeping pops from the back until it meets a
-// live entry — O(expired), not O(table).
+// sweeper drains expired entries until Close.
 func (s *Shadow) sweeper() {
 	ticker := time.NewTicker(sweepInterval)
 	defer ticker.Stop()
@@ -309,7 +281,10 @@ func (s *Shadow) sweeper() {
 	}
 }
 
-// sweep evicts expired entries in bounded chunks per lock acquisition.
+// sweep evicts expired entries from the cold end of the LRU in bounded
+// chunks per lock acquisition. Touches move entries to the front and push
+// expiry forward, so LRU order is expiry order and the scan is O(expired),
+// not O(table).
 func (s *Shadow) sweep() {
 	for {
 		evicted := 0
@@ -342,9 +317,9 @@ func (s *Shadow) Describe(ch chan<- *prometheus.Desc) {
 	ch <- trackedKeysDesc
 }
 
-// Collect implements prometheus.Collector: it walks the table and emits the
-// tracked-keys gauge — live keys by model, current HRW home, and current
-// replication factor. Only counts leave the lock; keys never do.
+// Collect implements prometheus.Collector: it aggregates live keys by
+// (model, home, replication factor). Only counts leave the lock; keys never
+// do.
 func (s *Shadow) Collect(ch chan<- prometheus.Metric) {
 	type group struct{ model, home, r string }
 	counts := make(map[group]int)

--- a/cacheroute/shadow.go
+++ b/cacheroute/shadow.go
@@ -175,10 +175,32 @@ func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost strin
 		RepeatIntervalSeconds.WithLabelValues(model).Observe(res.interval.Seconds())
 	}
 	KeyRPM.WithLabelValues(model).Observe(res.rpm)
+
+	// A breaker probe serves from outside the ranked membership (health
+	// beats cache), so the dispatch was not a random draw from the
+	// candidates and the pick-vs-random comparison is meaningless for it.
+	// Reuse and warmth above stay valid — the probe really warms that
+	// replica — but counting these requests in the pick metrics would
+	// deflate the match rate during exactly the degraded windows dashboards
+	// get read. Match rate = random_match / picks stays unbiased, and
+	// keyed − picks measures health-forced dispatch volume.
+	if !hostIn(pool.Candidates, actualHost) {
+		return
+	}
 	PicksTotal.WithLabelValues(model, res.pick, strconv.Itoa(res.r)).Inc()
 	if res.pick == actualHost {
 		RandomMatchTotal.WithLabelValues(model).Inc()
 	}
+}
+
+// hostIn reports whether host is one of the candidates.
+func hostIn(candidates []Candidate, host string) bool {
+	for _, c := range candidates {
+		if c.Host == host {
+			return true
+		}
+	}
+	return false
 }
 
 // keyedResult is what observeKeyed computes under the lock, so the metric

--- a/cacheroute/shadow.go
+++ b/cacheroute/shadow.go
@@ -1,0 +1,361 @@
+package cacheroute
+
+import (
+	"container/list"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// DefaultMaxKeys bounds the shadow table. At a few hundred bytes per entry
+// this costs tens of MB. Size it so capacity evictions stay ≈ 0 — a table at
+// capacity misclassifies genuine repeats as first-seen and understates the
+// prize (watch router_cache_route_key_evictions_total{reason="capacity"}).
+const DefaultMaxKeys = 100_000
+
+// retentionFactor extends entry lifetime past the classification window W.
+// Classification only trusts warmth within W, but the repeat-interval
+// histogram exists to validate W against real re-arrival spacing — which
+// requires seeing re-arrivals *beyond* W. Expiring entries exactly at W would
+// truncate the histogram at the window boundary and make the measurement an
+// artifact of itself.
+const retentionFactor = 4
+
+// sweepInterval is how often the background sweeper drains expired entries.
+// Expiry is also enforced at touch time (stale warmth classifies as
+// first-seen), so the sweeper is purely a memory bound, not a correctness
+// one.
+const sweepInterval = 30 * time.Second
+
+// sweepChunk caps evictions per lock acquisition so a large expired backlog
+// (e.g. after an idle night) can't stall the request path behind one long
+// sweep.
+const sweepChunk = 1024
+
+// Reuse classifications, the outcome label values of ReuseTotal and
+// ReusePromptBytesTotal. Closed set; dashboards depend on them.
+const (
+	// ReuseFirstSeen: the key is not in the table, or nothing is warm for
+	// it anymore.
+	ReuseFirstSeen = "first_seen"
+	// ReuseRepeatWarm: the actual pick was already warm for this key —
+	// random routing got the hit anyway.
+	ReuseRepeatWarm = "repeat_warm"
+	// ReuseRepeatCold: the key is warm somewhere, but not where the pick
+	// landed. This is the prize shadow mode exists to size.
+	ReuseRepeatCold = "repeat_cold"
+)
+
+// Shadow is the cache-aware routing shadow tracker: one bounded, evicting
+// table keyed by routing key that answers, at request time, "have we seen
+// this key recently, and where did it land?" — the join a per-request
+// decision log would have enabled offline, done in-enclave because metrics
+// are the only telemetry channel out. Nothing in it is exported except the
+// aggregates in metrics.go and the tracked-keys gauge it emits as a
+// prometheus.Collector.
+type Shadow struct {
+	mu      sync.Mutex
+	entries map[string]*entry // table key: model \x00 routing key
+	lru     *list.List        // front = most recently touched; values are table keys
+	maxKeys int
+
+	now  func() time.Time
+	done chan struct{}
+}
+
+// entry is the per-key shadow state. It never leaves the enclave.
+type entry struct {
+	model    string
+	lastSeen time.Time
+	expiry   time.Time
+
+	// warm records, per replica hostname, when this key last landed there
+	// — under random routing, "where this prefix is warm". Entries older
+	// than W are pruned on touch, so the map stays bounded by the pool
+	// size plus briefly-stale hosts.
+	warm map[string]time.Time
+
+	// Sliding-window request rate (two fixed one-minute buckets,
+	// interpolated), modeled on ratelimit.RequestTracker.
+	windowStart time.Time
+	prevCount   int
+	curCount    int
+
+	// home and r are the key's HRW rank-0 replica and replication factor
+	// as of the last observation, aggregated at scrape time into the
+	// tracked-keys gauge.
+	home string
+	r    int
+
+	elem *list.Element
+}
+
+// Option configures a Shadow.
+type Option func(*Shadow)
+
+// WithNowFunc injects a custom clock (for testing).
+func WithNowFunc(f func() time.Time) Option {
+	return func(s *Shadow) { s.now = f }
+}
+
+// WithMaxKeys overrides the table capacity (for testing).
+func WithMaxKeys(n int) Option {
+	return func(s *Shadow) { s.maxKeys = n }
+}
+
+// NewShadow creates a shadow tracker, registers its tracked-keys gauge with
+// reg (nil means the default registerer), and starts the background sweeper.
+// Callers own its lifetime: Close stops the sweeper.
+func NewShadow(reg prometheus.Registerer, opts ...Option) *Shadow {
+	s := &Shadow{
+		entries: make(map[string]*entry),
+		lru:     list.New(),
+		maxKeys: DefaultMaxKeys,
+		now:     time.Now,
+		done:    make(chan struct{}),
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+	reg.MustRegister(s)
+	go s.sweeper()
+	return s
+}
+
+// Close stops the background sweeper.
+func (s *Shadow) Close() {
+	close(s.done)
+}
+
+// Observe runs the shadow pipeline for one request after the production
+// selector has made its (still random) pick. It classifies the request
+// against the table, computes the would-be cache-aware pick, updates the
+// table, and increments metrics. It must never affect the request: any panic
+// is recovered into the error outcome, and its full cost is metered into
+// ComputeSeconds.
+func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost string, cfg Settings) {
+	start := time.Now()
+	defer func() {
+		if r := recover(); r != nil {
+			RequestsTotal.WithLabelValues(model, string(OutcomeError)).Inc()
+		}
+		var extraction time.Duration
+		if req != nil {
+			extraction = req.elapsed
+		}
+		ComputeSeconds.Observe((extraction + time.Since(start)).Seconds())
+	}()
+
+	if req.Outcome != OutcomeKeyed {
+		RequestsTotal.WithLabelValues(model, string(req.Outcome)).Inc()
+		return
+	}
+	if pool.Size < 2 {
+		RequestsTotal.WithLabelValues(model, string(OutcomePoolTooSmall)).Inc()
+		return
+	}
+	if len(pool.Candidates) == 0 {
+		// Can't happen while the pool snapshot falls back to all
+		// replicas, but a ranking over nothing must not panic into the
+		// error counter for a shape difference.
+		RequestsTotal.WithLabelValues(model, string(OutcomePoolTooSmall)).Inc()
+		return
+	}
+
+	res := s.observeKeyed(model, req.Key, pool.Candidates, actualHost, cfg)
+
+	RequestsTotal.WithLabelValues(model, string(OutcomeKeyed)).Inc()
+	ReuseTotal.WithLabelValues(model, res.reuse).Inc()
+	ReusePromptBytesTotal.WithLabelValues(model, res.reuse).Add(float64(req.PromptBytes))
+	if res.repeat {
+		RepeatIntervalSeconds.WithLabelValues(model).Observe(res.interval.Seconds())
+	}
+	KeyRPM.WithLabelValues(model).Observe(res.rpm)
+	PicksTotal.WithLabelValues(model, res.pick, strconv.Itoa(res.r)).Inc()
+	if res.pick == actualHost {
+		RandomMatchTotal.WithLabelValues(model).Inc()
+	}
+}
+
+// keyedResult carries everything observeKeyed computes under the lock so the
+// metric increments can happen outside it.
+type keyedResult struct {
+	reuse    string        // ReuseTotal outcome label
+	repeat   bool          // whether the key was in the table (interval is meaningful)
+	interval time.Duration // time since the key was last seen
+	rpm      float64       // sliding-window request rate, including this request
+	pick     string        // would-be pick: least-loaded of the top-R ranking
+	r        int           // replication factor at pick time
+}
+
+// observeKeyed does the table touch, classification, ranking, and state
+// update for one keyed request under a single lock acquisition.
+func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, actualHost string, cfg Settings) keyedResult {
+	now := s.now()
+	// The table key is model-scoped: the routing key itself contains no
+	// model (§5.1), so the same salted prompt sent to two models derives
+	// the same key — but warm hostnames are per-model replicas, and
+	// cross-model hits must not pollute each other's classification.
+	tableKey := model + "\x00" + string(key[:])
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var res keyedResult
+	e, ok := s.entries[tableKey]
+	if !ok {
+		e = s.insertLocked(model, tableKey, now)
+		res.reuse = ReuseFirstSeen
+	} else {
+		res.repeat = true
+		res.interval = now.Sub(e.lastSeen)
+		s.lru.MoveToFront(e.elem)
+
+		// Prune warmth beyond the classification window; what's left is
+		// where the engine plausibly still holds this prefix.
+		for host, seen := range e.warm {
+			if now.Sub(seen) > cfg.Retention {
+				delete(e.warm, host)
+			}
+		}
+		switch {
+		case len(e.warm) == 0:
+			// The key is back, but nothing is warm anymore —
+			// equivalent to a first sighting for cache purposes.
+			res.reuse = ReuseFirstSeen
+		case !e.warm[actualHost].IsZero():
+			res.reuse = ReuseRepeatWarm
+		default:
+			res.reuse = ReuseRepeatCold
+		}
+	}
+
+	res.rpm = e.bumpRate(now)
+	e.warm[actualHost] = now
+	e.lastSeen = now
+	e.expiry = now.Add(retentionFactor * cfg.Retention)
+
+	ranked := rank(key, candidates)
+	res.r = replicationFactor(res.rpm, cfg.SplitThresholdRPM, len(ranked))
+	res.pick = leastLoaded(ranked[:res.r]).Host
+	e.home = ranked[0].Host
+	e.r = res.r
+
+	return res
+}
+
+// insertLocked adds a fresh entry, evicting the least-recently-used one when
+// the table is full. Must be called with s.mu held.
+func (s *Shadow) insertLocked(model, tableKey string, now time.Time) *entry {
+	if len(s.entries) >= s.maxKeys {
+		if back := s.lru.Back(); back != nil {
+			evictKey := back.Value.(string)
+			KeyEvictionsTotal.WithLabelValues(s.entries[evictKey].model, "capacity").Inc()
+			delete(s.entries, evictKey)
+			s.lru.Remove(back)
+		}
+	}
+	e := &entry{
+		model: model,
+		warm:  make(map[string]time.Time, 4),
+	}
+	e.elem = s.lru.PushFront(tableKey)
+	s.entries[tableKey] = e
+	return e
+}
+
+// bumpRate records one request in the entry's rate window and returns the
+// sliding-window rate in requests/minute, including this request. Two fixed
+// one-minute buckets are interpolated by position within the current minute —
+// cheap, and smooth enough that the key_rpm histogram and R don't sawtooth at
+// minute boundaries.
+func (e *entry) bumpRate(now time.Time) float64 {
+	minute := now.Truncate(time.Minute)
+	switch {
+	case e.windowStart.Equal(minute):
+		e.curCount++
+	case minute.Sub(e.windowStart) == time.Minute:
+		e.prevCount = e.curCount
+		e.curCount = 1
+		e.windowStart = minute
+	default: // first request, or a gap of more than a minute
+		e.prevCount = 0
+		e.curCount = 1
+		e.windowStart = minute
+	}
+	frac := now.Sub(minute).Seconds() / 60
+	return float64(e.prevCount)*(1-frac) + float64(e.curCount)
+}
+
+// sweeper periodically drops expired entries from the cold end of the LRU.
+// Because a touch moves an entry to the front and pushes its expiry forward,
+// LRU order is expiry order, so sweeping pops from the back until it meets a
+// live entry — O(expired), not O(table).
+func (s *Shadow) sweeper() {
+	ticker := time.NewTicker(sweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.done:
+			return
+		case <-ticker.C:
+			s.sweep()
+		}
+	}
+}
+
+// sweep evicts expired entries in bounded chunks per lock acquisition.
+func (s *Shadow) sweep() {
+	for {
+		evicted := 0
+		s.mu.Lock()
+		now := s.now()
+		for evicted < sweepChunk {
+			back := s.lru.Back()
+			if back == nil {
+				break
+			}
+			tableKey := back.Value.(string)
+			e := s.entries[tableKey]
+			if e.expiry.After(now) {
+				break
+			}
+			KeyEvictionsTotal.WithLabelValues(e.model, "ttl").Inc()
+			delete(s.entries, tableKey)
+			s.lru.Remove(back)
+			evicted++
+		}
+		s.mu.Unlock()
+		if evicted < sweepChunk {
+			return
+		}
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (s *Shadow) Describe(ch chan<- *prometheus.Desc) {
+	ch <- trackedKeysDesc
+}
+
+// Collect implements prometheus.Collector: it walks the table and emits the
+// tracked-keys gauge — live keys by model, current HRW home, and current
+// replication factor. Only counts leave the lock; keys never do.
+func (s *Shadow) Collect(ch chan<- prometheus.Metric) {
+	type group struct{ model, home, r string }
+	counts := make(map[group]int)
+
+	s.mu.Lock()
+	for _, e := range s.entries {
+		counts[group{e.model, e.home, strconv.Itoa(e.r)}]++
+	}
+	s.mu.Unlock()
+
+	for g, n := range counts {
+		ch <- prometheus.MustNewConstMetric(trackedKeysDesc, prometheus.GaugeValue, float64(n), g.model, g.home, g.r)
+	}
+}

--- a/cacheroute/shadow.go
+++ b/cacheroute/shadow.go
@@ -46,11 +46,27 @@ const (
 type Shadow struct {
 	mu      sync.Mutex
 	entries map[string]*entry // table key: model \x00 routing key
-	lru     *list.List        // front = most recently touched; values are table keys
+	// One LRU list per retention duration; expiry is lastSeen plus a fixed
+	// multiple of retention, so WITHIN a list LRU order is expiry order and
+	// the sweeper can pop expired entries from the back. A single global
+	// list would not have that property across models with different
+	// retention windows, stranding expired entries behind an unexpired
+	// long-retention one.
+	lists map[time.Duration]*list.List
+	// Live tracked-keys aggregate by (model, home, r), maintained on every
+	// insert/touch/evict so Collect never has to walk the table under the
+	// request path's mutex.
+	counts  map[group]int
 	maxKeys int
 
 	now  func() time.Time
 	done chan struct{}
+}
+
+// group identifies one tracked-keys gauge series.
+type group struct {
+	model, home string
+	r           int
 }
 
 // entry is the per-key state.
@@ -68,12 +84,13 @@ type entry struct {
 	prevCount   int
 	curCount    int
 
-	// Last observed HRW home and replication factor, aggregated into the
-	// tracked-keys gauge at scrape time.
+	// Last observed HRW home and replication factor, mirrored into
+	// Shadow.counts.
 	home string
 	r    int
 
-	elem *list.Element
+	retention time.Duration // which of Shadow.lists holds elem
+	elem      *list.Element
 }
 
 // Option configures a Shadow.
@@ -95,7 +112,8 @@ func WithMaxKeys(n int) Option {
 func NewShadow(reg prometheus.Registerer, opts ...Option) *Shadow {
 	s := &Shadow{
 		entries: make(map[string]*entry),
-		lru:     list.New(),
+		lists:   make(map[time.Duration]*list.List),
+		counts:  make(map[group]int),
 		maxKeys: DefaultMaxKeys,
 		now:     time.Now,
 		done:    make(chan struct{}),
@@ -189,12 +207,12 @@ func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, act
 	var res keyedResult
 	e, ok := s.entries[tableKey]
 	if !ok {
-		e = s.insertLocked(model, tableKey, now)
+		e = s.insertLocked(model, tableKey, cfg.Retention)
 		res.reuse = ReuseFirstSeen
 	} else {
 		res.repeat = true
 		res.interval = now.Sub(e.lastSeen)
-		s.lru.MoveToFront(e.elem)
+		s.touchLocked(e, cfg.Retention)
 
 		for host, seen := range e.warm {
 			if now.Sub(seen) > cfg.Retention {
@@ -220,30 +238,92 @@ func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, act
 	ranked := rank(key, candidates)
 	res.r = replicationFactor(res.rpm, cfg.SplitThresholdRPM, len(ranked))
 	res.pick = leastLoaded(ranked[:res.r]).Host
+	s.shiftCountLocked(model, e.home, e.r, ranked[0].Host, res.r)
 	e.home = ranked[0].Host
 	e.r = res.r
 
 	return res
 }
 
-// insertLocked adds a fresh entry, evicting the least-recently-used one at
-// capacity. Caller holds s.mu.
-func (s *Shadow) insertLocked(model, tableKey string, now time.Time) *entry {
+// shiftCountLocked moves an entry between tracked-keys groups. An empty
+// oldHome means the entry is new; an empty newHome means it is leaving.
+// Caller holds s.mu.
+func (s *Shadow) shiftCountLocked(model, oldHome string, oldR int, newHome string, newR int) {
+	if oldHome == newHome && oldR == newR {
+		return
+	}
+	if oldHome != "" {
+		g := group{model, oldHome, oldR}
+		if s.counts[g]--; s.counts[g] <= 0 {
+			delete(s.counts, g)
+		}
+	}
+	if newHome != "" {
+		s.counts[group{model, newHome, newR}]++
+	}
+}
+
+// listFor returns the LRU list for a retention duration, creating it on
+// first use. Caller holds s.mu.
+func (s *Shadow) listFor(retention time.Duration) *list.List {
+	l := s.lists[retention]
+	if l == nil {
+		l = list.New()
+		s.lists[retention] = l
+	}
+	return l
+}
+
+// touchLocked moves an entry to the front of its retention list, migrating
+// it when the model's configured retention changed. Caller holds s.mu.
+func (s *Shadow) touchLocked(e *entry, retention time.Duration) {
+	if e.retention == retention {
+		s.lists[e.retention].MoveToFront(e.elem)
+		return
+	}
+	tableKey := e.elem.Value
+	s.lists[e.retention].Remove(e.elem)
+	e.retention = retention
+	e.elem = s.listFor(retention).PushFront(tableKey)
+}
+
+// insertLocked adds a fresh entry, evicting the least-recently-touched one
+// across all retention lists at capacity. Caller holds s.mu.
+func (s *Shadow) insertLocked(model, tableKey string, retention time.Duration) *entry {
 	if len(s.entries) >= s.maxKeys {
-		if back := s.lru.Back(); back != nil {
-			evictKey := back.Value.(string)
-			KeyEvictionsTotal.WithLabelValues(s.entries[evictKey].model, "capacity").Inc()
-			delete(s.entries, evictKey)
-			s.lru.Remove(back)
+		var oldest *list.Element
+		var oldestSeen time.Time
+		for _, l := range s.lists {
+			back := l.Back()
+			if back == nil {
+				continue
+			}
+			if seen := s.entries[back.Value.(string)].lastSeen; oldest == nil || seen.Before(oldestSeen) {
+				oldest, oldestSeen = back, seen
+			}
+		}
+		if oldest != nil {
+			s.evictLocked(oldest, "capacity")
 		}
 	}
 	e := &entry{
-		model: model,
-		warm:  make(map[string]time.Time, 4),
+		model:     model,
+		warm:      make(map[string]time.Time, 4),
+		retention: retention,
 	}
-	e.elem = s.lru.PushFront(tableKey)
+	e.elem = s.listFor(retention).PushFront(tableKey)
 	s.entries[tableKey] = e
 	return e
+}
+
+// evictLocked removes an entry given its list element. Caller holds s.mu.
+func (s *Shadow) evictLocked(elem *list.Element, reason string) {
+	tableKey := elem.Value.(string)
+	e := s.entries[tableKey]
+	KeyEvictionsTotal.WithLabelValues(e.model, reason).Inc()
+	s.shiftCountLocked(e.model, e.home, e.r, "", 0)
+	delete(s.entries, tableKey)
+	s.lists[e.retention].Remove(elem)
 }
 
 // bumpRate records one request and returns the sliding-window rate in
@@ -281,29 +361,30 @@ func (s *Shadow) sweeper() {
 	}
 }
 
-// sweep evicts expired entries from the cold end of the LRU in bounded
-// chunks per lock acquisition. Touches move entries to the front and push
-// expiry forward, so LRU order is expiry order and the scan is O(expired),
-// not O(table).
+// sweep evicts expired entries from the cold end of each retention list in
+// bounded chunks per lock acquisition. Within a list, touches move entries
+// to the front and push expiry forward by the same fixed multiple, so LRU
+// order is expiry order and the scan is O(expired), not O(table).
 func (s *Shadow) sweep() {
 	for {
 		evicted := 0
 		s.mu.Lock()
 		now := s.now()
-		for evicted < sweepChunk {
-			back := s.lru.Back()
-			if back == nil {
-				break
+		for retention, l := range s.lists {
+			for evicted < sweepChunk {
+				back := l.Back()
+				if back == nil {
+					break
+				}
+				if s.entries[back.Value.(string)].expiry.After(now) {
+					break
+				}
+				s.evictLocked(back, "ttl")
+				evicted++
 			}
-			tableKey := back.Value.(string)
-			e := s.entries[tableKey]
-			if e.expiry.After(now) {
-				break
+			if l.Len() == 0 {
+				delete(s.lists, retention)
 			}
-			KeyEvictionsTotal.WithLabelValues(e.model, "ttl").Inc()
-			delete(s.entries, tableKey)
-			s.lru.Remove(back)
-			evicted++
 		}
 		s.mu.Unlock()
 		if evicted < sweepChunk {
@@ -317,20 +398,23 @@ func (s *Shadow) Describe(ch chan<- *prometheus.Desc) {
 	ch <- trackedKeysDesc
 }
 
-// Collect implements prometheus.Collector: it aggregates live keys by
-// (model, home, replication factor). Only counts leave the lock; keys never
-// do.
+// Collect implements prometheus.Collector: it snapshots the incrementally
+// maintained per-(model, home, r) counts — O(series), never a table walk, so
+// a scrape cannot stall the request path behind the shared mutex. Only
+// counts leave the lock; keys never do.
 func (s *Shadow) Collect(ch chan<- prometheus.Metric) {
-	type group struct{ model, home, r string }
-	counts := make(map[group]int)
-
+	type sample struct {
+		g group
+		n int
+	}
 	s.mu.Lock()
-	for _, e := range s.entries {
-		counts[group{e.model, e.home, strconv.Itoa(e.r)}]++
+	samples := make([]sample, 0, len(s.counts))
+	for g, n := range s.counts {
+		samples = append(samples, sample{g, n})
 	}
 	s.mu.Unlock()
 
-	for g, n := range counts {
-		ch <- prometheus.MustNewConstMetric(trackedKeysDesc, prometheus.GaugeValue, float64(n), g.model, g.home, g.r)
+	for _, sm := range samples {
+		ch <- prometheus.MustNewConstMetric(trackedKeysDesc, prometheus.GaugeValue, float64(sm.n), sm.g.model, sm.g.home, strconv.Itoa(sm.g.r))
 	}
 }

--- a/cacheroute/shadow_test.go
+++ b/cacheroute/shadow_test.go
@@ -340,6 +340,58 @@ func TestRandomMatch(t *testing.T) {
 	}
 }
 
+// TestObserveProbeServed pins that a request served from outside the ranked
+// membership (a breaker probe) updates reuse and warmth but is excluded from
+// the pick-vs-random comparison.
+func TestObserveProbeServed(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	model := "probe-served-" + t.Name()
+	cfg := defaultSettings()
+	req := keyedRequest(t, "p", 1)
+
+	keyed := counterDelta(t, RequestsTotal, model, string(OutcomeKeyed))
+	matches := counterDelta(t, RandomMatchTotal, model)
+	picks := func() float64 {
+		total := 0.0
+		for _, host := range []string{"enclave-a", "enclave-b", "probe-c"} {
+			for _, r := range []string{"1", "2"} {
+				if c, err := PicksTotal.GetMetricWithLabelValues(model, host, r); err == nil {
+					total += testutil.ToFloat64(c)
+				}
+			}
+		}
+		return total
+	}
+	picksBase := picks()
+
+	// Served by a probing replica that is not a candidate.
+	s.Observe(model, req, pool2(), "probe-c", cfg)
+	if got := keyed(); got != 1 {
+		t.Fatalf("keyed = %v, want 1", got)
+	}
+	if got := picks() - picksBase; got != 0 {
+		t.Fatalf("picks after probe dispatch = %v, want 0", got)
+	}
+	if got := matches(); got != 0 {
+		t.Fatalf("matches after probe dispatch = %v, want 0", got)
+	}
+
+	// The probe still warmed its replica: a repeat onto it is warm.
+	warm := counterDelta(t, ReuseTotal, model, ReuseRepeatWarm)
+	clock.advance(time.Second)
+	s.Observe(model, req, pool2(), "probe-c", cfg)
+	if got := warm(); got != 1 {
+		t.Fatalf("repeat onto probed replica: warm = %v, want 1", got)
+	}
+
+	// A normally-served request resumes the comparison.
+	clock.advance(time.Second)
+	s.Observe(model, req, pool2(), "enclave-a", cfg)
+	if got := picks() - picksBase; got != 1 {
+		t.Fatalf("picks after normal dispatch = %v, want 1", got)
+	}
+}
+
 // TestTrackedKeysCollector checks the scrape-time gauge: distinct live keys
 // grouped by home enclave and replication factor.
 func TestTrackedKeysCollector(t *testing.T) {

--- a/cacheroute/shadow_test.go
+++ b/cacheroute/shadow_test.go
@@ -1,0 +1,399 @@
+package cacheroute
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/tinfoilsh/confidential-model-router/config"
+)
+
+// testClock is an injectable clock for the shadow table.
+type testClock struct{ t time.Time }
+
+func newTestClock() *testClock {
+	return &testClock{t: time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *testClock) now() time.Time          { return c.t }
+func (c *testClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// newTestShadow builds a Shadow on a private registry with a fake clock.
+func newTestShadow(t *testing.T, opts ...Option) (*Shadow, *testClock, *prometheus.Registry) {
+	t.Helper()
+	clock := newTestClock()
+	reg := prometheus.NewRegistry()
+	s := NewShadow(reg, append([]Option{WithNowFunc(clock.now)}, opts...)...)
+	t.Cleanup(s.Close)
+	return s, clock, reg
+}
+
+// keyedRequest fabricates a keyed request with a distinct key.
+func keyedRequest(t *testing.T, id string, promptBytes int) *Request {
+	t.Helper()
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "system", "content": "prefix-" + id + strings.Repeat("x", 4096)},
+			map[string]any{"role": "user", "content": "hello"},
+		},
+	}
+	req := ExtractRequest(body, "/v1/chat/completions", testSalt, defaultSettings())
+	if req.Outcome != OutcomeKeyed {
+		t.Fatalf("fixture not keyed: %s", req.Outcome)
+	}
+	req.PromptBytes = promptBytes
+	return req
+}
+
+func pool2() Pool {
+	return Pool{Size: 2, Candidates: hosts("enclave-a", "enclave-b")}
+}
+
+// counterDelta reads a counter child's value.
+func counterValue(t *testing.T, vec *prometheus.CounterVec, labels ...string) float64 {
+	t.Helper()
+	c, err := vec.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return testutil.ToFloat64(c)
+}
+
+func TestObserveClassification(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	model := "cls-" + t.Name()
+	cfg := defaultSettings() // W = 10 min
+	req := keyedRequest(t, "one", 100)
+
+	reuse := func(outcome string) float64 { return counterValue(t, ReuseTotal, model, outcome) }
+	base := [3]float64{reuse(ReuseFirstSeen), reuse(ReuseRepeatWarm), reuse(ReuseRepeatCold)}
+
+	// Never seen: first_seen; enclave-a becomes warm.
+	s.Observe(model, req, pool2(), "enclave-a", cfg)
+	if got := reuse(ReuseFirstSeen) - base[0]; got != 1 {
+		t.Fatalf("first_seen = %v, want 1", got)
+	}
+
+	// Repeat onto the warm replica: random routing already got the hit.
+	clock.advance(time.Minute)
+	s.Observe(model, req, pool2(), "enclave-a", cfg)
+	if got := reuse(ReuseRepeatWarm) - base[1]; got != 1 {
+		t.Fatalf("repeat_warm = %v, want 1", got)
+	}
+
+	// Repeat onto the cold replica while a is warm: the prize.
+	clock.advance(time.Minute)
+	s.Observe(model, req, pool2(), "enclave-b", cfg)
+	if got := reuse(ReuseRepeatCold) - base[2]; got != 1 {
+		t.Fatalf("repeat_cold = %v, want 1", got)
+	}
+
+	// Past W everything is stale: cache-wise a first sighting again.
+	clock.advance(cfg.Retention + time.Minute)
+	s.Observe(model, req, pool2(), "enclave-a", cfg)
+	if got := reuse(ReuseFirstSeen) - base[0]; got != 2 {
+		t.Fatalf("first_seen after W = %v, want 2", got)
+	}
+
+	// All four keyed requests counted in the funnel.
+	if got := counterValue(t, RequestsTotal, model, string(OutcomeKeyed)); got != 4 {
+		t.Fatalf("keyed = %v, want 4", got)
+	}
+}
+
+func TestObserveFunnel(t *testing.T) {
+	s, _, _ := newTestShadow(t)
+	model := "funnel-" + t.Name()
+	cfg := defaultSettings()
+
+	// Ineligible outcomes pass straight through to the funnel counter.
+	s.Observe(model, &Request{Outcome: OutcomeNoSalt}, pool2(), "enclave-a", cfg)
+	s.Observe(model, &Request{Outcome: OutcomeBelowFloor}, pool2(), "enclave-a", cfg)
+	if got := counterValue(t, RequestsTotal, model, string(OutcomeNoSalt)); got != 1 {
+		t.Fatalf("no_salt = %v, want 1", got)
+	}
+	if got := counterValue(t, RequestsTotal, model, string(OutcomeBelowFloor)); got != 1 {
+		t.Fatalf("below_floor = %v, want 1", got)
+	}
+
+	// A keyed request on a single-replica pool: nothing to route.
+	req := keyedRequest(t, "solo", 10)
+	s.Observe(model, req, Pool{Size: 1, Candidates: hosts("only")}, "only", cfg)
+	if got := counterValue(t, RequestsTotal, model, string(OutcomePoolTooSmall)); got != 1 {
+		t.Fatalf("pool_too_small = %v, want 1", got)
+	}
+	if got := counterValue(t, RequestsTotal, model, string(OutcomeKeyed)); got != 0 {
+		t.Fatalf("keyed = %v, want 0", got)
+	}
+}
+
+func TestObserveByteWeighting(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	model := "bytes-" + t.Name()
+	cfg := defaultSettings()
+	req := keyedRequest(t, "bw", 5000)
+
+	s.Observe(model, req, pool2(), "enclave-a", cfg)
+	clock.advance(time.Second)
+	s.Observe(model, req, pool2(), "enclave-b", cfg)
+
+	if got := counterValue(t, ReusePromptBytesTotal, model, ReuseFirstSeen); got != 5000 {
+		t.Fatalf("first_seen bytes = %v, want 5000", got)
+	}
+	if got := counterValue(t, ReusePromptBytesTotal, model, ReuseRepeatCold); got != 5000 {
+		t.Fatalf("repeat_cold bytes = %v, want 5000", got)
+	}
+}
+
+// TestObservePanicRecovery proves the shadow path cannot fail a request: a
+// nil *Request panics inside Observe and must be swallowed into the error
+// outcome.
+func TestObservePanicRecovery(t *testing.T) {
+	s, _, _ := newTestShadow(t)
+	model := "panic-" + t.Name()
+
+	s.Observe(model, nil, pool2(), "enclave-a", defaultSettings())
+
+	if got := counterValue(t, RequestsTotal, model, string(OutcomeError)); got != 1 {
+		t.Fatalf("error = %v, want 1", got)
+	}
+}
+
+func TestCapacityEviction(t *testing.T) {
+	s, clock, _ := newTestShadow(t, WithMaxKeys(2))
+	model := "cap-" + t.Name()
+	cfg := defaultSettings()
+
+	k1 := keyedRequest(t, "k1", 1)
+	k2 := keyedRequest(t, "k2", 1)
+	k3 := keyedRequest(t, "k3", 1)
+
+	s.Observe(model, k1, pool2(), "enclave-a", cfg)
+	clock.advance(time.Second)
+	s.Observe(model, k2, pool2(), "enclave-a", cfg)
+	clock.advance(time.Second)
+	// Touch k1 so k2 is the LRU entry, then insert k3 → k2 evicted.
+	s.Observe(model, k1, pool2(), "enclave-a", cfg)
+	clock.advance(time.Second)
+	s.Observe(model, k3, pool2(), "enclave-a", cfg)
+
+	if got := counterValue(t, KeyEvictionsTotal, model, "capacity"); got != 1 {
+		t.Fatalf("capacity evictions = %v, want 1", got)
+	}
+
+	// k1 survived (repeat), k2 was evicted (first_seen again) — the
+	// documented capacity bias.
+	warmBefore := counterValue(t, ReuseTotal, model, ReuseRepeatWarm)
+	clock.advance(time.Second)
+	s.Observe(model, k1, pool2(), "enclave-a", cfg)
+	if got := counterValue(t, ReuseTotal, model, ReuseRepeatWarm) - warmBefore; got != 1 {
+		t.Fatalf("k1 must still be tracked, warm delta = %v", got)
+	}
+	firstBefore := counterValue(t, ReuseTotal, model, ReuseFirstSeen)
+	clock.advance(time.Second)
+	s.Observe(model, k2, pool2(), "enclave-a", cfg)
+	if got := counterValue(t, ReuseTotal, model, ReuseFirstSeen) - firstBefore; got != 1 {
+		t.Fatalf("evicted k2 must classify first_seen, delta = %v", got)
+	}
+}
+
+func TestTTLSweep(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	model := "ttl-" + t.Name()
+	cfg := defaultSettings()
+
+	s.Observe(model, keyedRequest(t, "t1", 1), pool2(), "enclave-a", cfg)
+	s.Observe(model, keyedRequest(t, "t2", 1), pool2(), "enclave-b", cfg)
+
+	// Entries are retained retentionFactor×W past their last touch so the
+	// repeat-interval histogram can see beyond-W re-arrivals; only after
+	// that are they swept.
+	clock.advance(cfg.Retention + time.Minute)
+	s.sweep()
+	if got := counterValue(t, KeyEvictionsTotal, model, "ttl"); got != 0 {
+		t.Fatalf("swept %v entries before retention elapsed", got)
+	}
+
+	clock.advance(time.Duration(retentionFactor) * cfg.Retention)
+	s.sweep()
+	if got := counterValue(t, KeyEvictionsTotal, model, "ttl"); got != 2 {
+		t.Fatalf("ttl evictions = %v, want 2", got)
+	}
+}
+
+// TestHotKeyReplication drives one key past the split threshold and expects
+// its replication factor to grow — and a slow key's to stay at 1.
+func TestHotKeyReplication(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	model := "hot-" + t.Name()
+	cfg := defaultSettings() // threshold 15 rpm
+	hot := keyedRequest(t, "hot", 1)
+
+	// ~40 requests inside one minute: rpm crosses 15, R clamps to pool
+	// size 2.
+	for range 40 {
+		clock.advance(time.Second)
+		s.Observe(model, hot, pool2(), "enclave-a", cfg)
+	}
+
+	splitPicks := 0.0
+	for _, host := range []string{"enclave-a", "enclave-b"} {
+		if c, err := PicksTotal.GetMetricWithLabelValues(model, host, "2"); err == nil {
+			splitPicks += testutil.ToFloat64(c)
+		}
+	}
+	if splitPicks == 0 {
+		t.Fatal("hot key never reached replication factor 2")
+	}
+
+	cold := keyedRequest(t, "cold", 1)
+	s.Observe(model, cold, pool2(), "enclave-a", cfg)
+	r1 := 0.0
+	for _, host := range []string{"enclave-a", "enclave-b"} {
+		if c, err := PicksTotal.GetMetricWithLabelValues(model, host, "1"); err == nil {
+			r1 += testutil.ToFloat64(c)
+		}
+	}
+	if r1 == 0 {
+		t.Fatal("slow keys must keep replication factor 1")
+	}
+}
+
+// TestRandomMatch verifies the pick-vs-random agreement counter by inferring
+// the deterministic pick from the first observation.
+func TestRandomMatch(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	model := "match-" + t.Name()
+	cfg := defaultSettings()
+	req := keyedRequest(t, "m", 1)
+
+	s.Observe(model, req, pool2(), "enclave-a", cfg)
+	pick := "enclave-a"
+	other := "enclave-b"
+	if counterValue(t, RandomMatchTotal, model) == 0 {
+		pick, other = other, pick
+	}
+
+	base := counterValue(t, RandomMatchTotal, model)
+	clock.advance(time.Second)
+	s.Observe(model, req, pool2(), pick, cfg)
+	if got := counterValue(t, RandomMatchTotal, model) - base; got != 1 {
+		t.Fatalf("match on pick = %v, want 1", got)
+	}
+	clock.advance(time.Second)
+	s.Observe(model, req, pool2(), other, cfg)
+	if got := counterValue(t, RandomMatchTotal, model) - base; got != 1 {
+		t.Fatalf("non-pick must not count as match, delta = %v", got)
+	}
+}
+
+// TestTrackedKeysCollector checks the scrape-time gauge: distinct live keys
+// grouped by home enclave and replication factor.
+func TestTrackedKeysCollector(t *testing.T) {
+	s, clock, reg := newTestShadow(t)
+	model := "tracked-" + t.Name()
+	cfg := defaultSettings()
+
+	for i := range 10 {
+		clock.advance(time.Second)
+		s.Observe(model, keyedRequest(t, string(rune('a'+i)), 1), pool2(), "enclave-a", cfg)
+	}
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var total float64
+	homes := map[string]bool{}
+	for _, mf := range families {
+		if mf.GetName() != "router_cache_route_tracked_keys" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["model"] != model {
+				continue
+			}
+			if labels["r"] != "1" {
+				t.Errorf("unexpected replication factor %s for cold keys", labels["r"])
+			}
+			homes[labels["enclave"]] = true
+			total += m.GetGauge().GetValue()
+		}
+	}
+	if total != 10 {
+		t.Fatalf("tracked keys = %v, want 10", total)
+	}
+	if len(homes) == 0 {
+		t.Fatal("no home enclaves reported")
+	}
+}
+
+// TestPoolAndModeInfo exercises the config-sync info series: value changes
+// replace the old series rather than accumulating, and DropModel removes
+// them.
+func TestPoolAndModeInfo(t *testing.T) {
+	model := "info-" + t.Name()
+
+	SetPoolInfo(model, []string{"h2", "h1"})
+	SetPoolInfo(model, []string{"h1", "h2"}) // order-insensitive: same hash
+	if got := gatherLabelValues(t, PoolInfo, model, "pool_hash"); len(got) != 1 {
+		t.Fatalf("pool_hash series = %v, want exactly one", got)
+	}
+	SetPoolInfo(model, []string{"h1", "h2", "h3"})
+	if got := gatherLabelValues(t, PoolInfo, model, "pool_hash"); len(got) != 1 {
+		t.Fatalf("pool change must replace the series, got %v", got)
+	}
+
+	SetMode(model, nil)
+	if got := gatherLabelValues(t, ModeInfo, model, "mode"); len(got) != 1 || !got["off"] {
+		t.Fatalf("mode = %v, want off", got)
+	}
+	SetMode(model, &config.CacheRouteConfig{Mode: "shadow"})
+	if got := gatherLabelValues(t, ModeInfo, model, "mode"); len(got) != 1 || !got["shadow"] {
+		t.Fatalf("mode = %v, want shadow", got)
+	}
+	// The gauge reports the effective mode: enforced clamps to shadow.
+	SetMode(model, &config.CacheRouteConfig{Mode: "enforced"})
+	if got := gatherLabelValues(t, ModeInfo, model, "mode"); len(got) != 1 || !got["shadow"] {
+		t.Fatalf("mode = %v, want shadow (clamped)", got)
+	}
+
+	DropModel(model)
+	if got := gatherLabelValues(t, PoolInfo, model, "pool_hash"); len(got) != 0 {
+		t.Fatalf("dropped model still has pool series: %v", got)
+	}
+	if got := gatherLabelValues(t, ModeInfo, model, "mode"); len(got) != 0 {
+		t.Fatalf("dropped model still has mode series: %v", got)
+	}
+}
+
+// gatherLabelValues collects the values of one label across a vector's
+// series for a model, via the default registerer.
+func gatherLabelValues(t *testing.T, vec *prometheus.GaugeVec, model, label string) map[string]bool {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 64)
+	go func() { vec.Collect(ch); close(ch) }()
+	out := map[string]bool{}
+	for m := range ch {
+		var d dto.Metric
+		if err := m.Write(&d); err != nil {
+			t.Fatal(err)
+		}
+		labels := map[string]string{}
+		for _, lp := range d.GetLabel() {
+			labels[lp.GetName()] = lp.GetValue()
+		}
+		if labels["model"] == model {
+			out[labels[label]] = true
+		}
+	}
+	return out
+}

--- a/cacheroute/shadow_test.go
+++ b/cacheroute/shadow_test.go
@@ -53,7 +53,7 @@ func pool2() Pool {
 	return Pool{Size: 2, Candidates: hosts("enclave-a", "enclave-b")}
 }
 
-// counterDelta reads a counter child's value.
+// counterValue reads a counter child's value.
 func counterValue(t *testing.T, vec *prometheus.CounterVec, labels ...string) float64 {
 	t.Helper()
 	c, err := vec.GetMetricWithLabelValues(labels...)
@@ -61,6 +61,15 @@ func counterValue(t *testing.T, vec *prometheus.CounterVec, labels ...string) fl
 		t.Fatal(err)
 	}
 	return testutil.ToFloat64(c)
+}
+
+// counterDelta returns a reader for how much a counter child has grown since
+// this call. The promauto counters are process-global and never reset, so
+// assertions must be relative or the suite fails under go test -count=2.
+func counterDelta(t *testing.T, vec *prometheus.CounterVec, labels ...string) func() float64 {
+	t.Helper()
+	base := counterValue(t, vec, labels...)
+	return func() float64 { return counterValue(t, vec, labels...) - base }
 }
 
 func TestObserveClassification(t *testing.T) {
@@ -71,6 +80,7 @@ func TestObserveClassification(t *testing.T) {
 
 	reuse := func(outcome string) float64 { return counterValue(t, ReuseTotal, model, outcome) }
 	base := [3]float64{reuse(ReuseFirstSeen), reuse(ReuseRepeatWarm), reuse(ReuseRepeatCold)}
+	keyed := counterDelta(t, RequestsTotal, model, string(OutcomeKeyed))
 
 	// Never seen: first_seen; enclave-a becomes warm.
 	s.Observe(model, req, pool2(), "enclave-a", cfg)
@@ -100,7 +110,7 @@ func TestObserveClassification(t *testing.T) {
 	}
 
 	// All four keyed requests counted in the funnel.
-	if got := counterValue(t, RequestsTotal, model, string(OutcomeKeyed)); got != 4 {
+	if got := keyed(); got != 4 {
 		t.Fatalf("keyed = %v, want 4", got)
 	}
 }
@@ -109,24 +119,28 @@ func TestObserveFunnel(t *testing.T) {
 	s, _, _ := newTestShadow(t)
 	model := "funnel-" + t.Name()
 	cfg := defaultSettings()
+	noSalt := counterDelta(t, RequestsTotal, model, string(OutcomeNoSalt))
+	belowFloor := counterDelta(t, RequestsTotal, model, string(OutcomeBelowFloor))
+	tooSmall := counterDelta(t, RequestsTotal, model, string(OutcomePoolTooSmall))
+	keyed := counterDelta(t, RequestsTotal, model, string(OutcomeKeyed))
 
 	// Ineligible outcomes pass straight through to the funnel counter.
 	s.Observe(model, &Request{Outcome: OutcomeNoSalt}, pool2(), "enclave-a", cfg)
 	s.Observe(model, &Request{Outcome: OutcomeBelowFloor}, pool2(), "enclave-a", cfg)
-	if got := counterValue(t, RequestsTotal, model, string(OutcomeNoSalt)); got != 1 {
+	if got := noSalt(); got != 1 {
 		t.Fatalf("no_salt = %v, want 1", got)
 	}
-	if got := counterValue(t, RequestsTotal, model, string(OutcomeBelowFloor)); got != 1 {
+	if got := belowFloor(); got != 1 {
 		t.Fatalf("below_floor = %v, want 1", got)
 	}
 
 	// A keyed request on a single-replica pool: nothing to route.
 	req := keyedRequest(t, "solo", 10)
 	s.Observe(model, req, Pool{Size: 1, Candidates: hosts("only")}, "only", cfg)
-	if got := counterValue(t, RequestsTotal, model, string(OutcomePoolTooSmall)); got != 1 {
+	if got := tooSmall(); got != 1 {
 		t.Fatalf("pool_too_small = %v, want 1", got)
 	}
-	if got := counterValue(t, RequestsTotal, model, string(OutcomeKeyed)); got != 0 {
+	if got := keyed(); got != 0 {
 		t.Fatalf("keyed = %v, want 0", got)
 	}
 }
@@ -136,15 +150,17 @@ func TestObserveByteWeighting(t *testing.T) {
 	model := "bytes-" + t.Name()
 	cfg := defaultSettings()
 	req := keyedRequest(t, "bw", 5000)
+	firstBytes := counterDelta(t, ReusePromptBytesTotal, model, ReuseFirstSeen)
+	coldBytes := counterDelta(t, ReusePromptBytesTotal, model, ReuseRepeatCold)
 
 	s.Observe(model, req, pool2(), "enclave-a", cfg)
 	clock.advance(time.Second)
 	s.Observe(model, req, pool2(), "enclave-b", cfg)
 
-	if got := counterValue(t, ReusePromptBytesTotal, model, ReuseFirstSeen); got != 5000 {
+	if got := firstBytes(); got != 5000 {
 		t.Fatalf("first_seen bytes = %v, want 5000", got)
 	}
-	if got := counterValue(t, ReusePromptBytesTotal, model, ReuseRepeatCold); got != 5000 {
+	if got := coldBytes(); got != 5000 {
 		t.Fatalf("repeat_cold bytes = %v, want 5000", got)
 	}
 }
@@ -155,10 +171,11 @@ func TestObserveByteWeighting(t *testing.T) {
 func TestObservePanicRecovery(t *testing.T) {
 	s, _, _ := newTestShadow(t)
 	model := "panic-" + t.Name()
+	errored := counterDelta(t, RequestsTotal, model, string(OutcomeError))
 
 	s.Observe(model, nil, pool2(), "enclave-a", defaultSettings())
 
-	if got := counterValue(t, RequestsTotal, model, string(OutcomeError)); got != 1 {
+	if got := errored(); got != 1 {
 		t.Fatalf("error = %v, want 1", got)
 	}
 }
@@ -171,6 +188,7 @@ func TestCapacityEviction(t *testing.T) {
 	k1 := keyedRequest(t, "k1", 1)
 	k2 := keyedRequest(t, "k2", 1)
 	k3 := keyedRequest(t, "k3", 1)
+	capacityEvictions := counterDelta(t, KeyEvictionsTotal, model, "capacity")
 
 	s.Observe(model, k1, pool2(), "enclave-a", cfg)
 	clock.advance(time.Second)
@@ -181,7 +199,7 @@ func TestCapacityEviction(t *testing.T) {
 	clock.advance(time.Second)
 	s.Observe(model, k3, pool2(), "enclave-a", cfg)
 
-	if got := counterValue(t, KeyEvictionsTotal, model, "capacity"); got != 1 {
+	if got := capacityEvictions(); got != 1 {
 		t.Fatalf("capacity evictions = %v, want 1", got)
 	}
 
@@ -206,6 +224,7 @@ func TestTTLSweep(t *testing.T) {
 	model := "ttl-" + t.Name()
 	cfg := defaultSettings()
 
+	ttlEvictions := counterDelta(t, KeyEvictionsTotal, model, "ttl")
 	s.Observe(model, keyedRequest(t, "t1", 1), pool2(), "enclave-a", cfg)
 	s.Observe(model, keyedRequest(t, "t2", 1), pool2(), "enclave-b", cfg)
 
@@ -214,14 +233,43 @@ func TestTTLSweep(t *testing.T) {
 	// that are they swept.
 	clock.advance(cfg.Retention + time.Minute)
 	s.sweep()
-	if got := counterValue(t, KeyEvictionsTotal, model, "ttl"); got != 0 {
+	if got := ttlEvictions(); got != 0 {
 		t.Fatalf("swept %v entries before retention elapsed", got)
 	}
 
 	clock.advance(time.Duration(retentionFactor) * cfg.Retention)
 	s.sweep()
-	if got := counterValue(t, KeyEvictionsTotal, model, "ttl"); got != 2 {
+	if got := ttlEvictions(); got != 2 {
 		t.Fatalf("ttl evictions = %v, want 2", got)
+	}
+}
+
+// TestSweepPerRetention pins that an idle long-retention key cannot strand
+// expired keys from shorter-retention models behind it.
+func TestSweepPerRetention(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	longModel := "sweep-long-" + t.Name()
+	shortModel := "sweep-short-" + t.Name()
+	long := defaultSettings()
+	long.Retention = time.Hour
+	short := defaultSettings() // 10 min
+
+	ttlLong := counterDelta(t, KeyEvictionsTotal, longModel, "ttl")
+	ttlShort := counterDelta(t, KeyEvictionsTotal, shortModel, "ttl")
+
+	s.Observe(longModel, keyedRequest(t, "L", 1), pool2(), "enclave-a", long)
+	clock.advance(time.Minute)
+	s.Observe(shortModel, keyedRequest(t, "S1", 1), pool2(), "enclave-a", short)
+	s.Observe(shortModel, keyedRequest(t, "S2", 1), pool2(), "enclave-b", short)
+
+	// Past the short model's full retention but well inside the long one's.
+	clock.advance(time.Duration(retentionFactor)*short.Retention + time.Minute)
+	s.sweep()
+	if got := ttlShort(); got != 2 {
+		t.Fatalf("short-retention ttl evictions = %v, want 2", got)
+	}
+	if got := ttlLong(); got != 0 {
+		t.Fatalf("long-retention ttl evictions = %v, want 0", got)
 	}
 }
 
@@ -271,22 +319,23 @@ func TestRandomMatch(t *testing.T) {
 	cfg := defaultSettings()
 	req := keyedRequest(t, "m", 1)
 
+	matches := counterDelta(t, RandomMatchTotal, model)
 	s.Observe(model, req, pool2(), "enclave-a", cfg)
 	pick := "enclave-a"
 	other := "enclave-b"
-	if counterValue(t, RandomMatchTotal, model) == 0 {
+	if matches() == 0 {
 		pick, other = other, pick
 	}
 
-	base := counterValue(t, RandomMatchTotal, model)
+	afterInference := matches()
 	clock.advance(time.Second)
 	s.Observe(model, req, pool2(), pick, cfg)
-	if got := counterValue(t, RandomMatchTotal, model) - base; got != 1 {
+	if got := matches() - afterInference; got != 1 {
 		t.Fatalf("match on pick = %v, want 1", got)
 	}
 	clock.advance(time.Second)
 	s.Observe(model, req, pool2(), other, cfg)
-	if got := counterValue(t, RandomMatchTotal, model) - base; got != 1 {
+	if got := matches() - afterInference; got != 1 {
 		t.Fatalf("non-pick must not count as match, delta = %v", got)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -20,12 +20,26 @@ type RateLimitConfig struct {
 	MaxRequestsPerMinute int64 `yaml:"max_requests_per_minute"`
 }
 
+// CacheRouteConfig is the per-model cache-aware routing knob. Mode is the
+// rollout control: "off" (default), "shadow" (compute and meter the would-be
+// routing decision without acting), or "enforced" (act on it; not implemented
+// until Phase 5 — the router clamps it to shadow). The remaining fields tune
+// the shadow measurement and have package defaults in cacheroute; zero means
+// "use the default".
+type CacheRouteConfig struct {
+	Mode                   string  `yaml:"mode"`
+	RetentionWindowMinutes int     `yaml:"retention_window_minutes,omitempty"`
+	MinPromptBytes         int     `yaml:"min_prompt_bytes,omitempty"`
+	SplitThresholdRPM      float64 `yaml:"split_threshold_rpm,omitempty"`
+}
+
 // Model represents the configuration for a single model
 type Model struct {
-	Repo      string           `yaml:"repo"`
-	Hostnames []string         `yaml:"enclaves"`
-	Overload  *OverloadConfig  `yaml:"overload,omitempty"`
-	RateLimit *RateLimitConfig `yaml:"rate_limit,omitempty"`
+	Repo       string            `yaml:"repo"`
+	Hostnames  []string          `yaml:"enclaves"`
+	Overload   *OverloadConfig   `yaml:"overload,omitempty"`
+	RateLimit  *RateLimitConfig  `yaml:"rate_limit,omitempty"`
+	CacheRoute *CacheRouteConfig `yaml:"cache_route,omitempty"`
 }
 
 // OverloadConfig describes optional overload thresholds for a model.

--- a/config/config.go
+++ b/config/config.go
@@ -23,9 +23,8 @@ type RateLimitConfig struct {
 // CacheRouteConfig is the per-model cache-aware routing knob. Mode is the
 // rollout control: "off" (default), "shadow" (compute and meter the would-be
 // routing decision without acting), or "enforced" (act on it; not implemented
-// until Phase 5 — the router clamps it to shadow). The remaining fields tune
-// the shadow measurement and have package defaults in cacheroute; zero means
-// "use the default".
+// yet — the router clamps it to shadow). The remaining fields tune the
+// measurement; zero means "use the cacheroute package default".
 type CacheRouteConfig struct {
 	Mode                   string  `yaml:"mode"`
 	RetentionWindowMinutes int     `yaml:"retention_window_minutes,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -51,3 +51,34 @@ models:
 		t.Fatalf("parsed overload = %+v", overload)
 	}
 }
+
+func TestCacheRouteConfigParsing(t *testing.T) {
+	cfg, err := FromBytes([]byte(`
+models:
+  shadowed:
+    repo: org/repo
+    enclaves: [a.example, b.example]
+    cache_route:
+      mode: shadow
+      retention_window_minutes: 5
+      min_prompt_bytes: 2048
+      split_threshold_rpm: 30
+  plain:
+    repo: org/repo
+    enclaves: [c.example]
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cr := cfg.Models["shadowed"].CacheRoute
+	if cr == nil {
+		t.Fatal("cache_route block not parsed")
+	}
+	if cr.Mode != "shadow" || cr.RetentionWindowMinutes != 5 || cr.MinPromptBytes != 2048 || cr.SplitThresholdRPM != 30 {
+		t.Fatalf("cache_route = %+v", cr)
+	}
+	if cfg.Models["plain"].CacheRoute != nil {
+		t.Fatal("absent cache_route must stay nil")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/tinfoilsh/confidential-model-router
 go 1.25.5
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/google/jsonschema-go v0.4.2
 	github.com/google/uuid v1.6.0
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/tinfoilsh/tinfoil-go v0.12.7
@@ -19,7 +21,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20250730155240-ffadbf3f398c // indirect
 	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea // indirect
@@ -61,7 +62,6 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.2 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect

--- a/main.go
+++ b/main.go
@@ -364,10 +364,9 @@ func main() {
 
 	routeContextClient := newRouteContextClient(*controlPlaneURL)
 
-	// Cache-aware routing shadow (Phase 4): measures what cache-aware
-	// replica selection would do without acting, emitting only aggregate
-	// Prometheus metrics — the enclave has no log sink. Per-model modes
-	// come from config (cache_route.mode).
+	// Measures what cache-aware replica selection would do, without
+	// acting, as aggregate Prometheus metrics. Enabled per model via the
+	// cache_route config block.
 	cacheRouteShadow := cacheroute.NewShadow(nil)
 	defer cacheRouteShadow.Close()
 
@@ -376,8 +375,7 @@ func main() {
 		var err error
 
 		// Set when the request is eligible for cache-route shadow
-		// observation (path-routed OpenAI-compatible requests on a
-		// salt-supporting endpoint, model pool in shadow mode).
+		// observation.
 		var cacheRouteReq *cacheroute.Request
 		var cacheRouteSettings cacheroute.Settings
 
@@ -669,13 +667,11 @@ func main() {
 					return
 				}
 
-				// Cache-route shadow, step 1 of 2: classify the request
-				// and derive its routing key from the parsed body, now
-				// that the body is final (post file-input rewriting, post
-				// salt injection) and the request is known to take the
-				// plain proxy path below — the tool runtime above picks
-				// its own enclaves and joins in Phase 5. Never fails the
-				// request; observation happens after replica selection.
+				// Derive the cache-route shadow key now that the body is
+				// final (post file-input rewriting, post salt injection)
+				// and the request is known to take the plain proxy path —
+				// the tool runtime above picks its own enclaves. Observed
+				// after replica selection below; never fails the request.
 				if cacheSaltPaths[r.URL.Path] {
 					if m, ok := em.GetModel(modelName); ok {
 						if s := m.CacheRouteSettings(); s.Mode != cacheroute.ModeOff {
@@ -775,11 +771,9 @@ func main() {
 
 		log.Debugf("%s serving request\n", enclave)
 
-		// Cache-route shadow, step 2 of 2: hand the production pick to
-		// the tracker, which classifies prefix reuse, computes the
-		// would-be cache-aware pick, and increments metrics. Observed at
+		// Hand the production pick to the cache-route shadow. Observed at
 		// dispatch so the picked replica counts as warm from prefill
-		// start. Panic-recovered; cannot affect the request.
+		// start; cannot affect the request.
 		if cacheRouteReq != nil {
 			cacheRouteShadow.Observe(modelName, cacheRouteReq, model.CacheRoutePool(), enclave.String(), cacheRouteSettings)
 		}

--- a/main.go
+++ b/main.go
@@ -366,9 +366,9 @@ func main() {
 
 	// Measures what cache-aware replica selection would do, without
 	// acting, as aggregate Prometheus metrics. Enabled per model via the
-	// cache_route config block.
-	cacheRouteShadow := cacheroute.NewShadow(nil)
-	defer cacheRouteShadow.Close()
+	// cache_route config block; owned by the manager so the tool loop's
+	// internal dispatches are observed too.
+	cacheRouteShadow := em.CacheRouteShadow()
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		var modelName string
@@ -670,8 +670,9 @@ func main() {
 				// Derive the cache-route shadow key now that the body is
 				// final (post file-input rewriting, post salt injection)
 				// and the request is known to take the plain proxy path —
-				// the tool runtime above picks its own enclaves. Observed
-				// after replica selection below; never fails the request.
+				// the tool runtime above observes its own dispatches via
+				// DoModelRequestJSON. Observed after replica selection
+				// below; never fails the request.
 				if cacheSaltPaths[r.URL.Path] {
 					if m, ok := em.GetModel(modelName); ok {
 						if s := m.CacheRouteSettings(); s.Mode != cacheroute.ModeOff {

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/tinfoilsh/confidential-model-router/cacheroute"
 	"github.com/tinfoilsh/confidential-model-router/manager"
 	"github.com/tinfoilsh/confidential-model-router/toolruntime"
 )
@@ -363,9 +364,22 @@ func main() {
 
 	routeContextClient := newRouteContextClient(*controlPlaneURL)
 
+	// Cache-aware routing shadow (Phase 4): measures what cache-aware
+	// replica selection would do without acting, emitting only aggregate
+	// Prometheus metrics — the enclave has no log sink. Per-model modes
+	// come from config (cache_route.mode).
+	cacheRouteShadow := cacheroute.NewShadow(nil)
+	defer cacheRouteShadow.Close()
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		var modelName string
 		var err error
+
+		// Set when the request is eligible for cache-route shadow
+		// observation (path-routed OpenAI-compatible requests on a
+		// salt-supporting endpoint, model pool in shadow mode).
+		var cacheRouteReq *cacheroute.Request
+		var cacheRouteSettings cacheroute.Settings
 
 		// Extract API key early for rate limiting decisions
 		apiKey := ""
@@ -654,6 +668,23 @@ func main() {
 					}
 					return
 				}
+
+				// Cache-route shadow, step 1 of 2: classify the request
+				// and derive its routing key from the parsed body, now
+				// that the body is final (post file-input rewriting, post
+				// salt injection) and the request is known to take the
+				// plain proxy path below — the tool runtime above picks
+				// its own enclaves and joins in Phase 5. Never fails the
+				// request; observation happens after replica selection.
+				if cacheSaltPaths[r.URL.Path] {
+					if m, ok := em.GetModel(modelName); ok {
+						if s := m.CacheRouteSettings(); s.Mode != cacheroute.ModeOff {
+							salt, _ := body["cache_salt"].(string)
+							cacheRouteSettings = s
+							cacheRouteReq = cacheroute.ExtractRequest(body, r.URL.Path, salt, s)
+						}
+					}
+				}
 			}
 		} else if cacheSaltPaths[r.URL.Path] {
 			// Subdomain-routed request on a salt-supporting endpoint. This
@@ -743,6 +774,15 @@ func main() {
 		}
 
 		log.Debugf("%s serving request\n", enclave)
+
+		// Cache-route shadow, step 2 of 2: hand the production pick to
+		// the tracker, which classifies prefix reuse, computes the
+		// would-be cache-aware pick, and increments metrics. Observed at
+		// dispatch so the picked replica counts as warm from prefill
+		// start. Panic-recovered; cannot affect the request.
+		if cacheRouteReq != nil {
+			cacheRouteShadow.Observe(modelName, cacheRouteReq, model.CacheRoutePool(), enclave.String(), cacheRouteSettings)
+		}
 
 		enclave.ServeHTTP(w, r)
 	})

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -3,11 +3,14 @@ package manager
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 
 	tinfoilClient "github.com/tinfoilsh/tinfoil-go/verifier/client"
+
+	"github.com/tinfoilsh/confidential-model-router/cacheroute"
 )
 
 func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *http.Client, error) {
@@ -36,7 +39,7 @@ func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *ht
 		},
 	}
 
-	return "https://" + enclave.host, client, nil
+	return enclave.host, client, nil
 }
 
 // DoModelRequest performs an attested POST against the next available enclave
@@ -44,12 +47,57 @@ func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *ht
 // billing/usage hooks) so that internal callers can be responsible for their
 // own billing accounting without needing a trust-the-caller HTTP header.
 func (em *EnclaveManager) DoModelRequest(ctx context.Context, modelName, path string, body []byte, headers http.Header) (*http.Response, error) {
-	baseURL, client, err := em.boundHTTPClientForModel(modelName)
+	host, client, err := em.boundHTTPClientForModel(modelName)
 	if err != nil {
 		return nil, err
 	}
+	return postToEnclave(ctx, client, host, path, body, headers)
+}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+path, bytes.NewReader(body))
+// DoModelRequestJSON marshals and dispatches a parsed request body the way
+// DoModelRequest does, and feeds the dispatch to the cache-route shadow. The
+// tool loop calls this for every model iteration — replaying a growing shared
+// prefix, the strongest case for cache-aware routing — so those requests must
+// be measured like plain proxied ones.
+func (em *EnclaveManager) DoModelRequestJSON(ctx context.Context, modelName, path string, body map[string]any, headers http.Header) (*http.Response, error) {
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	host, client, err := em.boundHTTPClientForModel(modelName)
+	if err != nil {
+		return nil, err
+	}
+	// Observed at dispatch, like the public proxy path, so the picked
+	// replica counts as warm from prefill start.
+	em.observeCacheRoute(modelName, path, body, host)
+	return postToEnclave(ctx, client, host, path, bodyBytes, headers)
+}
+
+// observeCacheRoute feeds one internally dispatched request to the
+// cache-route shadow, with the same gating as the public path. Callers only
+// dispatch to cache_salt-capable endpoints, so no endpoint allowlist is
+// re-checked here. Never fails the request.
+func (em *EnclaveManager) observeCacheRoute(modelName, path string, body map[string]any, actualHost string) {
+	if em.cacheRouteShadow == nil {
+		return
+	}
+	model, found := em.GetModel(modelName)
+	if !found {
+		return
+	}
+	settings := model.CacheRouteSettings()
+	if settings.Mode == cacheroute.ModeOff {
+		return
+	}
+	salt, _ := body["cache_salt"].(string)
+	req := cacheroute.ExtractRequest(body, path, salt, settings)
+	em.cacheRouteShadow.Observe(modelName, req, model.CacheRoutePool(), actualHost, settings)
+}
+
+// postToEnclave builds and sends an attested POST to one enclave host.
+func postToEnclave(ctx context.Context, client *http.Client, host, path string, body []byte, headers http.Header) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://"+host+path, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -78,11 +126,11 @@ func (em *EnclaveManager) MCPServerEndpoint(modelName string) (string, *http.Cli
 		}
 	}
 
-	baseURL, client, err := em.boundHTTPClientForModel(modelName)
+	host, client, err := em.boundHTTPClientForModel(modelName)
 	if err != nil {
 		return "", nil, err
 	}
-	return baseURL + "/mcp", client, nil
+	return "https://" + host + "/mcp", client, nil
 }
 
 // localMCPEndpointEnvVar returns the model-specific debug-bypass env

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -64,6 +64,7 @@ type EnclaveManager struct {
 	billingCollector     *billing.Collector
 	usageContextSecret   string
 	requestTracker       *ratelimit.RequestTracker
+	cacheRouteShadow     *cacheroute.Shadow
 	refreshInterval      time.Duration
 	stateMu              sync.Mutex
 	errors               []string
@@ -103,6 +104,11 @@ func (em *EnclaveManager) GetModel(modelName string) (*Model, bool) {
 // RequestTracker returns the shared request tracker for rate limiting.
 func (em *EnclaveManager) RequestTracker() *ratelimit.RequestTracker {
 	return em.requestTracker
+}
+
+// CacheRouteShadow returns the cache-aware routing shadow tracker.
+func (em *EnclaveManager) CacheRouteShadow() *cacheroute.Shadow {
+	return em.cacheRouteShadow
 }
 
 func (em *EnclaveManager) AddBillingEvent(event billing.Event) {
@@ -303,6 +309,9 @@ func (em *EnclaveManager) Shutdown() {
 	if em.billingCollector != nil {
 		em.billingCollector.Stop()
 	}
+	if em.cacheRouteShadow != nil {
+		em.cacheRouteShadow.Close()
+	}
 	em.models.Range(func(_, value any) bool {
 		model := value.(*Model)
 		model.mu.RLock()
@@ -370,7 +379,11 @@ func (m *Model) CacheRoutePool() cacheroute.Pool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	pool := cacheroute.Pool{Size: len(m.Enclaves)}
+	// Size comes from the config, not the live enclave map: during a
+	// release the map is cleared and re-attested one host at a time, and a
+	// multi-replica pool must not reclassify as pool_too_small (skipping
+	// warmth tracking) for that window.
+	pool := cacheroute.Pool{Size: m.expectedHosts}
 	for _, enclave := range m.Enclaves {
 		if enclave.cb != nil && !enclave.cb.Closed() {
 			continue
@@ -521,6 +534,7 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterI
 		billingCollector:   billing.NewCollector(controlPlaneURL, usageReporterID, usageReporterSecret),
 		usageContextSecret: usageContextSecret,
 		requestTracker:     ratelimit.NewRequestTracker(),
+		cacheRouteShadow:   cacheroute.NewShadow(nil),
 		refreshInterval:    refreshInterval,
 	}
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -35,10 +35,9 @@ type Enclave struct {
 	metrics   *enclaveMetrics
 	cb        *circuitBreaker
 
-	// inflight counts requests currently being proxied through this
-	// enclave. Unlike the polled queue depth (up to ~45s stale), it is
-	// live, which is what least-loaded selection within a hot key's warm
-	// set needs (design doc §5.5).
+	// inflight counts requests currently proxied through this enclave —
+	// a live load signal, unlike the polled queue depth, which can be up
+	// to ~45s stale.
 	inflight atomic.Int64
 }
 
@@ -362,12 +361,11 @@ func (m *Model) EnclaveCount() int {
 	return len(m.Enclaves)
 }
 
-// CacheRoutePool snapshots the model's replica set for the cache-route
-// shadow: the breaker-closed enclaves with their live in-flight counts —
-// the stable HRW membership of the design doc's §5.3, deliberately ignoring
-// the overload flag so a flapping load signal can't re-home keys — falling
-// back to all enclaves when every breaker is open, mirroring NextEnclave's
-// degraded fallback.
+// CacheRoutePool snapshots the model's replica set for cache-aware routing:
+// breaker-closed enclaves with live in-flight counts, falling back to all
+// enclaves when every breaker is open (mirroring NextEnclave). The overload
+// flag is deliberately ignored — membership must stay stable so a flapping
+// load signal can't move a key's home.
 func (m *Model) CacheRoutePool() cacheroute.Pool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -19,6 +20,7 @@ import (
 	"github.com/tinfoilsh/tinfoil-go/verifier/sigstore"
 
 	"github.com/tinfoilsh/confidential-model-router/billing"
+	"github.com/tinfoilsh/confidential-model-router/cacheroute"
 	"github.com/tinfoilsh/confidential-model-router/config"
 	"github.com/tinfoilsh/confidential-model-router/ratelimit"
 )
@@ -32,6 +34,12 @@ type Enclave struct {
 	proxy     *httputil.ReverseProxy
 	metrics   *enclaveMetrics
 	cb        *circuitBreaker
+
+	// inflight counts requests currently being proxied through this
+	// enclave. Unlike the polled queue depth (up to ~45s stale), it is
+	// live, which is what least-loaded selection within a hot key's warm
+	// set needs (design doc §5.5).
+	inflight atomic.Int64
 }
 
 type Model struct {
@@ -41,6 +49,7 @@ type Model struct {
 	Enclaves          map[string]*Enclave      `json:"enclaves"`
 	Overload          *config.OverloadConfig   `json:"overload,omitempty"`
 	RateLimit         *config.RateLimitConfig  `json:"rate_limit,omitempty"`
+	CacheRoute        *config.CacheRouteConfig `json:"cache_route,omitempty"`
 
 	expectedHosts int // number of configured hostnames; 0 means no backends expected
 	mu            sync.RWMutex
@@ -353,6 +362,44 @@ func (m *Model) EnclaveCount() int {
 	return len(m.Enclaves)
 }
 
+// CacheRoutePool snapshots the model's replica set for the cache-route
+// shadow: the breaker-closed enclaves with their live in-flight counts —
+// the stable HRW membership of the design doc's §5.3, deliberately ignoring
+// the overload flag so a flapping load signal can't re-home keys — falling
+// back to all enclaves when every breaker is open, mirroring NextEnclave's
+// degraded fallback.
+func (m *Model) CacheRoutePool() cacheroute.Pool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	pool := cacheroute.Pool{Size: len(m.Enclaves)}
+	for _, enclave := range m.Enclaves {
+		if enclave.cb != nil && !enclave.cb.Closed() {
+			continue
+		}
+		pool.Candidates = append(pool.Candidates, cacheroute.Candidate{
+			Host:     enclave.host,
+			InFlight: int(enclave.inflight.Load()),
+		})
+	}
+	if len(pool.Candidates) == 0 {
+		for _, enclave := range m.Enclaves {
+			pool.Candidates = append(pool.Candidates, cacheroute.Candidate{
+				Host:     enclave.host,
+				InFlight: int(enclave.inflight.Load()),
+			})
+		}
+	}
+	return pool
+}
+
+// CacheRouteSettings returns the model's resolved cache-route settings.
+func (m *Model) CacheRouteSettings() cacheroute.Settings {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return cacheroute.SettingsFrom(m.CacheRoute)
+}
+
 // HasHealthyEnclave reports whether the model has at least one enclave whose
 // circuit breaker is currently closed. Used by ResolvePreferredModel to skip
 // models whose backends are all tripped (i.e. effectively down).
@@ -392,6 +439,9 @@ func (e *Enclave) isOverloaded() bool {
 }
 
 func (e *Enclave) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	e.inflight.Add(1)
+	defer e.inflight.Add(-1)
+
 	w.Header().Set("Tinfoil-Enclave", e.host)
 
 	// Check if client requested usage metrics in response header/trailer
@@ -493,8 +543,11 @@ func (em *EnclaveManager) addModel(modelName string, modelConfig config.Model) {
 		Enclaves:          make(map[string]*Enclave),
 		Overload:          modelConfig.Overload,
 		RateLimit:         modelConfig.RateLimit,
+		CacheRoute:        modelConfig.CacheRoute,
 		expectedHosts:     len(modelConfig.Hostnames),
 	})
+	cacheroute.SetMode(modelName, modelConfig.CacheRoute)
+	cacheroute.SetPoolInfo(modelName, modelConfig.Hostnames)
 }
 
 // updateModelMeasurements checks if there's a new tag, and if so, updates the model's tag and measurement
@@ -579,6 +632,7 @@ func (em *EnclaveManager) sync() error {
 				}
 				model.Enclaves = make(map[string]*Enclave)
 				model.mu.Unlock()
+				cacheroute.DropModel(modelName)
 				return
 			}
 
@@ -598,9 +652,12 @@ func (em *EnclaveManager) sync() error {
 			model.expectedHosts = len(configModel.Hostnames)
 			model.Overload = configModel.Overload
 			model.RateLimit = configModel.RateLimit
+			model.CacheRoute = configModel.CacheRoute
 			for _, enclave := range model.Enclaves {
 				enclave.updateOverloadConfig(model.Overload)
 			}
+			cacheroute.SetMode(modelName, configModel.CacheRoute)
+			cacheroute.SetPoolInfo(modelName, configModel.Hostnames)
 
 			// Updating enclaves for each model
 			log.Tracef("updating enclaves for model %s", modelName)

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -1,10 +1,14 @@
 package manager
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/tinfoilsh/confidential-model-router/cacheroute"
 	"github.com/tinfoilsh/confidential-model-router/config"
 )
 
@@ -177,4 +181,94 @@ func (em *EnclaveManager) mustModel(t *testing.T, name string) *Model {
 		t.Fatalf("model %q not found", name)
 	}
 	return m
+}
+
+func TestCacheRoutePool(t *testing.T) {
+	m := newTestModel("a", "b", "c")
+	m.Enclaves["b"].inflight.Add(3)
+
+	pool := m.CacheRoutePool()
+	if pool.Size != 3 || len(pool.Candidates) != 3 {
+		t.Fatalf("pool = %+v, want size 3 with 3 candidates", pool)
+	}
+	for _, c := range pool.Candidates {
+		if c.Host == "b" && c.InFlight != 3 {
+			t.Fatalf("candidate b in-flight = %d, want 3", c.InFlight)
+		}
+	}
+
+	// A tripped breaker leaves the stable membership.
+	tripBreaker(m.Enclaves["a"])
+	pool = m.CacheRoutePool()
+	if pool.Size != 3 || len(pool.Candidates) != 2 {
+		t.Fatalf("pool after trip = %+v, want size 3 with 2 candidates", pool)
+	}
+	for _, c := range pool.Candidates {
+		if c.Host == "a" {
+			t.Fatal("breaker-open enclave must not be a candidate")
+		}
+	}
+
+	// All breakers open: degraded fallback to the full pool, mirroring
+	// NextEnclave.
+	tripBreaker(m.Enclaves["b"])
+	tripBreaker(m.Enclaves["c"])
+	if pool = m.CacheRoutePool(); len(pool.Candidates) != 3 {
+		t.Fatalf("all-open pool = %+v, want fallback to all 3", pool)
+	}
+}
+
+func TestCacheRouteSettings(t *testing.T) {
+	m := newTestModel("a", "b")
+	if s := m.CacheRouteSettings(); s.Mode != cacheroute.ModeOff {
+		t.Fatalf("unconfigured mode = %s, want off", s.Mode)
+	}
+
+	m.CacheRoute = &config.CacheRouteConfig{Mode: "shadow", RetentionWindowMinutes: 5}
+	s := m.CacheRouteSettings()
+	if s.Mode != cacheroute.ModeShadow || s.Retention != 5*time.Minute {
+		t.Fatalf("settings = %+v, want shadow with 5m retention", s)
+	}
+}
+
+func TestEnclaveInflightTracking(t *testing.T) {
+	e := newTestEnclave("a")
+	release := make(chan struct{})
+	e.proxy = &httputil.ReverseProxy{
+		Director: func(r *http.Request) {},
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			<-release
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil
+		}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		req := httptest.NewRequest(http.MethodGet, "http://example/", nil)
+		e.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+
+	waitFor(t, func() bool { return e.inflight.Load() == 1 })
+	close(release)
+	<-done
+	if got := e.inflight.Load(); got != 0 {
+		t.Fatalf("in-flight after completion = %d, want 0", got)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition not reached in time")
 }

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -4,9 +4,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/tinfoilsh/confidential-model-router/cacheroute"
 	"github.com/tinfoilsh/confidential-model-router/config"
@@ -21,7 +25,7 @@ func newTestEnclave(host string) *Enclave {
 }
 
 func newTestModel(hosts ...string) *Model {
-	m := &Model{Enclaves: make(map[string]*Enclave, len(hosts))}
+	m := &Model{Enclaves: make(map[string]*Enclave, len(hosts)), expectedHosts: len(hosts)}
 	for _, h := range hosts {
 		m.Enclaves[h] = newTestEnclave(h)
 	}
@@ -216,6 +220,67 @@ func TestCacheRoutePool(t *testing.T) {
 	if pool = m.CacheRoutePool(); len(pool.Candidates) != 3 {
 		t.Fatalf("all-open pool = %+v, want fallback to all 3", pool)
 	}
+}
+
+// TestCacheRoutePoolSizeIsConfigured pins that Size reflects the config, not
+// the live enclave map: during a release the map is re-attested one host at a
+// time, and a multi-replica pool must stay routable for measurement.
+func TestCacheRoutePoolSizeIsConfigured(t *testing.T) {
+	m := newTestModel("a", "b", "c", "d")
+	delete(m.Enclaves, "b")
+	delete(m.Enclaves, "c")
+	delete(m.Enclaves, "d")
+
+	pool := m.CacheRoutePool()
+	if pool.Size != 4 {
+		t.Fatalf("Size = %d, want configured 4", pool.Size)
+	}
+	if len(pool.Candidates) != 1 {
+		t.Fatalf("candidates = %d, want the 1 live enclave", len(pool.Candidates))
+	}
+}
+
+// TestObserveCacheRoute covers the tool-loop observation gate: a shadow-mode
+// dispatch reaches the shadow's funnel, mode off and a missing shadow are
+// no-ops.
+func TestObserveCacheRoute(t *testing.T) {
+	body := map[string]any{
+		"cache_salt": strings.Repeat("0", 43),
+		"messages": []any{
+			map[string]any{"role": "system", "content": strings.Repeat("s", 5000)},
+			map[string]any{"role": "user", "content": "hello"},
+		},
+	}
+	model := newTestModel("a", "b")
+	model.CacheRoute = &config.CacheRouteConfig{Mode: "shadow"}
+	em := newTestManager(map[string]*Model{"tool-observed": model})
+	em.cacheRouteShadow = cacheroute.NewShadow(prometheus.NewRegistry())
+	defer em.cacheRouteShadow.Close()
+
+	keyed := func() float64 {
+		c, err := cacheroute.RequestsTotal.GetMetricWithLabelValues("tool-observed", string(cacheroute.OutcomeKeyed))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return testutil.ToFloat64(c)
+	}
+	base := keyed()
+
+	em.observeCacheRoute("tool-observed", "/v1/chat/completions", body, "a")
+	if got := keyed() - base; got != 1 {
+		t.Fatalf("keyed delta = %v, want 1", got)
+	}
+
+	// Mode off: no observation.
+	model.CacheRoute = nil
+	em.observeCacheRoute("tool-observed", "/v1/chat/completions", body, "a")
+	if got := keyed() - base; got != 1 {
+		t.Fatalf("keyed delta after mode off = %v, want 1", got)
+	}
+
+	// No shadow (tests construct managers without one): must not panic.
+	em.cacheRouteShadow = nil
+	em.observeCacheRoute("tool-observed", "/v1/chat/completions", body, "a")
 }
 
 func TestCacheRouteSettings(t *testing.T) {

--- a/manager/metrics_test.go
+++ b/manager/metrics_test.go
@@ -79,28 +79,31 @@ func TestEvaluateThresholds_ExplicitClearMark(t *testing.T) {
 }
 
 func TestEvaluateThresholds_TransitionCountersOncePerEpisode(t *testing.T) {
-	// Unique labels so the shared counters are zero-valued for this test.
 	m := newTestMetrics("transition-count-host", &config.OverloadConfig{MaxRequestsWaiting: 16})
+	// The shared counters carry values across test reruns in one process,
+	// so assert growth, not absolutes.
 	trips := OverloadEventsTotal.WithLabelValues("test-model", "transition-count-host")
 	recoveries := RecoveryEventsTotal.WithLabelValues("test-model", "transition-count-host")
+	tripBase := testutil.ToFloat64(trips)
+	recoveryBase := testutil.ToFloat64(recoveries)
 
 	// One episode: trip once, oscillate inside the band, then drain.
 	for _, waiting := range []float64{16, 12, 15, 9, 14, 16, 12} {
 		observe(m, waiting)
 	}
-	if got := testutil.ToFloat64(trips); got != 1 {
+	if got := testutil.ToFloat64(trips) - tripBase; got != 1 {
 		t.Fatalf("trip events during episode = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(recoveries); got != 0 {
+	if got := testutil.ToFloat64(recoveries) - recoveryBase; got != 0 {
 		t.Fatalf("recovery events during episode = %v, want 0", got)
 	}
 
 	observe(m, 8)
 	observe(m, 3)
-	if got := testutil.ToFloat64(recoveries); got != 1 {
+	if got := testutil.ToFloat64(recoveries) - recoveryBase; got != 1 {
 		t.Fatalf("recovery events after drain = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(trips); got != 1 {
+	if got := testutil.ToFloat64(trips) - tripBase; got != 1 {
 		t.Fatalf("trip events after drain = %v, want 1", got)
 	}
 }

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -297,15 +297,10 @@ func runResponsesLoop(ctx context.Context, em *manager.EnclaveManager, registry 
 // ---------------------------------------------------------------------------
 
 func postJSON(ctx context.Context, em *manager.EnclaveManager, modelName, path string, body map[string]any, requestHeaders http.Header) (*upstreamJSONResponse, error) {
-	bodyBytes, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-
 	reqHeaders := cloneHeaders(requestHeaders)
 	reqHeaders.Set("Content-Type", "application/json")
 
-	resp, err := em.DoModelRequest(ctx, modelName, path, bodyBytes, reqHeaders)
+	resp, err := em.DoModelRequestJSON(ctx, modelName, path, body, reqHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/toolruntime/stream_base.go
+++ b/toolruntime/stream_base.go
@@ -126,15 +126,11 @@ func (s *streamBase) openUpstreamSSE(
 	reqBody map[string]any,
 	requestHeaders http.Header,
 ) (io.ReadCloser, error) {
-	bodyBytes, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, err
-	}
 	hdrs := cloneHeaders(requestHeaders)
 	hdrs.Set("Content-Type", "application/json")
 	hdrs.Set("Accept", "text/event-stream")
 
-	resp, err := em.DoModelRequest(ctx, modelName, path, bodyBytes, hdrs)
+	resp, err := em.DoModelRequestJSON(ctx, modelName, path, reqBody, hdrs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Cache-aware replica routing, shipped in shadow mode: the router derives a routing key from each request, ranks the model's replicas with rendezvous hashing, and computes which replica cache-aware routing *would* pick — but only measures. Production replica selection is byte-for-byte unchanged, and nothing is enabled by default. The output is aggregate Prometheus metrics (the router runs inside an enclave with no log sink), built to answer one question per panel: is there enough missed prefix reuse to justify routing on it, are the would-be homes balanced, and do hot keys split sanely?

## How it works

- **`cacheroute/` (new package)** — key derivation frozen and vector-pinned: domain tag `tinfoil/route-key/v1`, length-prefixed `salt ‖ prompt_cache_key ‖ 1KB prefix window` built from the parsed `tools`/system/first-user fields (never raw body bytes, so sampling params and marshaler field order can't split a key). Multimodal content flattens through a budget-bounded deterministic walker instead of `json.Marshal`, so megabyte image payloads can't blow the sub-1ms shadow budget.
- **Reuse classification** — a bounded LRU key table (100k keys, tens of MB) records where each key's requests actually landed. Each keyed request classifies as `first_seen`, `repeat_warm` (random routing already got the hit), or `repeat_cold` (a warm prefix existed on a replica the pick missed — the reuse routing would capture). Byte-weighted variants size that in prefill cost.
- **Wiring** — two hooks in `main.go` for the plain proxy path (derive the key once the body is final, observe right before `ServeHTTP`), and `DoModelRequestJSON` in the manager for the tool loop, which observes every loop iteration at dispatch — the growing-prefix replay that benefits most from routing. Panic-recovered, off the request error path, ~5µs mean overhead in a simulated-traffic run.
- **Rollout knob** — per-model config `cache_route: {mode: off|shadow|enforced}` plus optional `retention_window_minutes`, `min_prompt_bytes`, `split_threshold_rpm`, refreshed on the normal config sync. `enforced` is accepted but clamps to shadow with a warning until enforcement ships; the mode gauge reports the effective mode.
- **Privacy** — no per-request records, no debug IDs; every metric label is a closed enum; per-key state never leaves the enclave. Also adds a live per-enclave in-flight counter (the polled queue depth is up to ~45s stale) feeding the least-loaded pick within a hot key's warm set.

## Metric contract

`router_cache_route_{requests,reuse,reuse_prompt_bytes,picks,random_match,key_evictions}_total`, `{repeat_interval_seconds,key_rpm,compute_seconds}` histograms, `{tracked_keys,pool_info,mode}` gauges. Names carry no "shadow" so the same panels verify the eventual enforcement flip — `repeat_cold` collapsing toward zero is the success signal. `pool_info` hashes each model's sorted configured replica set; instances that agree on it compute identical rankings by construction.

## Testing

- 20 new tests: key construction pinned by a hand-framed reference + golden vector; window-cap behavior in both directions; multimodal boundedness; determinism across JSON decodes; endpoint shapes (chat/responses/completions); malformed-shape safety; classification lifecycle including staleness; LRU capacity bias; TTL retention; hot-key replication growth; random-match sanity; tracked-keys collector; info-series replacement; breaker filtering with degraded fallback; in-flight lifecycle; config parsing; and a metric-contract test pinning every exposed name and label set.
- `go test ./...` green (10 packages), `-race` clean on `cacheroute` and `manager`, `go vet`/`gofmt` clean.
- Drove the real scrape surface with simulated traffic: exposition matches the contract exactly; `random_match_total` landed at exactly 1/N on a 4-replica pool.

## Rollout

Deploy, then flip one salted multi-replica pool via config (`cache_route: {mode: shadow}`). Shadow data is only meaningful where `cache_salt` injection is live — unsalted requests classify `no_salt` and derive no key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
