### PR TITLE
chore: remove inf14 models

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -55,7 +55,6 @@ models:
     enclaves:
       - gpt-oss-120b-0.inf6.tinfoil.sh
       - gpt-oss-120b-1.inf10.tinfoil.sh
-      - gpt-oss-120b-2.inf14.tinfoil.sh
     overload:
       max_requests_waiting: 8
       retry_after_minutes: 1
@@ -95,8 +94,6 @@ models:
       - gemma4-31b-2.inf10.tinfoil.sh
       - gemma4-31b-3.inf10.tinfoil.sh
       - gemma4-31b-4.inf10.tinfoil.sh
-      - gemma4-31b-0.inf14.tinfoil.sh
-      - gemma4-31b-1.inf14.tinfoil.sh
     overload:
       max_requests_waiting: 32
       retry_after_minutes: 1


### PR DESCRIPTION
inf14 will be temporarily taken offline for testing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily remove `inf14` model endpoints from the `gpt-oss-120b` and `gemma4-31b` pools to take `inf14` offline for testing. Traffic will route to remaining enclaves to avoid downtime.

<sup>Written for commit 7bac9ec20cd516ed954f0cfad3f1a11e04fc681a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

