### PR TITLE
config: enforce cache-aware routing on glm-5-2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -45,7 +45,7 @@ models:
       - glm-5-2-inf11.tinfoil.containers.tinfoil.dev
       - glm-5-2-inf12.tinfoil.containers.tinfoil.dev
     cache_route:
-      mode: shadow
+      mode: enforced
 
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b


### PR DESCRIPTION
## Summary by cubic
Switch `glm-5-2` to enforced cache-aware routing to prefer warm replicas and reduce cold hits. Routers will pick up the config within ~5 minutes.

- **Migration**
  - Monitor: `repeat_cold` should drop near zero within ~15 minutes; `random_match_total` should flatline; overload rejects and breaker trips should stay flat.
  - Rollback: set `cache_route.mode` back to `shadow`.

<sup>Written for commit 6add631a7c725b11d3a8534b4f7a7e493b76882f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

