### PR TITLE
feat: enforce cache-aware routing on pools with mode: enforced

### DIFF
--- a/cache_salt_test.go
+++ b/cache_salt_test.go
@@ -369,14 +369,18 @@ func TestRecordCacheSaltInjection(t *testing.T) {
 		t.Errorf("ModeNone minted a series: %d -> %d", before, after)
 	}
 
+	// The shared counters carry values across test reruns in one process,
+	// so assert growth, not absolutes.
+	tenantBase := testutil.ToFloat64(manager.CacheSaltInjectionsTotal.WithLabelValues("record-metric-count", "tenant"))
+	userBase := testutil.ToFloat64(manager.CacheSaltInjectionsTotal.WithLabelValues("record-metric-count", "user"))
 	recordCacheSaltInjection("record-metric-count", cachesalt.ModeTenant)
 	recordCacheSaltInjection("record-metric-count", cachesalt.ModeUser)
 	recordCacheSaltInjection("record-metric-count", cachesalt.ModeUser)
-	if got := testutil.ToFloat64(manager.CacheSaltInjectionsTotal.WithLabelValues("record-metric-count", "tenant")); got != 1 {
-		t.Errorf(`series {record-metric-count,tenant} = %v, want 1`, got)
+	if got := testutil.ToFloat64(manager.CacheSaltInjectionsTotal.WithLabelValues("record-metric-count", "tenant")) - tenantBase; got != 1 {
+		t.Errorf(`series {record-metric-count,tenant} delta = %v, want 1`, got)
 	}
-	if got := testutil.ToFloat64(manager.CacheSaltInjectionsTotal.WithLabelValues("record-metric-count", "user")); got != 2 {
-		t.Errorf(`series {record-metric-count,user} = %v, want 2`, got)
+	if got := testutil.ToFloat64(manager.CacheSaltInjectionsTotal.WithLabelValues("record-metric-count", "user")) - userBase; got != 2 {
+		t.Errorf(`series {record-metric-count,user} delta = %v, want 2`, got)
 	}
 }
 

--- a/cacheroute/cacheroute.go
+++ b/cacheroute/cacheroute.go
@@ -47,22 +47,21 @@ const (
 	ModeOff Mode = "off"
 	// ModeShadow computes and meters routing decisions without acting.
 	ModeShadow Mode = "shadow"
-	// ModeEnforced acts on routing decisions. Not implemented yet;
-	// resolveMode clamps it to ModeShadow.
+	// ModeEnforced acts on routing decisions: keyed requests are served
+	// by their cache-aware pick instead of a random replica.
 	ModeEnforced Mode = "enforced"
 )
 
-// resolveMode maps a raw config string to the mode this build runs,
-// reporting clamped=true when enforcement was requested but isn't
-// available. Unknown values resolve to off.
-func resolveMode(raw string) (mode Mode, clamped bool) {
+// resolveMode maps a raw config string to a mode. Unknown values resolve to
+// off.
+func resolveMode(raw string) Mode {
 	switch Mode(raw) {
 	case ModeShadow:
-		return ModeShadow, false
+		return ModeShadow
 	case ModeEnforced:
-		return ModeShadow, true
+		return ModeEnforced
 	default:
-		return ModeOff, false
+		return ModeOff
 	}
 }
 
@@ -86,7 +85,7 @@ func SettingsFrom(c *config.CacheRouteConfig) Settings {
 	if c == nil {
 		return s
 	}
-	s.Mode, _ = resolveMode(c.Mode)
+	s.Mode = resolveMode(c.Mode)
 	if c.RetentionWindowMinutes > 0 {
 		s.Retention = time.Duration(c.RetentionWindowMinutes) * time.Minute
 	}

--- a/cacheroute/cacheroute.go
+++ b/cacheroute/cacheroute.go
@@ -1,10 +1,11 @@
-// Package cacheroute implements cache-aware replica routing in shadow mode:
-// it derives a routing key from the parsed request body, ranks a model's
-// replicas with rendezvous hashing, and measures what cache-aware routing
-// would have done — without influencing which replica serves a request.
+// Package cacheroute implements cache-aware replica routing: it derives a
+// routing key from the parsed request body, ranks a model's replicas with
+// rendezvous hashing, and — per pool — either only measures what routing
+// would have done (shadow) or drives replica selection (enforced, via
+// Shadow.Decide feeding the manager's selectors).
 //
 // The router's only telemetry channel is Prometheus, so everything the
-// shadow learns is exported as aggregate metrics over closed label sets.
+// pipeline learns is exported as aggregate metrics over closed label sets.
 // Per-key state stays in process memory; a routing key, or anything derived
 // from one, must never appear in a label or log line.
 package cacheroute

--- a/cacheroute/cacheroute_test.go
+++ b/cacheroute/cacheroute_test.go
@@ -313,10 +313,8 @@ func TestSettingsFrom(t *testing.T) {
 		t.Fatalf("explicit config not applied: %+v", s)
 	}
 
-	// Enforcement is not implemented: the config value is accepted but
-	// clamped to shadow.
-	if s := SettingsFrom(&config.CacheRouteConfig{Mode: "enforced"}); s.Mode != ModeShadow {
-		t.Fatalf("enforced must clamp to shadow in this build, got %s", s.Mode)
+	if s := SettingsFrom(&config.CacheRouteConfig{Mode: "enforced"}); s.Mode != ModeEnforced {
+		t.Fatalf("enforced must resolve to enforced, got %s", s.Mode)
 	}
 	if s := SettingsFrom(&config.CacheRouteConfig{Mode: "bogus"}); s.Mode != ModeOff {
 		t.Fatalf("unknown mode must resolve to off, got %s", s.Mode)

--- a/cacheroute/metrics.go
+++ b/cacheroute/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/tinfoilsh/confidential-model-router/cachesalt"
 	"github.com/tinfoilsh/confidential-model-router/config"
@@ -154,6 +155,7 @@ var (
 	infoMu       sync.Mutex
 	lastPoolHash = map[string]string{}
 	lastMode     = map[string]Mode{}
+	lastRawMode  = map[string]string{}
 )
 
 // SetPoolInfo publishes the pool_info series for a model from its configured
@@ -181,7 +183,10 @@ func SetPoolInfo(model string, hostnames []string) {
 	PoolInfo.WithLabelValues(model, hash).Set(1)
 }
 
-// SetMode publishes the effective mode for a model.
+// SetMode publishes the effective mode for a model, logging when a
+// configured value is unrecognized: mode is a live traffic lever, and a
+// typo silently resolving to off would otherwise leave only the gauge as
+// evidence.
 func SetMode(model string, cfg *config.CacheRouteConfig) {
 	raw := ""
 	if cfg != nil {
@@ -190,6 +195,13 @@ func SetMode(model string, cfg *config.CacheRouteConfig) {
 	mode := resolveMode(raw)
 
 	infoMu.Lock()
+	if raw != "" && raw != string(ModeOff) && mode == ModeOff && lastRawMode[model] != raw {
+		log.WithFields(log.Fields{
+			"model": model,
+			"mode":  raw,
+		}).Error("unrecognized cache_route mode; treating as off")
+	}
+	lastRawMode[model] = raw
 	defer infoMu.Unlock()
 	if prev, ok := lastMode[model]; ok && prev != mode {
 		ModeInfo.DeleteLabelValues(model, string(prev))
@@ -210,4 +222,5 @@ func DropModel(model string) {
 		ModeInfo.DeleteLabelValues(model, string(prev))
 		delete(lastMode, model)
 	}
+	delete(lastRawMode, model)
 }

--- a/cacheroute/metrics.go
+++ b/cacheroute/metrics.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/tinfoilsh/confidential-model-router/cachesalt"
 	"github.com/tinfoilsh/confidential-model-router/config"
@@ -182,21 +181,13 @@ func SetPoolInfo(model string, hostnames []string) {
 	PoolInfo.WithLabelValues(model, hash).Set(1)
 }
 
-// SetMode publishes the effective mode for a model, logging when it clamps
-// a configured "enforced" down to shadow so config intent and router
-// behavior can't silently diverge.
+// SetMode publishes the effective mode for a model.
 func SetMode(model string, cfg *config.CacheRouteConfig) {
 	raw := ""
 	if cfg != nil {
 		raw = cfg.Mode
 	}
-	mode, clamped := resolveMode(raw)
-	if clamped {
-		log.WithFields(log.Fields{
-			"model": model,
-			"mode":  raw,
-		}).Warn("cache_route mode 'enforced' is not implemented in this build; running shadow")
-	}
+	mode := resolveMode(raw)
 
 	infoMu.Lock()
 	defer infoMu.Unlock()

--- a/cacheroute/shadow.go
+++ b/cacheroute/shadow.go
@@ -39,10 +39,11 @@ const (
 	ReuseRepeatCold = "repeat_cold"
 )
 
-// Shadow measures what cache-aware routing would do without acting: a
-// bounded, evicting table keyed by routing key records where each key's
-// requests actually landed, and Observe turns that into the aggregate
-// metrics in metrics.go. Per-key state never leaves this process.
+// Shadow is the cache-aware routing engine: a bounded, evicting table keyed
+// by routing key records where each key's requests actually landed. On
+// shadow pools Observe only measures; on enforced pools Decide drives
+// replica selection and ObserveLanding records it. Per-key state never
+// leaves this process.
 type Shadow struct {
 	mu      sync.Mutex
 	entries map[string]*entry // table key: model \x00 routing key
@@ -134,21 +135,87 @@ func (s *Shadow) Close() {
 	close(s.done)
 }
 
+// Decision is one keyed request's routing decision, made before dispatch by
+// Decide and consumed by ObserveLanding once the landing is known — one
+// ranking and one pool snapshot per request, so the recorded replication
+// factor is the one that actually shaped routing.
+type Decision struct {
+	// Order is the host preference: the pick (least-loaded of the key's
+	// top-R replicas) first, then the rest of the ranking, so an
+	// unacceptable pick spills to the next-warmest host.
+	Order []string
+
+	pool    Pool
+	home    string
+	r       int
+	elapsed time.Duration
+}
+
+// Decide computes the routing decision for a keyed request on an enforced
+// pool. Nil when the request is not keyed or the pool is too small — the
+// caller falls back to random selection — and on a recovered panic, so a
+// derivation bug degrades to random routing instead of failing the request.
+// Read-only: rate and warmth accounting happen at landing time.
+func (s *Shadow) Decide(model string, req *Request, pool Pool, cfg Settings) (d *Decision) {
+	start := time.Now()
+	defer func() {
+		if r := recover(); r != nil {
+			RequestsTotal.WithLabelValues(model, string(OutcomeError)).Inc()
+			d = nil
+		}
+	}()
+
+	if req == nil || req.Outcome != OutcomeKeyed || pool.Size < 2 || len(pool.Candidates) == 0 {
+		return nil
+	}
+	ranked := rank(req.Key, pool.Candidates)
+	r := replicationFactor(s.peekRate(model, req.Key), cfg.SplitThresholdRPM, len(ranked))
+	pick := leastLoaded(ranked[:r]).Host
+	order := make([]string, 0, len(ranked))
+	order = append(order, pick)
+	for _, c := range ranked {
+		if c.Host != pick {
+			order = append(order, c.Host)
+		}
+	}
+	return &Decision{
+		Order:   order,
+		pool:    pool,
+		home:    ranked[0].Host,
+		r:       r,
+		elapsed: time.Since(start),
+	}
+}
+
 // Observe runs the shadow pipeline for one request after the production
 // selector has picked a replica: classify the request against the table,
 // compute the would-be pick, update state, increment metrics. It must never
 // affect the request — panics are recovered into OutcomeError.
 func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost string, cfg Settings) {
+	s.observe(model, req, pool, actualHost, nil, cfg)
+}
+
+// ObserveLanding records the landing of a dispatch routed by d, reusing the
+// decision's pool snapshot and ranking so the metrics describe the decision
+// that was actually made.
+func (s *Shadow) ObserveLanding(model string, req *Request, d *Decision, actualHost string, cfg Settings) {
+	s.observe(model, req, d.pool, actualHost, d, cfg)
+}
+
+func (s *Shadow) observe(model string, req *Request, pool Pool, actualHost string, d *Decision, cfg Settings) {
 	start := time.Now()
 	defer func() {
 		if r := recover(); r != nil {
 			RequestsTotal.WithLabelValues(model, string(OutcomeError)).Inc()
 		}
-		var extraction time.Duration
+		var elapsed time.Duration
 		if req != nil {
-			extraction = req.elapsed
+			elapsed = req.elapsed
 		}
-		ComputeSeconds.Observe((extraction + time.Since(start)).Seconds())
+		if d != nil {
+			elapsed += d.elapsed
+		}
+		ComputeSeconds.Observe((elapsed + time.Since(start)).Seconds())
 	}()
 
 	if req.Outcome != OutcomeKeyed {
@@ -166,7 +233,7 @@ func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost strin
 		return
 	}
 
-	res := s.observeKeyed(model, req.Key, pool.Candidates, actualHost, cfg)
+	res := s.observeKeyed(model, req.Key, pool.Candidates, actualHost, d, cfg)
 
 	RequestsTotal.WithLabelValues(model, string(OutcomeKeyed)).Inc()
 	ReuseTotal.WithLabelValues(model, res.reuse).Inc()
@@ -187,10 +254,11 @@ func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost strin
 	if !hostIn(pool.Candidates, actualHost) {
 		return
 	}
-	if cfg.Mode == ModeEnforced {
+	if d != nil || cfg.Mode == ModeEnforced {
 		// The landing is the cache-aware pick (modulo overload spill), so
-		// record the real routed distribution and leave the random
-		// comparison quiet.
+		// record the real routed distribution — labeled with the
+		// replication factor that shaped the routing when a decision is
+		// available — and leave the random comparison quiet.
 		PicksTotal.WithLabelValues(model, actualHost, strconv.Itoa(res.r)).Inc()
 		return
 	}
@@ -198,29 +266,6 @@ func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost strin
 	if res.pick == actualHost {
 		RandomMatchTotal.WithLabelValues(model).Inc()
 	}
-}
-
-// PreferenceOrder returns the cache-aware host order for a keyed request:
-// the least-loaded of the key's top-R replicas first, then the remaining
-// ranking, so an unacceptable pick spills to the next-warmest host. Nil when
-// the request is not keyed or the pool is too small — the caller falls back
-// to random selection. Read-only: rate and warmth accounting happen in
-// Observe at dispatch.
-func (s *Shadow) PreferenceOrder(model string, req *Request, pool Pool, cfg Settings) []string {
-	if req == nil || req.Outcome != OutcomeKeyed || pool.Size < 2 || len(pool.Candidates) == 0 {
-		return nil
-	}
-	ranked := rank(req.Key, pool.Candidates)
-	r := replicationFactor(s.peekRate(model, req.Key), cfg.SplitThresholdRPM, len(ranked))
-	pick := leastLoaded(ranked[:r]).Host
-	order := make([]string, 0, len(ranked))
-	order = append(order, pick)
-	for _, c := range ranked {
-		if c.Host != pick {
-			order = append(order, c.Host)
-		}
-	}
-	return order
 }
 
 // peekRate reads a key's current request rate without recording an arrival.
@@ -251,13 +296,15 @@ type keyedResult struct {
 	repeat   bool // the key was already in the table
 	interval time.Duration
 	rpm      float64
-	pick     string // least-loaded of the top-R ranking
+	pick     string // least-loaded of the top-R ranking; unset when a Decision was supplied
 	r        int
 }
 
 // observeKeyed does the table touch, classification, and ranking for one
-// keyed request under a single lock acquisition.
-func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, actualHost string, cfg Settings) keyedResult {
+// keyed request under a single lock acquisition. When d is non-nil the
+// dispatch was routed by that decision, so its home and replication factor
+// are recorded instead of re-deriving them.
+func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, actualHost string, d *Decision, cfg Settings) keyedResult {
 	now := s.now()
 	// Scope the table key by model: the routing key contains no model id,
 	// so the same salted prompt sent to two models collides — but warmth
@@ -298,12 +345,17 @@ func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, act
 	e.lastSeen = now
 	e.expiry = now.Add(retentionFactor * cfg.Retention)
 
-	ranked := rank(key, candidates)
-	res.r = replicationFactor(res.rpm, cfg.SplitThresholdRPM, len(ranked))
-	res.pick = leastLoaded(ranked[:res.r]).Host
-	s.shiftCountLocked(model, e.home, e.r, ranked[0].Host, res.r)
-	e.home = ranked[0].Host
-	e.r = res.r
+	home := ""
+	if d != nil {
+		home, res.r = d.home, d.r
+	} else {
+		ranked := rank(key, candidates)
+		res.r = replicationFactor(res.rpm, cfg.SplitThresholdRPM, len(ranked))
+		res.pick = leastLoaded(ranked[:res.r]).Host
+		home = ranked[0].Host
+	}
+	s.shiftCountLocked(model, e.home, e.r, home, res.r)
+	e.home, e.r = home, res.r
 
 	return res
 }

--- a/cacheroute/shadow.go
+++ b/cacheroute/shadow.go
@@ -187,10 +187,51 @@ func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost strin
 	if !hostIn(pool.Candidates, actualHost) {
 		return
 	}
+	if cfg.Mode == ModeEnforced {
+		// The landing is the cache-aware pick (modulo overload spill), so
+		// record the real routed distribution and leave the random
+		// comparison quiet.
+		PicksTotal.WithLabelValues(model, actualHost, strconv.Itoa(res.r)).Inc()
+		return
+	}
 	PicksTotal.WithLabelValues(model, res.pick, strconv.Itoa(res.r)).Inc()
 	if res.pick == actualHost {
 		RandomMatchTotal.WithLabelValues(model).Inc()
 	}
+}
+
+// PreferenceOrder returns the cache-aware host order for a keyed request:
+// the least-loaded of the key's top-R replicas first, then the remaining
+// ranking, so an unacceptable pick spills to the next-warmest host. Nil when
+// the request is not keyed or the pool is too small — the caller falls back
+// to random selection. Read-only: rate and warmth accounting happen in
+// Observe at dispatch.
+func (s *Shadow) PreferenceOrder(model string, req *Request, pool Pool, cfg Settings) []string {
+	if req == nil || req.Outcome != OutcomeKeyed || pool.Size < 2 || len(pool.Candidates) == 0 {
+		return nil
+	}
+	ranked := rank(req.Key, pool.Candidates)
+	r := replicationFactor(s.peekRate(model, req.Key), cfg.SplitThresholdRPM, len(ranked))
+	pick := leastLoaded(ranked[:r]).Host
+	order := make([]string, 0, len(ranked))
+	order = append(order, pick)
+	for _, c := range ranked {
+		if c.Host != pick {
+			order = append(order, c.Host)
+		}
+	}
+	return order
+}
+
+// peekRate reads a key's current request rate without recording an arrival.
+func (s *Shadow) peekRate(model string, key Key) float64 {
+	tableKey := model + "\x00" + string(key[:])
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e := s.entries[tableKey]; e != nil {
+		return e.peekRate(s.now())
+	}
+	return 0
 }
 
 // hostIn reports whether host is one of the candidates.
@@ -367,6 +408,21 @@ func (e *entry) bumpRate(now time.Time) float64 {
 	}
 	frac := now.Sub(minute).Seconds() / 60
 	return float64(e.prevCount)*(1-frac) + float64(e.curCount)
+}
+
+// peekRate is bumpRate without the arrival: the sliding-window rate as of
+// now, aging the window forward when the minute has rolled over.
+func (e *entry) peekRate(now time.Time) float64 {
+	minute := now.Truncate(time.Minute)
+	frac := now.Sub(minute).Seconds() / 60
+	switch {
+	case e.windowStart.Equal(minute):
+		return float64(e.prevCount)*(1-frac) + float64(e.curCount)
+	case minute.Sub(e.windowStart) == time.Minute:
+		return float64(e.curCount) * (1 - frac)
+	default:
+		return 0
+	}
 }
 
 // sweeper drains expired entries until Close.

--- a/cacheroute/shadow_test.go
+++ b/cacheroute/shadow_test.go
@@ -392,65 +392,58 @@ func TestObserveProbeServed(t *testing.T) {
 	}
 }
 
-// TestPreferenceOrder pins the enforcement ordering contract: the pick
-// first, then the rest of the ranking, covering every candidate exactly
-// once; ineligible requests yield nil so callers fall back to random.
-func TestPreferenceOrder(t *testing.T) {
+// TestDecide pins the enforcement ordering contract: the pick first, then
+// the rest of the ranking, covering every candidate exactly once;
+// ineligible requests yield nil so callers fall back to random.
+func TestDecide(t *testing.T) {
 	s, _, _ := newTestShadow(t)
 	model := "order-" + t.Name()
 	cfg := defaultSettings()
 	req := keyedRequest(t, "o", 1)
 	pool := Pool{Size: 3, Candidates: hosts("enclave-a", "enclave-b", "enclave-c")}
 
-	order := s.PreferenceOrder(model, req, pool, cfg)
-	if len(order) != 3 {
-		t.Fatalf("order = %v, want all 3 candidates", order)
+	d := s.Decide(model, req, pool, cfg)
+	if d == nil || len(d.Order) != 3 {
+		t.Fatalf("decision = %+v, want an order over all 3 candidates", d)
 	}
 	seen := map[string]bool{}
-	for _, h := range order {
+	for _, h := range d.Order {
 		if seen[h] {
-			t.Fatalf("order = %v, duplicate host", order)
+			t.Fatalf("order = %v, duplicate host", d.Order)
 		}
 		seen[h] = true
 	}
 	for range 5 {
-		again := s.PreferenceOrder(model, req, pool, cfg)
-		for i := range order {
-			if again[i] != order[i] {
-				t.Fatalf("order not deterministic: %v vs %v", again, order)
+		again := s.Decide(model, req, pool, cfg)
+		for i := range d.Order {
+			if again.Order[i] != d.Order[i] {
+				t.Fatalf("order not deterministic: %v vs %v", again.Order, d.Order)
 			}
 		}
 	}
 
-	// The first element is the ranking's home for a cold key (R = 1): the
-	// same host Observe would report as the would-be pick.
-	s.Observe(model, req, pool, "enclave-a", cfg)
-	pick := "enclave-a"
-	if counterValue(t, RandomMatchTotal, model) == 0 {
-		for _, h := range []string{"enclave-b", "enclave-c"} {
-			if c, err := PicksTotal.GetMetricWithLabelValues(model, h, "1"); err == nil && testutil.ToFloat64(c) > 0 {
-				pick = h
-			}
-		}
+	// For a cold key R=1, so the pick is the ranking's head.
+	if want := rankedHosts(req.Key, pool.Candidates)[0]; d.Order[0] != want {
+		t.Fatalf("order[0] = %s, want ranking head %s", d.Order[0], want)
 	}
-	if order[0] != pick {
-		t.Fatalf("order[0] = %s, want the pick %s", order[0], pick)
+	if d.home != d.Order[0] || d.r != 1 {
+		t.Fatalf("decision home/r = %s/%d, want %s/1", d.home, d.r, d.Order[0])
 	}
 
-	if got := s.PreferenceOrder(model, &Request{Outcome: OutcomeNoSalt}, pool, cfg); got != nil {
-		t.Fatalf("non-keyed request must yield nil order, got %v", got)
+	if got := s.Decide(model, &Request{Outcome: OutcomeNoSalt}, pool, cfg); got != nil {
+		t.Fatalf("non-keyed request must yield nil decision, got %+v", got)
 	}
-	if got := s.PreferenceOrder(model, req, Pool{Size: 1, Candidates: hosts("only")}, cfg); got != nil {
-		t.Fatalf("single-replica pool must yield nil order, got %v", got)
+	if got := s.Decide(model, req, Pool{Size: 1, Candidates: hosts("only")}, cfg); got != nil {
+		t.Fatalf("single-replica pool must yield nil decision, got %+v", got)
 	}
-	if got := s.PreferenceOrder(model, nil, pool, cfg); got != nil {
-		t.Fatalf("nil request must yield nil order, got %v", got)
+	if got := s.Decide(model, nil, pool, cfg); got != nil {
+		t.Fatalf("nil request must yield nil decision, got %+v", got)
 	}
 }
 
-// TestPreferenceOrderHotKey drives a key past the split threshold and pins
-// that the order starts with the least-loaded of the top-R set.
-func TestPreferenceOrderHotKey(t *testing.T) {
+// TestDecideHotKey drives a key past the split threshold and pins that the
+// order starts with the least-loaded of the top-R set.
+func TestDecideHotKey(t *testing.T) {
 	s, clock, _ := newTestShadow(t)
 	model := "order-hot-" + t.Name()
 	cfg := defaultSettings() // threshold 15 rpm
@@ -463,7 +456,7 @@ func TestPreferenceOrderHotKey(t *testing.T) {
 	}
 
 	// Find the cold home: order with idle candidates starts there.
-	home := s.PreferenceOrder(model, req, pool2(), cfg)[0]
+	home := s.Decide(model, req, pool2(), cfg).Order[0]
 	other := "enclave-b"
 	if home == other {
 		other = "enclave-a"
@@ -475,9 +468,74 @@ func TestPreferenceOrderHotKey(t *testing.T) {
 		{Host: home, InFlight: 5},
 		{Host: other, InFlight: 0},
 	}}
-	order := s.PreferenceOrder(model, req, loaded, cfg)
-	if order[0] != other {
-		t.Fatalf("hot key order = %v, want least-loaded %s first", order, other)
+	d := s.Decide(model, req, loaded, cfg)
+	if d.Order[0] != other {
+		t.Fatalf("hot key order = %v, want least-loaded %s first", d.Order, other)
+	}
+	if d.r != 2 {
+		t.Fatalf("hot key r = %d, want 2", d.r)
+	}
+}
+
+// TestObserveLanding pins the decision-threading contract: picks_total is
+// labeled with the landing and the replication factor that shaped routing,
+// the random comparison stays quiet, and the same-host repeat is warm.
+func TestObserveLanding(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	model := "landing-" + t.Name()
+	cfg := defaultSettings()
+	cfg.Mode = ModeEnforced
+	req := keyedRequest(t, "l", 1)
+
+	matches := counterDelta(t, RandomMatchTotal, model)
+	landedPicks := counterDelta(t, PicksTotal, model, "enclave-b", "1")
+	warm := counterDelta(t, ReuseTotal, model, ReuseRepeatWarm)
+
+	d := s.Decide(model, req, pool2(), cfg)
+	s.ObserveLanding(model, req, d, "enclave-b", cfg)
+	clock.advance(time.Second)
+	d = s.Decide(model, req, pool2(), cfg)
+	s.ObserveLanding(model, req, d, "enclave-b", cfg)
+
+	if got := landedPicks(); got != 2 {
+		t.Fatalf("picks for landing = %v, want 2", got)
+	}
+	if got := matches(); got != 0 {
+		t.Fatalf("random match under enforcement = %v, want 0", got)
+	}
+	if got := warm(); got != 1 {
+		t.Fatalf("repeat_warm = %v, want 1", got)
+	}
+}
+
+// TestObserveLandingUsesDecisionR pins that picks_total is labeled with the
+// replication factor that routed the request, not one recomputed after the
+// arrival bumps the rate: near the split threshold the two differ.
+func TestObserveLandingUsesDecisionR(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	model := "decision-r-" + t.Name()
+	cfg := defaultSettings()
+	cfg.Mode = ModeEnforced
+	cfg.SplitThresholdRPM = 3
+	req := keyedRequest(t, "dr", 1)
+
+	// Three arrivals in one minute, then step into the next minute: the
+	// pre-arrival rate reads just under the threshold (r=1) while the
+	// post-arrival rate crosses it (r=2).
+	for range 3 {
+		clock.advance(time.Second)
+		s.Observe(model, req, pool2(), "enclave-a", cfg)
+	}
+	clock.advance(time.Minute)
+
+	r1Picks := counterDelta(t, PicksTotal, model, "enclave-a", "1")
+	d := s.Decide(model, req, pool2(), cfg)
+	if d.r != 1 {
+		t.Fatalf("decision r = %d, want 1 (pre-arrival rate under threshold)", d.r)
+	}
+	s.ObserveLanding(model, req, d, "enclave-a", cfg)
+	if got := r1Picks(); got != 1 {
+		t.Fatalf("picks labeled with routed r=1: %v, want 1 (post-arrival recompute would label r=2)", got)
 	}
 }
 

--- a/cacheroute/shadow_test.go
+++ b/cacheroute/shadow_test.go
@@ -392,6 +392,127 @@ func TestObserveProbeServed(t *testing.T) {
 	}
 }
 
+// TestPreferenceOrder pins the enforcement ordering contract: the pick
+// first, then the rest of the ranking, covering every candidate exactly
+// once; ineligible requests yield nil so callers fall back to random.
+func TestPreferenceOrder(t *testing.T) {
+	s, _, _ := newTestShadow(t)
+	model := "order-" + t.Name()
+	cfg := defaultSettings()
+	req := keyedRequest(t, "o", 1)
+	pool := Pool{Size: 3, Candidates: hosts("enclave-a", "enclave-b", "enclave-c")}
+
+	order := s.PreferenceOrder(model, req, pool, cfg)
+	if len(order) != 3 {
+		t.Fatalf("order = %v, want all 3 candidates", order)
+	}
+	seen := map[string]bool{}
+	for _, h := range order {
+		if seen[h] {
+			t.Fatalf("order = %v, duplicate host", order)
+		}
+		seen[h] = true
+	}
+	for range 5 {
+		again := s.PreferenceOrder(model, req, pool, cfg)
+		for i := range order {
+			if again[i] != order[i] {
+				t.Fatalf("order not deterministic: %v vs %v", again, order)
+			}
+		}
+	}
+
+	// The first element is the ranking's home for a cold key (R = 1): the
+	// same host Observe would report as the would-be pick.
+	s.Observe(model, req, pool, "enclave-a", cfg)
+	pick := "enclave-a"
+	if counterValue(t, RandomMatchTotal, model) == 0 {
+		for _, h := range []string{"enclave-b", "enclave-c"} {
+			if c, err := PicksTotal.GetMetricWithLabelValues(model, h, "1"); err == nil && testutil.ToFloat64(c) > 0 {
+				pick = h
+			}
+		}
+	}
+	if order[0] != pick {
+		t.Fatalf("order[0] = %s, want the pick %s", order[0], pick)
+	}
+
+	if got := s.PreferenceOrder(model, &Request{Outcome: OutcomeNoSalt}, pool, cfg); got != nil {
+		t.Fatalf("non-keyed request must yield nil order, got %v", got)
+	}
+	if got := s.PreferenceOrder(model, req, Pool{Size: 1, Candidates: hosts("only")}, cfg); got != nil {
+		t.Fatalf("single-replica pool must yield nil order, got %v", got)
+	}
+	if got := s.PreferenceOrder(model, nil, pool, cfg); got != nil {
+		t.Fatalf("nil request must yield nil order, got %v", got)
+	}
+}
+
+// TestPreferenceOrderHotKey drives a key past the split threshold and pins
+// that the order starts with the least-loaded of the top-R set.
+func TestPreferenceOrderHotKey(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	model := "order-hot-" + t.Name()
+	cfg := defaultSettings() // threshold 15 rpm
+	req := keyedRequest(t, "oh", 1)
+
+	// Establish a hot rate through observations.
+	for range 40 {
+		clock.advance(time.Second)
+		s.Observe(model, req, pool2(), "enclave-a", cfg)
+	}
+
+	// Find the cold home: order with idle candidates starts there.
+	home := s.PreferenceOrder(model, req, pool2(), cfg)[0]
+	other := "enclave-b"
+	if home == other {
+		other = "enclave-a"
+	}
+
+	// With the home busier than its sibling, R=2 must steer the order to
+	// the least-loaded of the pair.
+	loaded := Pool{Size: 2, Candidates: []Candidate{
+		{Host: home, InFlight: 5},
+		{Host: other, InFlight: 0},
+	}}
+	order := s.PreferenceOrder(model, req, loaded, cfg)
+	if order[0] != other {
+		t.Fatalf("hot key order = %v, want least-loaded %s first", order, other)
+	}
+}
+
+// TestObserveEnforced pins enforcement metric semantics: picks_total records
+// the landing, and the random comparison stays quiet.
+func TestObserveEnforced(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	model := "enforced-" + t.Name()
+	cfg := defaultSettings()
+	cfg.Mode = ModeEnforced
+	req := keyedRequest(t, "e", 1)
+
+	matches := counterDelta(t, RandomMatchTotal, model)
+	landedPicks := counterDelta(t, PicksTotal, model, "enclave-b", "1")
+	warm := counterDelta(t, ReuseTotal, model, ReuseRepeatWarm)
+
+	// Land twice on enclave-b regardless of what the ranking would pick.
+	s.Observe(model, req, pool2(), "enclave-b", cfg)
+	clock.advance(time.Second)
+	s.Observe(model, req, pool2(), "enclave-b", cfg)
+
+	if got := landedPicks(); got != 2 {
+		t.Fatalf("picks for landing = %v, want 2", got)
+	}
+	if got := matches(); got != 0 {
+		t.Fatalf("random match under enforcement = %v, want 0", got)
+	}
+
+	// The second landing on the same host is the enforcement success
+	// signal: repeat_warm, not repeat_cold.
+	if got := warm(); got != 1 {
+		t.Fatalf("repeat_warm = %v, want 1", got)
+	}
+}
+
 // TestTrackedKeysCollector checks the scrape-time gauge: distinct live keys
 // grouped by home enclave and replication factor.
 func TestTrackedKeysCollector(t *testing.T) {
@@ -461,10 +582,9 @@ func TestPoolAndModeInfo(t *testing.T) {
 	if got := gatherLabelValues(t, ModeInfo, model, "mode"); len(got) != 1 || !got["shadow"] {
 		t.Fatalf("mode = %v, want shadow", got)
 	}
-	// The gauge reports the effective mode: enforced clamps to shadow.
 	SetMode(model, &config.CacheRouteConfig{Mode: "enforced"})
-	if got := gatherLabelValues(t, ModeInfo, model, "mode"); len(got) != 1 || !got["shadow"] {
-		t.Fatalf("mode = %v, want shadow (clamped)", got)
+	if got := gatherLabelValues(t, ModeInfo, model, "mode"); len(got) != 1 || !got["enforced"] {
+		t.Fatalf("mode = %v, want enforced", got)
 	}
 
 	DropModel(model)

--- a/config/config.go
+++ b/config/config.go
@@ -22,9 +22,9 @@ type RateLimitConfig struct {
 
 // CacheRouteConfig is the per-model cache-aware routing knob. Mode is the
 // rollout control: "off" (default), "shadow" (compute and meter the would-be
-// routing decision without acting), or "enforced" (act on it; not implemented
-// yet — the router clamps it to shadow). The remaining fields tune the
-// measurement; zero means "use the cacheroute package default".
+// routing decision without acting), or "enforced" (route keyed requests to
+// their cache-aware pick). The remaining fields tune the measurement; zero
+// means "use the cacheroute package default".
 type CacheRouteConfig struct {
 	Mode                   string  `yaml:"mode"`
 	RetentionWindowMinutes int     `yaml:"retention_window_minutes,omitempty"`

--- a/main.go
+++ b/main.go
@@ -775,10 +775,17 @@ func main() {
 		// On enforced pools, keyed requests are served in cache-aware
 		// preference order: the key's pick first, then the rest of its
 		// ranking, so an overloaded pick spills to the next-warmest host
-		// via the skip loop below instead of a random sibling.
+		// via the skip loop below instead of a random sibling. The
+		// decision carries its pool snapshot and replication factor to
+		// the landing observation, so the metrics describe the decision
+		// that actually routed the request.
+		var cacheRouteDecision *cacheroute.Decision
 		var cacheRouteOrder []string
 		if cacheRouteReq != nil && cacheRouteSettings.Mode == cacheroute.ModeEnforced {
-			cacheRouteOrder = cacheRouteShadow.PreferenceOrder(modelName, cacheRouteReq, model.CacheRoutePool(), cacheRouteSettings)
+			cacheRouteDecision = cacheRouteShadow.Decide(modelName, cacheRouteReq, model.CacheRoutePool(), cacheRouteSettings)
+			if cacheRouteDecision != nil {
+				cacheRouteOrder = cacheRouteDecision.Order
+			}
 		}
 
 		// Try up to N picks (N = number of configured enclaves). Each pick
@@ -838,10 +845,12 @@ func main() {
 
 		log.Debugf("%s serving request\n", enclave)
 
-		// Hand the production pick to the cache-route shadow. Observed at
+		// Hand the landing to the cache-route pipeline. Observed at
 		// dispatch so the picked replica counts as warm from prefill
 		// start; cannot affect the request.
-		if cacheRouteReq != nil {
+		if cacheRouteDecision != nil {
+			cacheRouteShadow.ObserveLanding(modelName, cacheRouteReq, cacheRouteDecision, enclave.String(), cacheRouteSettings)
+		} else if cacheRouteReq != nil {
 			cacheRouteShadow.Observe(modelName, cacheRouteReq, model.CacheRoutePool(), enclave.String(), cacheRouteSettings)
 		}
 

--- a/main.go
+++ b/main.go
@@ -772,10 +772,19 @@ func main() {
 			return
 		}
 
+		// On enforced pools, keyed requests are served in cache-aware
+		// preference order: the key's pick first, then the rest of its
+		// ranking, so an overloaded pick spills to the next-warmest host
+		// via the skip loop below instead of a random sibling.
+		var cacheRouteOrder []string
+		if cacheRouteReq != nil && cacheRouteSettings.Mode == cacheroute.ModeEnforced {
+			cacheRouteOrder = cacheRouteShadow.PreferenceOrder(modelName, cacheRouteReq, model.CacheRoutePool(), cacheRouteSettings)
+		}
+
 		// Try up to N picks (N = number of configured enclaves). Each pick
-		// that turns out overloaded goes into skip, so NextEnclave will prefer
-		// a sibling on the next iteration. Bounded so a single backed-up
-		// enclave doesn't cascade into a 429 when others are healthy.
+		// that turns out overloaded goes into skip, so the next iteration
+		// prefers a sibling. Bounded so a single backed-up enclave doesn't
+		// cascade into a 429 when others are healthy.
 		var (
 			enclave    *manager.Enclave
 			overloaded bool
@@ -784,7 +793,7 @@ func main() {
 			skip       = map[string]bool{}
 		)
 		for range model.EnclaveCount() {
-			enclave = model.NextEnclave(skip)
+			enclave = model.NextEnclavePreferring(cacheRouteOrder, skip)
 			if enclave == nil {
 				break
 			}

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"sync/atomic"
 
 	tinfoilClient "github.com/tinfoilsh/tinfoil-go/verifier/client"
 
@@ -14,20 +16,25 @@ import (
 )
 
 func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *http.Client, error) {
-	return em.boundHTTPClientPreferring(modelName, nil)
+	enclave, client, err := em.boundHTTPClientPreferring(modelName, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	return enclave.host, client, nil
 }
 
-// boundHTTPClientPreferring is boundHTTPClientForModel with a cache-aware
-// host preference (see Model.NextEnclavePreferring).
-func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []string) (string, *http.Client, error) {
+// boundHTTPClientPreferring picks the serving enclave for an internal
+// dispatch — honoring a cache-aware host preference with overload spill (see
+// Model.SelectForDispatch) — and builds its attested client.
+func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []string) (*Enclave, *http.Client, error) {
 	model, found := em.GetModel(modelName)
 	if !found {
-		return "", nil, fmt.Errorf("model %s not found", modelName)
+		return nil, nil, fmt.Errorf("model %s not found", modelName)
 	}
 
-	enclave := model.NextEnclavePreferring(order, nil)
+	enclave := model.SelectForDispatch(order)
 	if enclave == nil {
-		return "", nil, fmt.Errorf("model %s has no available enclave", modelName)
+		return nil, nil, fmt.Errorf("model %s has no available enclave", modelName)
 	}
 
 	// No client-level Timeout: it would cover the entire exchange including
@@ -45,7 +52,7 @@ func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []st
 		},
 	}
 
-	return enclave.host, client, nil
+	return enclave, client, nil
 }
 
 // DoModelRequest performs an attested POST against the next available enclave
@@ -53,19 +60,20 @@ func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []st
 // billing/usage hooks) so that internal callers can be responsible for their
 // own billing accounting without needing a trust-the-caller HTTP header.
 func (em *EnclaveManager) DoModelRequest(ctx context.Context, modelName, path string, body []byte, headers http.Header) (*http.Response, error) {
-	host, client, err := em.boundHTTPClientForModel(modelName)
+	enclave, client, err := em.boundHTTPClientPreferring(modelName, nil)
 	if err != nil {
 		return nil, err
 	}
-	return postToEnclave(ctx, client, host, path, body, headers)
+	return postToEnclave(ctx, client, enclave, path, body, headers)
 }
 
 // DoModelRequestJSON marshals and dispatches a parsed request body the way
 // DoModelRequest does, threading it through cache-aware routing. The tool
 // loop calls this for every model iteration — replaying a growing shared
 // prefix, the strongest case for cache-aware routing — so those requests are
-// measured (and, on enforced pools, pinned) like plain proxied ones: the
-// key is stable across iterations, so the whole loop homes to one replica.
+// measured (and, on enforced pools, pinned) like plain proxied ones. The key
+// stays stable across iterations while the request shape does (the forced
+// final turn drops tool definitions and re-keys; see toolruntime).
 func (em *EnclaveManager) DoModelRequestJSON(ctx context.Context, modelName, path string, body map[string]any, headers http.Header) (*http.Response, error) {
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
@@ -73,21 +81,27 @@ func (em *EnclaveManager) DoModelRequestJSON(ctx context.Context, modelName, pat
 	}
 
 	req, settings, pool, ok := em.cacheRouteRequest(modelName, path, body)
-	var order []string
+	var decision *cacheroute.Decision
 	if ok && settings.Mode == cacheroute.ModeEnforced {
-		order = em.cacheRouteShadow.PreferenceOrder(modelName, req, pool, settings)
+		decision = em.cacheRouteShadow.Decide(modelName, req, pool, settings)
+	}
+	var order []string
+	if decision != nil {
+		order = decision.Order
 	}
 
-	host, client, err := em.boundHTTPClientPreferring(modelName, order)
+	enclave, client, err := em.boundHTTPClientPreferring(modelName, order)
 	if err != nil {
 		return nil, err
 	}
 	// Observed at dispatch, like the public proxy path, so the picked
 	// replica counts as warm from prefill start.
-	if ok {
-		em.cacheRouteShadow.Observe(modelName, req, pool, host, settings)
+	if decision != nil {
+		em.cacheRouteShadow.ObserveLanding(modelName, req, decision, enclave.host, settings)
+	} else if ok {
+		em.cacheRouteShadow.Observe(modelName, req, pool, enclave.host, settings)
 	}
-	return postToEnclave(ctx, client, host, path, bodyBytes, headers)
+	return postToEnclave(ctx, client, enclave, path, bodyBytes, headers)
 }
 
 // cacheRouteRequest classifies one internally dispatched request for the
@@ -113,9 +127,12 @@ func (em *EnclaveManager) cacheRouteRequest(modelName, path string, body map[str
 	return req, settings, model.CacheRoutePool(), true
 }
 
-// postToEnclave builds and sends an attested POST to one enclave host.
-func postToEnclave(ctx context.Context, client *http.Client, host, path string, body []byte, headers http.Header) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://"+host+path, bytes.NewReader(body))
+// postToEnclave builds and sends an attested POST to one enclave, counting
+// it in the enclave's in-flight gauge for the lifetime of the response body
+// so internal dispatches are visible to least-loaded selection like proxied
+// requests are.
+func postToEnclave(ctx context.Context, client *http.Client, enclave *Enclave, path string, body []byte, headers http.Header) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://"+enclave.host+path, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +144,30 @@ func postToEnclave(ctx context.Context, client *http.Client, host, path string, 
 	req.ContentLength = int64(len(body))
 	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(body)))
 
-	return client.Do(req)
+	enclave.inflight.Add(1)
+	resp, err := client.Do(req)
+	if err != nil {
+		enclave.inflight.Add(-1)
+		return nil, err
+	}
+	resp.Body = &inflightBody{ReadCloser: resp.Body, enclave: enclave}
+	return resp, nil
+}
+
+// inflightBody decrements the enclave's in-flight gauge when the response
+// body is closed — client.Do returns at response headers, so for streaming
+// responses the request is still in flight until the consumer finishes.
+type inflightBody struct {
+	io.ReadCloser
+	enclave *Enclave
+	closed  atomic.Bool
+}
+
+func (b *inflightBody) Close() error {
+	if b.closed.CompareAndSwap(false, true) {
+		b.enclave.inflight.Add(-1)
+	}
+	return b.ReadCloser.Close()
 }
 
 func (em *EnclaveManager) MCPServerEndpoint(modelName string) (string, *http.Client, error) {

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -163,10 +163,14 @@ type inflightBody struct {
 	closed  atomic.Bool
 }
 
+// Close is idempotent, like net/http's own response bodies: the first call
+// decrements the gauge and closes the underlying body, later calls do
+// nothing and return nil.
 func (b *inflightBody) Close() error {
-	if b.closed.CompareAndSwap(false, true) {
-		b.enclave.inflight.Add(-1)
+	if !b.closed.CompareAndSwap(false, true) {
+		return nil
 	}
+	b.enclave.inflight.Add(-1)
 	return b.ReadCloser.Close()
 }
 

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -14,12 +14,18 @@ import (
 )
 
 func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *http.Client, error) {
+	return em.boundHTTPClientPreferring(modelName, nil)
+}
+
+// boundHTTPClientPreferring is boundHTTPClientForModel with a cache-aware
+// host preference (see Model.NextEnclavePreferring).
+func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []string) (string, *http.Client, error) {
 	model, found := em.GetModel(modelName)
 	if !found {
 		return "", nil, fmt.Errorf("model %s not found", modelName)
 	}
 
-	enclave := model.NextEnclave(nil)
+	enclave := model.NextEnclavePreferring(order, nil)
 	if enclave == nil {
 		return "", nil, fmt.Errorf("model %s has no available enclave", modelName)
 	}
@@ -55,44 +61,56 @@ func (em *EnclaveManager) DoModelRequest(ctx context.Context, modelName, path st
 }
 
 // DoModelRequestJSON marshals and dispatches a parsed request body the way
-// DoModelRequest does, and feeds the dispatch to the cache-route shadow. The
-// tool loop calls this for every model iteration — replaying a growing shared
-// prefix, the strongest case for cache-aware routing — so those requests must
-// be measured like plain proxied ones.
+// DoModelRequest does, threading it through cache-aware routing. The tool
+// loop calls this for every model iteration — replaying a growing shared
+// prefix, the strongest case for cache-aware routing — so those requests are
+// measured (and, on enforced pools, pinned) like plain proxied ones: the
+// key is stable across iterations, so the whole loop homes to one replica.
 func (em *EnclaveManager) DoModelRequestJSON(ctx context.Context, modelName, path string, body map[string]any, headers http.Header) (*http.Response, error) {
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
-	host, client, err := em.boundHTTPClientForModel(modelName)
+
+	req, settings, pool, ok := em.cacheRouteRequest(modelName, path, body)
+	var order []string
+	if ok && settings.Mode == cacheroute.ModeEnforced {
+		order = em.cacheRouteShadow.PreferenceOrder(modelName, req, pool, settings)
+	}
+
+	host, client, err := em.boundHTTPClientPreferring(modelName, order)
 	if err != nil {
 		return nil, err
 	}
 	// Observed at dispatch, like the public proxy path, so the picked
 	// replica counts as warm from prefill start.
-	em.observeCacheRoute(modelName, path, body, host)
+	if ok {
+		em.cacheRouteShadow.Observe(modelName, req, pool, host, settings)
+	}
 	return postToEnclave(ctx, client, host, path, bodyBytes, headers)
 }
 
-// observeCacheRoute feeds one internally dispatched request to the
-// cache-route shadow, with the same gating as the public path. Callers only
-// dispatch to cache_salt-capable endpoints, so no endpoint allowlist is
-// re-checked here. Never fails the request.
-func (em *EnclaveManager) observeCacheRoute(modelName, path string, body map[string]any, actualHost string) {
+// cacheRouteRequest classifies one internally dispatched request for the
+// cache-route pipeline, with the same gating as the public path, returning
+// the pool snapshot the decision should be made over. Callers only dispatch
+// to cache_salt-capable endpoints, so no endpoint allowlist is re-checked
+// here. ok is false when the pipeline is off for the model (or the manager
+// has no shadow, as in tests).
+func (em *EnclaveManager) cacheRouteRequest(modelName, path string, body map[string]any) (*cacheroute.Request, cacheroute.Settings, cacheroute.Pool, bool) {
 	if em.cacheRouteShadow == nil {
-		return
+		return nil, cacheroute.Settings{}, cacheroute.Pool{}, false
 	}
 	model, found := em.GetModel(modelName)
 	if !found {
-		return
+		return nil, cacheroute.Settings{}, cacheroute.Pool{}, false
 	}
 	settings := model.CacheRouteSettings()
 	if settings.Mode == cacheroute.ModeOff {
-		return
+		return nil, cacheroute.Settings{}, cacheroute.Pool{}, false
 	}
 	salt, _ := body["cache_salt"].(string)
 	req := cacheroute.ExtractRequest(body, path, salt, settings)
-	em.cacheRouteShadow.Observe(modelName, req, model.CacheRoutePool(), actualHost, settings)
+	return req, settings, model.CacheRoutePool(), true
 }
 
 // postToEnclave builds and sends an attested POST to one enclave host.

--- a/manager/http_client_test.go
+++ b/manager/http_client_test.go
@@ -1,6 +1,13 @@
 package manager
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
 
 // TestLocalMCPEndpointEnvVar pins the exact shape of the debug-bypass
 // env var name derived from a model name. The router advertises this
@@ -22,5 +29,56 @@ func TestLocalMCPEndpointEnvVar(t *testing.T) {
 		if got := localMCPEndpointEnvVar(tc.model); got != tc.want {
 			t.Errorf("localMCPEndpointEnvVar(%q) = %q, want %q", tc.model, got, tc.want)
 		}
+	}
+}
+
+// TestPostToEnclaveInflight pins that internal dispatches are visible to
+// least-loaded selection: in flight from dispatch until the response body is
+// closed, decremented exactly once, and released on transport errors.
+func TestPostToEnclaveInflight(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseFn := func() { releaseOnce.Do(func() { close(release) }) }
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-release
+	}))
+	// Cleanups run LIFO: the handler must be released before ts.Close
+	// waits on it, or a failed assertion deadlocks the test binary.
+	t.Cleanup(ts.Close)
+	t.Cleanup(releaseFn)
+	e := &Enclave{host: strings.TrimPrefix(ts.URL, "https://")}
+
+	resp, err := postToEnclave(context.Background(), ts.Client(), e, "/v1/chat/completions", []byte("{}"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := e.inflight.Load(); got != 1 {
+		t.Fatalf("in-flight after headers = %d, want 1 (body still open)", got)
+	}
+	releaseFn()
+	if err := resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.inflight.Load(); got != 0 {
+		t.Fatalf("in-flight after body close = %d, want 0", got)
+	}
+	// Double-close must not double-decrement.
+	resp.Body.Close()
+	if got := e.inflight.Load(); got != 0 {
+		t.Fatalf("in-flight after double close = %d, want 0", got)
+	}
+
+	// Transport error: released immediately.
+	ts2 := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	client := ts2.Client()
+	ts2.Close()
+	e2 := &Enclave{host: strings.TrimPrefix(ts2.URL, "https://")}
+	if _, err := postToEnclave(context.Background(), client, e2, "/x", nil, nil); err == nil {
+		t.Fatal("expected transport error against closed server")
+	}
+	if got := e2.inflight.Load(); got != 0 {
+		t.Fatalf("in-flight after error = %d, want 0", got)
 	}
 }

--- a/manager/http_client_test.go
+++ b/manager/http_client_test.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -80,5 +81,41 @@ func TestPostToEnclaveInflight(t *testing.T) {
 	}
 	if got := e2.inflight.Load(); got != 0 {
 		t.Fatalf("in-flight after error = %d, want 0", got)
+	}
+}
+
+type strictCloser struct {
+	closes int
+}
+
+func (c *strictCloser) Read(p []byte) (int, error) { return 0, nil }
+func (c *strictCloser) Close() error {
+	c.closes++
+	if c.closes > 1 {
+		return fmt.Errorf("closed %d times", c.closes)
+	}
+	return nil
+}
+
+// TestInflightBodyCloseIdempotent pins that the wrapper owns the body's
+// lifecycle: exactly one underlying close, exactly one gauge decrement, and
+// nil on every later call.
+func TestInflightBodyCloseIdempotent(t *testing.T) {
+	e := &Enclave{}
+	e.inflight.Add(1)
+	rc := &strictCloser{}
+	b := &inflightBody{ReadCloser: rc, enclave: e}
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("first close = %v, want nil", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("second close = %v, want nil", err)
+	}
+	if rc.closes != 1 {
+		t.Fatalf("underlying closes = %d, want 1", rc.closes)
+	}
+	if got := e.inflight.Load(); got != 0 {
+		t.Fatalf("in-flight = %d, want 0", got)
 	}
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -365,9 +365,10 @@ func (m *Model) NextEnclave(skip map[string]bool) *Enclave {
 // acceptable host from order — the cache-aware preference, best first —
 // before falling back to random selection. Health still beats cache: a due
 // probe wins, and order hosts are honored only while their breakers are
-// closed. The overload flag deliberately does not veto an order host; the
-// caller's retry loop steps aside per request via skip, so a flapping load
-// signal can never move a key's home.
+// closed. The overload flag deliberately does not veto an order host; every
+// caller must step aside per request via ShouldReject and skip (main.go's
+// retry loop, SelectForDispatch for internal dispatches), so a flapping
+// load signal can never move a key's home.
 func (m *Model) NextEnclavePreferring(order []string, skip map[string]bool) *Enclave {
 	if len(order) == 0 {
 		return m.NextEnclave(skip)
@@ -393,6 +394,28 @@ func (m *Model) NextEnclavePreferring(order []string, skip map[string]bool) *Enc
 	}
 	m.mu.RUnlock()
 	return m.NextEnclave(skip)
+}
+
+// SelectForDispatch picks the serving enclave for an internal dispatch (the
+// tool loop), honoring the cache-aware order with the same overload spill as
+// the public retry loop: an overloaded pick is skipped and selection moves
+// to the next-warmest host. When every candidate is overloaded it returns
+// the last pick anyway — internal dispatches have no 429 path, matching the
+// old NextEnclave behavior of serving through overload.
+func (m *Model) SelectForDispatch(order []string) *Enclave {
+	skip := map[string]bool{}
+	var enclave *Enclave
+	for range m.EnclaveCount() {
+		enclave = m.NextEnclavePreferring(order, skip)
+		if enclave == nil {
+			return nil
+		}
+		if overloaded, _, _ := enclave.ShouldReject(); !overloaded {
+			return enclave
+		}
+		skip[enclave.String()] = true
+	}
+	return enclave
 }
 
 // EnclaveCount returns the number of configured enclaves under the model lock.

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -361,6 +361,40 @@ func (m *Model) NextEnclave(skip map[string]bool) *Enclave {
 	return nil
 }
 
+// NextEnclavePreferring picks like NextEnclave, but serves the first
+// acceptable host from order — the cache-aware preference, best first —
+// before falling back to random selection. Health still beats cache: a due
+// probe wins, and order hosts are honored only while their breakers are
+// closed. The overload flag deliberately does not veto an order host; the
+// caller's retry loop steps aside per request via skip, so a flapping load
+// signal can never move a key's home.
+func (m *Model) NextEnclavePreferring(order []string, skip map[string]bool) *Enclave {
+	if len(order) == 0 {
+		return m.NextEnclave(skip)
+	}
+
+	m.mu.RLock()
+	for _, enclave := range m.Enclaves {
+		if enclave.cb != nil && !enclave.cb.Closed() && enclave.cb.NeedProbe() {
+			m.mu.RUnlock()
+			return enclave
+		}
+	}
+	for _, host := range order {
+		enclave := m.Enclaves[host]
+		if enclave == nil || skip[host] {
+			continue
+		}
+		if enclave.cb != nil && !enclave.cb.Closed() {
+			continue
+		}
+		m.mu.RUnlock()
+		return enclave
+	}
+	m.mu.RUnlock()
+	return m.NextEnclave(skip)
+}
+
 // EnclaveCount returns the number of configured enclaves under the model lock.
 // Callers that need to bound a retry loop on enclave cardinality should use
 // this rather than reading len(m.Enclaves) directly.

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -303,12 +303,25 @@ func TestNextEnclavePreferring(t *testing.T) {
 		t.Fatalf("pick with b skipped = %v, want c", got)
 	}
 
+	// An overloaded order host is still returned: the overload flag must
+	// never move a key's home — stepping aside is the caller's per-request
+	// job (skip / SelectForDispatch), not the selector's.
+	m.Enclaves["b"].metrics.overloaded.Store(true)
+	if got := m.NextEnclavePreferring(order, nil); got == nil || got.host != "b" {
+		t.Fatalf("pick with b overloaded = %v, want b (no overload veto)", got)
+	}
+	m.Enclaves["b"].metrics.overloaded.Store(false)
+
 	tripBreaker(m.Enclaves["b"])
+	// Keep the trip fresh so a stalled test runner cannot cross the probe
+	// cooldown and turn the open breaker into a served probe mid-test.
+	m.Enclaves["b"].cb.lastFailureNano.Store(time.Now().UnixNano())
 	if got := m.NextEnclavePreferring(order, nil); got == nil || got.host != "c" {
 		t.Fatalf("pick with b open = %v, want c", got)
 	}
 
 	// Order exhausted: fall back to random among the acceptable rest.
+	m.Enclaves["b"].cb.lastFailureNano.Store(time.Now().UnixNano())
 	if got := m.NextEnclavePreferring([]string{"b"}, nil); got == nil || got.host == "b" {
 		t.Fatalf("exhausted order = %v, want random fallback avoiding b", got)
 	}
@@ -323,6 +336,35 @@ func TestNextEnclavePreferring(t *testing.T) {
 	// Empty order behaves like NextEnclave.
 	if got := m.NextEnclavePreferring(nil, map[string]bool{"a": true, "b": true}); got == nil || got.host != "c" {
 		t.Fatalf("nil order = %v, want c", got)
+	}
+}
+
+// TestSelectForDispatch pins the internal-dispatch overload spill: an
+// overloaded order head is skipped for the next-warmest host, and when every
+// candidate is overloaded the dispatch still gets an enclave (internal
+// callers have no 429 path).
+func TestSelectForDispatch(t *testing.T) {
+	m := newTestModel("a", "b", "c")
+	order := []string{"b", "c", "a"}
+
+	if got := m.SelectForDispatch(order); got == nil || got.host != "b" {
+		t.Fatalf("pick = %v, want order head b", got)
+	}
+
+	m.Enclaves["b"].metrics.overloaded.Store(true)
+	m.Enclaves["b"].metrics.cfg = &config.OverloadConfig{MaxRequestsWaiting: 1, RetryAfterMinutes: 1}
+	m.Enclaves["b"].metrics.updateLatest(5, time.Now())
+	if got := m.SelectForDispatch(order); got == nil || got.host != "c" {
+		t.Fatalf("pick with b overloaded = %v, want spill to c", got)
+	}
+
+	for _, h := range []string{"a", "c"} {
+		m.Enclaves[h].metrics.overloaded.Store(true)
+		m.Enclaves[h].metrics.cfg = &config.OverloadConfig{MaxRequestsWaiting: 1, RetryAfterMinutes: 1}
+		m.Enclaves[h].metrics.updateLatest(5, time.Now())
+	}
+	if got := m.SelectForDispatch(order); got == nil {
+		t.Fatal("all-overloaded dispatch must still return an enclave")
 	}
 }
 

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -240,10 +240,10 @@ func TestCacheRoutePoolSizeIsConfigured(t *testing.T) {
 	}
 }
 
-// TestObserveCacheRoute covers the tool-loop observation gate: a shadow-mode
-// dispatch reaches the shadow's funnel, mode off and a missing shadow are
-// no-ops.
-func TestObserveCacheRoute(t *testing.T) {
+// TestCacheRouteRequest covers the tool-loop gate: a shadow-mode dispatch
+// classifies and reaches the shadow's funnel via Observe, mode off and a
+// missing shadow gate out.
+func TestCacheRouteRequest(t *testing.T) {
 	body := map[string]any{
 		"cache_salt": strings.Repeat("0", 43),
 		"messages": []any{
@@ -266,21 +266,64 @@ func TestObserveCacheRoute(t *testing.T) {
 	}
 	base := keyed()
 
-	em.observeCacheRoute("tool-observed", "/v1/chat/completions", body, "a")
+	req, settings, pool, ok := em.cacheRouteRequest("tool-observed", "/v1/chat/completions", body)
+	if !ok || req == nil || pool.Size != 2 {
+		t.Fatalf("gate = (%v, %+v, %+v), want open with 2-replica pool", ok, req, pool)
+	}
+	em.cacheRouteShadow.Observe("tool-observed", req, pool, "a", settings)
 	if got := keyed() - base; got != 1 {
 		t.Fatalf("keyed delta = %v, want 1", got)
 	}
 
-	// Mode off: no observation.
+	// Mode off gates out.
 	model.CacheRoute = nil
-	em.observeCacheRoute("tool-observed", "/v1/chat/completions", body, "a")
-	if got := keyed() - base; got != 1 {
-		t.Fatalf("keyed delta after mode off = %v, want 1", got)
+	if _, _, _, stillOK := em.cacheRouteRequest("tool-observed", "/v1/chat/completions", body); stillOK {
+		t.Fatal("mode off must gate out")
 	}
 
-	// No shadow (tests construct managers without one): must not panic.
+	// No shadow (tests construct managers without one) gates out.
 	em.cacheRouteShadow = nil
-	em.observeCacheRoute("tool-observed", "/v1/chat/completions", body, "a")
+	if _, _, _, stillOK := em.cacheRouteRequest("tool-observed", "/v1/chat/completions", body); stillOK {
+		t.Fatal("missing shadow must gate out")
+	}
+}
+
+// TestNextEnclavePreferring pins enforcement selection: order is honored
+// among breaker-closed replicas, skip and open breakers spill down the
+// order, a due probe wins over the order, and exhaustion falls back to
+// random selection.
+func TestNextEnclavePreferring(t *testing.T) {
+	m := newTestModel("a", "b", "c")
+	order := []string{"b", "c", "a"}
+
+	if got := m.NextEnclavePreferring(order, nil); got == nil || got.host != "b" {
+		t.Fatalf("pick = %v, want order head b", got)
+	}
+	if got := m.NextEnclavePreferring(order, map[string]bool{"b": true}); got == nil || got.host != "c" {
+		t.Fatalf("pick with b skipped = %v, want c", got)
+	}
+
+	tripBreaker(m.Enclaves["b"])
+	if got := m.NextEnclavePreferring(order, nil); got == nil || got.host != "c" {
+		t.Fatalf("pick with b open = %v, want c", got)
+	}
+
+	// Order exhausted: fall back to random among the acceptable rest.
+	if got := m.NextEnclavePreferring([]string{"b"}, nil); got == nil || got.host == "b" {
+		t.Fatalf("exhausted order = %v, want random fallback avoiding b", got)
+	}
+
+	// A due probe beats the cache preference.
+	probe := m.Enclaves["b"]
+	probe.cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
+	if got := m.NextEnclavePreferring([]string{"a", "c"}, nil); got == nil || got.host != "b" {
+		t.Fatalf("pick with due probe = %v, want probe b", got)
+	}
+
+	// Empty order behaves like NextEnclave.
+	if got := m.NextEnclavePreferring(nil, map[string]bool{"a": true, "b": true}); got == nil || got.host != "c" {
+		t.Fatalf("nil order = %v, want c", got)
+	}
 }
 
 func TestCacheRouteSettings(t *testing.T) {


### PR DESCRIPTION
Routing now acts on the shadow data: a pool configured `cache_route: {mode: enforced}` serves each keyed request at its cache-aware pick instead of a random replica. Nothing changes for `off`/`shadow` pools, and flipping back is a config push.

Selection keeps the existing precedence — health probes win, only breaker-closed replicas are picked, and overload steps aside per request without ever re-homing a key. The tool loop pins all its iterations to the same replica, which is the traffic caching helps most.

**For review:** the second commit folds in fixes from a deep review of the first — tool-path overload spill and in-flight accounting, plus threading the routing decision into the landing observation so metrics record the decision that actually routed. The subtlest part is the Decide → dispatch → ObserveLanding handshake (`manager/http_client.go`, `main.go`); that deserves the closest look. Deliberate gaps: subdomain ingress bypasses routing entirely (pre-existing scope decision), and the half-open probe-stranding pattern predates this PR.

Verifying the flip needs no new dashboards: on the enforced pool, `repeat_cold` should collapse toward zero and `random_match_total` goes quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
