### PR TITLE
Enable cache-route shadow mode on the N≥2 pools

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -44,6 +44,8 @@ models:
       - glm-5-2-inf7.tinfoil.containers.tinfoil.dev
       - glm-5-2-inf11.tinfoil.containers.tinfoil.dev
       - glm-5-2-inf12.tinfoil.containers.tinfoil.dev
+    cache_route:
+      mode: shadow
 
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
@@ -53,6 +55,8 @@ models:
     overload:
       max_requests_waiting: 8
       retry_after_minutes: 1
+    cache_route:
+      mode: shadow
 
   gpt-oss-safeguard-120b:
     repo: tinfoilsh/confidential-gpt-oss-safeguard-120b
@@ -98,3 +102,5 @@ models:
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1
+    cache_route:
+      mode: shadow


### PR DESCRIPTION
Flips `gemma4-31b`, `glm-5-2`, and `gpt-oss-120b` to `cache_route: {mode: shadow}` so the Phase 4 exit questions start accumulating data. Config-only — routers pick it up on their next refresh, no redeploy.

Shadow observes the production pick after selection and cannot change routing. Watch it on the [Cache-Aware Routing dashboard](/d/cache-aware-routing) Phase 4 section: guardrails must stay green (compute p99 <1ms, zero pipeline errors, zero capacity evictions, zero pool-hash disagreements, random-match calibration ≈1.0), then the exit read after a full traffic week: repeat-cold byte share (the prize), home balance, and R>1 share.

Rollback: set `mode: off` or delete the block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables `cache_route: { mode: shadow }` for `gemma4-31b`, `glm-5-2`, and `gpt-oss-120b` to start Phase 4 data collection. Shadow is observation-only and does not change routing.

- **Migration**
  - No deploy needed; routers pick this up on their next config refresh.
  - Rollback: set `mode: off` or remove the `cache_route` block.

<sup>Written for commit cf493f535e2f96f912d15eeced16a192dc41bd24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

