### PR TITLE
Return only served models from /v1/models

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,15 +152,15 @@ func sendJSON(w http.ResponseWriter, data any) {
 
 // filterModelsToServed narrows an OpenAI-compatible /v1/models payload to the
 // models this router actually serves, so the list reflects local availability
-// rather than the control plane's full catalog. Returns false if the payload
-// can't be parsed, signalling the caller to pass it through unchanged.
-func filterModelsToServed(body []byte, served map[string]*manager.Model) ([]byte, bool) {
+// rather than the control plane's full catalog. Returns an error if the payload
+// can't be parsed, so the caller can surface the upstream problem.
+func filterModelsToServed(body []byte, served map[string]*manager.Model) ([]byte, error) {
 	var payload struct {
 		Object string           `json:"object"`
 		Data   []map[string]any `json:"data"`
 	}
 	if err := json.Unmarshal(body, &payload); err != nil {
-		return nil, false
+		return nil, fmt.Errorf("parsing models list: %w", err)
 	}
 
 	kept := make([]map[string]any, 0, len(payload.Data))
@@ -181,9 +181,9 @@ func filterModelsToServed(body []byte, served map[string]*manager.Model) ([]byte
 		"data":   kept,
 	})
 	if err != nil {
-		return nil, false
+		return nil, fmt.Errorf("encoding models list: %w", err)
 	}
-	return out, true
+	return out, nil
 }
 
 func isWebSocketUpgrade(r *http.Request) bool {
@@ -519,18 +519,24 @@ func main() {
 					return
 				}
 				w.Header().Set("Content-Type", "application/json")
-				// Narrow the control plane's full catalog to the models this
-				// router actually serves. On any parse failure, pass the
-				// upstream response through untouched.
-				if resp.StatusCode == http.StatusOK {
-					if filtered, ok := filterModelsToServed(body, em.Models()); ok {
-						w.WriteHeader(http.StatusOK)
-						w.Write(filtered)
-						return
-					}
+				// Forward upstream errors as-is; only a 200 is a models list
+				// we should rewrite.
+				if resp.StatusCode != http.StatusOK {
+					w.WriteHeader(resp.StatusCode)
+					w.Write(body)
+					return
 				}
-				w.WriteHeader(resp.StatusCode)
-				w.Write(body)
+				// A 200 we can't parse means the control plane returned
+				// something unexpected — surface it rather than forwarding a
+				// body we couldn't filter.
+				filtered, err := filterModelsToServed(body, em.Models())
+				if err != nil {
+					log.Errorf("filtering /v1/models response: %v", err)
+					jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusBadGateway)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				w.Write(filtered)
 				return
 			} else if r.URL.Path == "/v1/audio/speech" {
 				// Extract model from JSON body, default to qwen3-tts

--- a/main.go
+++ b/main.go
@@ -150,6 +150,42 @@ func sendJSON(w http.ResponseWriter, data any) {
 	}
 }
 
+// filterModelsToServed narrows an OpenAI-compatible /v1/models payload to the
+// models this router actually serves, so the list reflects local availability
+// rather than the control plane's full catalog. Returns false if the payload
+// can't be parsed, signalling the caller to pass it through unchanged.
+func filterModelsToServed(body []byte, served map[string]*manager.Model) ([]byte, bool) {
+	var payload struct {
+		Object string           `json:"object"`
+		Data   []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, false
+	}
+
+	kept := make([]map[string]any, 0, len(payload.Data))
+	for _, entry := range payload.Data {
+		if id, ok := entry["id"].(string); ok {
+			if _, served := served[id]; served {
+				kept = append(kept, entry)
+			}
+		}
+	}
+
+	object := payload.Object
+	if object == "" {
+		object = "list"
+	}
+	out, err := json.Marshal(map[string]any{
+		"object": object,
+		"data":   kept,
+	})
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
 func isWebSocketUpgrade(r *http.Request) bool {
 	if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
 		return false
@@ -477,9 +513,24 @@ func main() {
 					return
 				}
 				defer resp.Body.Close()
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusBadGateway)
+					return
+				}
 				w.Header().Set("Content-Type", "application/json")
+				// Narrow the control plane's full catalog to the models this
+				// router actually serves. On any parse failure, pass the
+				// upstream response through untouched.
+				if resp.StatusCode == http.StatusOK {
+					if filtered, ok := filterModelsToServed(body, em.Models()); ok {
+						w.WriteHeader(http.StatusOK)
+						w.Write(filtered)
+						return
+					}
+				}
 				w.WriteHeader(resp.StatusCode)
-				io.Copy(w, resp.Body)
+				w.Write(body)
 				return
 			} else if r.URL.Path == "/v1/audio/speech" {
 				// Extract model from JSON body, default to qwen3-tts

--- a/main_test.go
+++ b/main_test.go
@@ -669,9 +669,9 @@ func TestFilterModelsToServed(t *testing.T) {
 		{"id":"glm-5-2","name":"GLM-5.2","type":"chat"}
 	]}`)
 
-	out, ok := filterModelsToServed(body, served)
-	if !ok {
-		t.Fatal("expected ok=true for a well-formed payload")
+	out, err := filterModelsToServed(body, served)
+	if err != nil {
+		t.Fatalf("unexpected error for a well-formed payload: %v", err)
 	}
 
 	var parsed struct {
@@ -702,7 +702,7 @@ func TestFilterModelsToServed(t *testing.T) {
 }
 
 func TestFilterModelsToServedRejectsMalformed(t *testing.T) {
-	if _, ok := filterModelsToServed([]byte(`{bad json`), map[string]*manager.Model{}); ok {
-		t.Error("expected ok=false for malformed payload so caller passes it through")
+	if _, err := filterModelsToServed([]byte(`{bad json`), map[string]*manager.Model{}); err == nil {
+		t.Error("expected an error for a malformed payload so the caller can surface it")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/tinfoilsh/confidential-model-router/manager"
 	"github.com/tinfoilsh/confidential-model-router/toolruntime"
 )
 
@@ -653,5 +654,55 @@ func TestResolveAutoModel_MissingOptions(t *testing.T) {
 	}
 	if _, ok := body["auto_model_options"]; ok {
 		t.Fatal("auto_model_options should be stripped even on error")
+	}
+}
+
+func TestFilterModelsToServed(t *testing.T) {
+	served := map[string]*manager.Model{
+		"kimi-k2-6": {},
+		"glm-5-2":   {},
+	}
+
+	body := []byte(`{"object":"list","data":[
+		{"id":"kimi-k2-6","name":"Kimi K2.6","type":"chat"},
+		{"id":"deepseek-v4-pro","name":"DeepSeek V4 Pro","type":"chat"},
+		{"id":"glm-5-2","name":"GLM-5.2","type":"chat"}
+	]}`)
+
+	out, ok := filterModelsToServed(body, served)
+	if !ok {
+		t.Fatal("expected ok=true for a well-formed payload")
+	}
+
+	var parsed struct {
+		Object string           `json:"object"`
+		Data   []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("unmarshal filtered output: %v", err)
+	}
+	if parsed.Object != "list" {
+		t.Errorf("object = %q, want %q", parsed.Object, "list")
+	}
+
+	gotIDs := make(map[string]map[string]any)
+	for _, m := range parsed.Data {
+		gotIDs[m["id"].(string)] = m
+	}
+	if len(gotIDs) != 2 {
+		t.Fatalf("kept %d models, want 2: %v", len(gotIDs), gotIDs)
+	}
+	if _, ok := gotIDs["deepseek-v4-pro"]; ok {
+		t.Error("deepseek-v4-pro is not served but was kept")
+	}
+	// Passthrough fields (name) must survive filtering.
+	if kimi := gotIDs["kimi-k2-6"]; kimi == nil || kimi["name"] != "Kimi K2.6" {
+		t.Errorf("kimi-k2-6 name not preserved: %v", kimi)
+	}
+}
+
+func TestFilterModelsToServedRejectsMalformed(t *testing.T) {
+	if _, ok := filterModelsToServed([]byte(`{bad json`), map[string]*manager.Model{}); ok {
+		t.Error("expected ok=false for malformed payload so caller passes it through")
 	}
 }


### PR DESCRIPTION
Filters the control plane's model list down to what this router actually serves (its `config.yml`), instead of proxying the full catalog. Falls back to passthrough on any parse error.

Pairs with the name/description passthrough: tinfoilsh/controlplane#491

