### PR TITLE
Fix internal-dispatch selection under pool-wide pressure

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -328,6 +328,14 @@ func (em *EnclaveManager) Shutdown() {
 // open breaker is past its cooldown, it sends a probe to that enclave. Falls
 // back to any closed enclave, then any enclave (degraded > unavailable).
 func (m *Model) NextEnclave(skip map[string]bool) *Enclave {
+	return m.nextEnclave(skip, true)
+}
+
+// nextEnclave is NextEnclave with probe claiming optional: internal
+// dispatches never record breaker outcomes, so a probe they claim is a
+// probe that strands the breaker in half-open — only the public proxy
+// path, which records outcomes, may claim one.
+func (m *Model) nextEnclave(skip map[string]bool, claimProbes bool) *Enclave {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -336,7 +344,7 @@ func (m *Model) NextEnclave(skip map[string]bool) *Enclave {
 	for _, enclave := range m.Enclaves {
 		all = append(all, enclave)
 		if enclave.cb != nil && !enclave.cb.Closed() {
-			if enclave.cb.NeedProbe() {
+			if claimProbes && enclave.cb.NeedProbe() {
 				return enclave
 			}
 			continue
@@ -370,17 +378,25 @@ func (m *Model) NextEnclave(skip map[string]bool) *Enclave {
 // retry loop, SelectForDispatch for internal dispatches), so a flapping
 // load signal can never move a key's home.
 func (m *Model) NextEnclavePreferring(order []string, skip map[string]bool) *Enclave {
+	return m.nextEnclavePreferring(order, skip, true)
+}
+
+func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, claimProbes bool) *Enclave {
 	if len(order) == 0 {
-		return m.NextEnclave(skip)
+		return m.nextEnclave(skip, claimProbes)
 	}
 
-	m.mu.RLock()
-	for _, enclave := range m.Enclaves {
-		if enclave.cb != nil && !enclave.cb.Closed() && enclave.cb.NeedProbe() {
-			m.mu.RUnlock()
-			return enclave
+	if claimProbes {
+		m.mu.RLock()
+		for _, enclave := range m.Enclaves {
+			if enclave.cb != nil && !enclave.cb.Closed() && enclave.cb.NeedProbe() {
+				m.mu.RUnlock()
+				return enclave
+			}
 		}
+		m.mu.RUnlock()
 	}
+	m.mu.RLock()
 	for _, host := range order {
 		enclave := m.Enclaves[host]
 		if enclave == nil || skip[host] {
@@ -393,27 +409,42 @@ func (m *Model) NextEnclavePreferring(order []string, skip map[string]bool) *Enc
 		return enclave
 	}
 	m.mu.RUnlock()
-	return m.NextEnclave(skip)
+	return m.nextEnclave(skip, claimProbes)
 }
 
 // SelectForDispatch picks the serving enclave for an internal dispatch (the
 // tool loop), honoring the cache-aware order with the same overload spill as
 // the public retry loop: an overloaded pick is skipped and selection moves
-// to the next-warmest host. When every candidate is overloaded it returns
-// the last pick anyway — internal dispatches have no 429 path, matching the
-// old NextEnclave behavior of serving through overload.
+// to the next-warmest host. Internal dispatches have no 429 path, so when
+// every live candidate is overloaded it serves through overload at the
+// warmest one — never at a breaker-open host, which is reachable only when
+// no closed replica exists at all. It also never claims recovery probes:
+// internal dispatches don't record breaker outcomes, so a probe claimed
+// here would strand the breaker in half-open.
 func (m *Model) SelectForDispatch(order []string) *Enclave {
 	skip := map[string]bool{}
+	var firstOverloaded *Enclave
 	var enclave *Enclave
 	for range m.EnclaveCount() {
-		enclave = m.NextEnclavePreferring(order, skip)
+		enclave = m.nextEnclavePreferring(order, skip, false)
 		if enclave == nil {
-			return nil
+			break
+		}
+		if enclave.cb != nil && !enclave.cb.Closed() {
+			// Selection is down to non-closed last resorts: every
+			// remaining closed candidate is overloaded or none exist.
+			break
 		}
 		if overloaded, _, _ := enclave.ShouldReject(); !overloaded {
 			return enclave
 		}
+		if firstOverloaded == nil {
+			firstOverloaded = enclave
+		}
 		skip[enclave.String()] = true
+	}
+	if firstOverloaded != nil {
+		return firstOverloaded
 	}
 	return enclave
 }
@@ -798,6 +829,13 @@ func (e *Enclave) shutdown() {
 
 func (e *Enclave) ShouldReject() (bool, time.Duration, float64) {
 	if e == nil || e.metrics == nil {
+		return false, 0, 0
+	}
+	// A pick whose breaker isn't closed is a recovery probe or a last
+	// resort — rejecting it for overload defeats its purpose (and swallows
+	// the probe: claimed but never dispatched, the breaker would strand in
+	// half-open). Its queue metrics are suspect while the host fails, too.
+	if e.cb != nil && !e.cb.Closed() {
 		return false, 0, 0
 	}
 	return e.metrics.shouldReject()

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -422,3 +422,80 @@ func waitFor(t *testing.T, cond func() bool) {
 	}
 	t.Fatal("condition not reached in time")
 }
+
+// makeOverloaded flags an enclave overloaded with a fresh queue sample so
+// ShouldReject fires deterministically.
+func makeOverloaded(e *Enclave) {
+	e.metrics.cfgMu.Lock()
+	e.metrics.cfg = &config.OverloadConfig{MaxRequestsWaiting: 1, RetryAfterMinutes: 1}
+	e.metrics.cfgMu.Unlock()
+	e.metrics.updateLatest(5, time.Now())
+	e.metrics.overloaded.Store(true)
+}
+
+// TestSelectForDispatchAllOverloadedReturnsWarmest pins the exhaustion
+// fallback: when every candidate is overloaded, the dispatch serves through
+// overload at the order head (the key's warmest replica), not at whatever
+// host the spill loop examined last.
+func TestSelectForDispatchAllOverloadedReturnsWarmest(t *testing.T) {
+	m := newTestModel("a", "b", "c")
+	for _, h := range []string{"a", "b", "c"} {
+		makeOverloaded(m.Enclaves[h])
+	}
+	for range 20 {
+		if got := m.SelectForDispatch([]string{"b", "c", "a"}); got == nil || got.host != "b" {
+			t.Fatalf("all-overloaded pick = %v, want warmest b", got)
+		}
+	}
+}
+
+// TestSelectForDispatchNeverPicksDeadHost pins that a breaker-open host is
+// unreachable while any closed candidate exists, even with every closed
+// candidate overloaded — busy-but-alive always beats dead.
+func TestSelectForDispatchNeverPicksDeadHost(t *testing.T) {
+	m := newTestModel("a", "b", "c")
+	makeOverloaded(m.Enclaves["a"])
+	makeOverloaded(m.Enclaves["b"])
+	tripBreaker(m.Enclaves["c"])
+	m.Enclaves["c"].cb.lastFailureNano.Store(time.Now().UnixNano()) // not probe-due
+
+	for range 200 {
+		got := m.SelectForDispatch([]string{"a", "b"})
+		if got == nil || got.host == "c" {
+			t.Fatalf("pick = %v, must never be dead host c", got)
+		}
+		if got.host != "a" {
+			t.Fatalf("pick = %v, want warmest overloaded a", got)
+		}
+	}
+}
+
+// TestSelectForDispatchDoesNotClaimProbes pins that internal dispatches
+// leave recovery probes alone: they never record breaker outcomes, so a
+// probe claimed here would strand the breaker in half-open until restart.
+func TestSelectForDispatchDoesNotClaimProbes(t *testing.T) {
+	m := newTestModel("a", "b")
+	tripBreaker(m.Enclaves["b"])
+	m.Enclaves["b"].cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano()) // probe due
+
+	if got := m.SelectForDispatch([]string{"a"}); got == nil || got.host != "a" {
+		t.Fatalf("pick = %v, want a (probe must not be claimed)", got)
+	}
+	if st := m.Enclaves["b"].cb.State(); st != cbOpen {
+		t.Fatalf("breaker state = %v, want still open (probe claim belongs to the public path)", st)
+	}
+}
+
+// TestShouldRejectNonClosedBreaker pins that overload rejection only applies
+// to healthy replicas: a probe or last-resort pick must dispatch.
+func TestShouldRejectNonClosedBreaker(t *testing.T) {
+	e := newTestEnclave("reject-open-host")
+	makeOverloaded(e)
+	if reject, _, _ := e.ShouldReject(); !reject {
+		t.Fatal("closed + overloaded must reject")
+	}
+	tripBreaker(e)
+	if reject, _, _ := e.ShouldReject(); reject {
+		t.Fatal("non-closed breaker must not be overload-rejected")
+	}
+}


### PR DESCRIPTION
Adversarial review of #397 found the internal (tool-loop) dispatch selection misbehaving exactly when the pool is most stressed. With every replica overloaded it served the key's *coldest* replica rather than its warmest; exhaustion could hand a dispatch to a breaker-open dead host that stale metrics let through (~1/N, reproduced 66/200) while busy-but-alive replicas sat next to it; and worst, selection could claim a recovery probe and never send it — internal dispatches don't record breaker outcomes, so the breaker stranded in half-open and the replica stayed quarantined until restart.

The fix: exhaustion serves through overload at the warmest live candidate; dead hosts are reachable only when no closed replica exists (the pre-#397 behavior); internal selection no longer claims probes at all, leaving probing to the public path which records outcomes; and overload rejection no longer applies to non-closed picks — which also fixes a pre-existing probe swallow in the public retry loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes internal dispatch selection under pool-wide pressure. Now prefers the warmest live replica, avoids dead hosts while any closed exists, and leaves breaker probes to the public path to prevent stranded breakers.

- **Bug Fixes**
  - When all candidates are overloaded, serve through overload at the warmest live replica.
  - Never select breaker-open hosts unless no closed replicas exist.
  - Internal dispatches no longer claim recovery probes; the public path claims and records outcomes.
  - Overload rejection is skipped for non-closed picks (probe or last resort), preventing swallowed probes in the public retry loop.

<sup>Written for commit 4655d891a86e753311e63076561f9fe4d9d4d2cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

