### PR TITLE
chore: reduce gemma

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -91,14 +91,6 @@ models:
       - gemma4-31b-2.inf10.tinfoil.sh
       - gemma4-31b-3.inf10.tinfoil.sh
       - gemma4-31b-4.inf10.tinfoil.sh
-      - gemma4-31b-0.inf8.tinfoil.sh
-      - gemma4-31b-1.inf8.tinfoil.sh
-      - gemma4-31b-2.inf8.tinfoil.sh
-      - gemma4-31b-3.inf8.tinfoil.sh
-      - gemma4-31b-4.inf8.tinfoil.sh
-      - gemma4-31b-5.inf8.tinfoil.sh
-      - gemma4-31b-6.inf8.tinfoil.sh
-      - gemma4-31b-7.inf8.tinfoil.sh
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed eight obsolete `gemma4-31b` `inf8` backends from `config.yml` so traffic only targets active `inf10` nodes. This prevents routing to decommissioned hosts and simplifies ops.

<sup>Written for commit 503644958659e356a1561520b7045c40e089d1db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

