### PR TITLE
fix: align Docker builder with Go 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
+FROM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- update the pinned Docker builder from Go 1.25 to Go 1.26.5
- keep the builder on Alpine 3.23
- pin the official multi-architecture image digest

## Root cause

`tinfoil-go v0.14.1` requires Go 1.26.5, but the release Dockerfile still used Go 1.25.10. The release build failed at `go mod download`, and the dependent release-preparation job was skipped.

## Validation

- `GOTOOLCHAIN=go1.26.5 go test ./...`
- `docker build --platform linux/amd64 --build-arg VERSION=v0.0.117 -t confidential-model-router:ci-fix-amd64 .`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the release Docker builder to Go 1.26.5 on Alpine 3.23 and pin the multi-arch image digest. This unblocks releases by matching the Go requirement of `tinfoil-go v0.14.1` and fixing `go mod download` failures.

- **Dependencies**
  - Base image: `golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc`

<sup>Written for commit 730db1faa287e332ad5f514f159c852e25c19af0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

