### PR TITLE
Give glm-5-2 an overload backstop now that it routes enforced

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -44,6 +44,9 @@ models:
       - glm-5-2-inf7.tinfoil.containers.tinfoil.dev
       - glm-5-2-inf11.tinfoil.containers.tinfoil.dev
       - glm-5-2-inf12.tinfoil.containers.tinfoil.dev
+    overload:
+      max_requests_waiting: 16
+      retry_after_minutes: 1
     cache_route:
       mode: enforced
 


### PR DESCRIPTION
glm-5-2 went to `cache_route: enforced` without an `overload` block. Enforcement concentrates each key's traffic on its home replica, and the design bounds that concentration with the overload spill — which only engages where overload thresholds exist. Right now nothing steps aside if a glm home replica backs up, and the router doesn't even poll glm queue depths (polling is gated on the same block).

Same thresholds as the other large pools (trip 16, hysteresis clear 8, retry-after 1m). Best merged after #402, which fixes how the spill path behaves when every replica is overloaded — this block is what activates that path on glm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an overload backstop to `glm-5-2` now that `cache_route` is enforced, so requests can spill when a home replica backs up instead of piling up. Sets `overload.max_requests_waiting: 16` and `overload.retry_after_minutes: 1`, which also enables queue-depth polling for `glm-5-2`.

<sup>Written for commit 6b876bc2c837ac514fb1931de6cea78b8caa3362. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

