### PR TITLE
chore: add Gemma and get oss replicas

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -52,6 +52,7 @@ models:
     enclaves:
       - gpt-oss-120b-0.inf6.tinfoil.sh
       - gpt-oss-120b-1.inf10.tinfoil.sh
+      - gpt-oss-120b-2.inf14.tinfoil.sh
     overload:
       max_requests_waiting: 8
       retry_after_minutes: 1
@@ -91,8 +92,10 @@ models:
       - gemma4-31b-2.inf10.tinfoil.sh
       - gemma4-31b-3.inf10.tinfoil.sh
       - gemma4-31b-4.inf10.tinfoil.sh
+      - gemma4-31b-0.inf14.tinfoil.sh
+      - gemma4-31b-1.inf14.tinfoil.sh
     overload:
-      max_requests_waiting: 16
+      max_requests_waiting: 32
       retry_after_minutes: 1
     cache_route:
       mode: shadow


### PR DESCRIPTION
Added new enclave entries for gpt-oss-120b and gemma4-31b, and increased max_requests_waiting for overload.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new enclaves for `gpt-oss-120b` and `gemma4-31b`, and raises `gemma4-31b` overload queue (`max_requests_waiting`) to improve capacity under load. New enclaves: `gpt-oss-120b-2.inf14.tinfoil.sh`, `gemma4-31b-0.inf14.tinfoil.sh`, `gemma4-31b-1.inf14.tinfoil.sh`; `max_requests_waiting` for `gemma4-31b` increases from 16 to 32.

<sup>Written for commit bc131e9a0d58ac4d3404e56284d438d0203aacb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

