### PR TITLE
Harden prompt cache routing

### DIFF
--- a/cache_salt.go
+++ b/cache_salt.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -64,8 +65,8 @@ func applyCacheSalt(body map[string]any, path, apiKey string, enabled bool) (cac
 // saltProxiedBody applies cache-salt handling to a request that the router
 // otherwise forwards verbatim (the subdomain routing path, which never
 // parses the body). It rewrites r.Body in place and returns the derivation
-// mode. Only JSON-object bodies are touched; a non-JSON body is forwarded
-// byte-for-byte, and a body that needs no change is not re-marshaled.
+// mode. The body must be one JSON object so router-owned cache fields can
+// never bypass stripping on a malformed request.
 func saltProxiedBody(r *http.Request, apiKey string, enabled bool) (cachesalt.Mode, error) {
 	bodyBytes, err := io.ReadAll(r.Body)
 	r.Body.Close()
@@ -81,9 +82,11 @@ func saltProxiedBody(r *http.Request, apiKey string, enabled bool) (cachesalt.Mo
 	dec := json.NewDecoder(bytes.NewReader(bodyBytes))
 	dec.UseNumber()
 	var body map[string]any
-	if err := dec.Decode(&body); err != nil || !decodeConsumedAll(dec) {
-		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-		return cachesalt.ModeNone, nil
+	if err := dec.Decode(&body); err != nil || !decodeConsumedAll(dec) || body == nil {
+		if err != nil {
+			return cachesalt.ModeNone, err
+		}
+		return cachesalt.ModeNone, errors.New("request body must be one JSON object")
 	}
 
 	mode, changed := applyCacheSalt(body, r.URL.Path, apiKey, enabled)

--- a/cache_salt_test.go
+++ b/cache_salt_test.go
@@ -14,11 +14,12 @@ import (
 	"github.com/tinfoilsh/confidential-model-router/manager"
 )
 
-// jwtWithSubject builds an unsigned compact JWT carrying the given subject,
-// matching what jwtSubject parses (payload only, signature ignored).
+// jwtWithSubject builds an unsigned at+jwt-shaped token carrying the given
+// subject, matching the token type the outer shim verifies.
 func jwtWithSubject(sub string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"typ":"at+jwt"}`))
 	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"` + sub + `"}`))
-	return "hdr." + payload + ".sig"
+	return header + "." + payload + ".sig"
 }
 
 func TestApplyCacheSaltStripsFieldsUnconditionally(t *testing.T) {
@@ -194,6 +195,18 @@ func TestApplyCacheSaltOpaqueKeyIdentity(t *testing.T) {
 	}
 }
 
+func TestApplyCacheSaltJWTShapedOpaqueKeyUsesRawIdentity(t *testing.T) {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"typ":"api-key"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"attacker-chosen"}`))
+	key := header + "." + payload + ".opaque"
+	want, _ := cachesalt.Derive(key, "")
+	body := map[string]any{"model": "m"}
+	applyCacheSalt(body, "/v1/chat/completions", key, true)
+	if got, _ := body["cache_salt"].(string); got != want {
+		t.Errorf("cache_salt = %q, want raw opaque-key identity %q", got, want)
+	}
+}
+
 // TestSaltProxiedBody covers the subdomain routing path, where the body is
 // otherwise forwarded verbatim.
 func TestSaltProxiedBody(t *testing.T) {
@@ -275,23 +288,15 @@ func TestSaltProxiedBody(t *testing.T) {
 		}
 	})
 
-	t.Run("forwards a non-JSON body untouched", func(t *testing.T) {
+	t.Run("rejects a non-JSON body", func(t *testing.T) {
 		const raw = `not json`
 		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(raw))
-		mode, err := saltProxiedBody(req, "tenant-a", true)
-		if err != nil {
-			t.Fatalf("saltProxiedBody: %v", err)
-		}
-		if mode != cachesalt.ModeNone {
-			t.Errorf("mode = %q, want ModeNone", mode)
-		}
-		out, _ := io.ReadAll(req.Body)
-		if string(out) != raw {
-			t.Errorf("non-JSON body altered: got %q", out)
+		if _, err := saltProxiedBody(req, "tenant-a", true); err == nil {
+			t.Fatal("expected malformed subdomain body to be rejected")
 		}
 	})
 
-	t.Run("forwards a body with trailing data untouched", func(t *testing.T) {
+	t.Run("rejects a body with trailing data", func(t *testing.T) {
 		// json.Unmarshal rejects all of these, and so must the engine-bound
 		// rewrite: re-marshaling only the first value would silently convert
 		// a request the engine rejects into one it accepts. The '}'/' ]'
@@ -305,16 +310,8 @@ func TestSaltProxiedBody(t *testing.T) {
 			`{"model":"m"} x`,
 		} {
 			req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(raw))
-			mode, err := saltProxiedBody(req, "tenant-a", true)
-			if err != nil {
-				t.Fatalf("saltProxiedBody(%q): %v", raw, err)
-			}
-			if mode != cachesalt.ModeNone {
-				t.Errorf("mode = %q for %q, want ModeNone", mode, raw)
-			}
-			out, _ := io.ReadAll(req.Body)
-			if string(out) != raw {
-				t.Errorf("trailing-data body altered: got %q, want %q", out, raw)
+			if _, err := saltProxiedBody(req, "tenant-a", true); err == nil {
+				t.Errorf("expected trailing-data body %q to be rejected", raw)
 			}
 		}
 	})

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func limitRequestBody(w http.ResponseWriter, r *http.Request) bool {
 		return true
 	}
 	if r.ContentLength > maxRequestBodySize {
-		jsonError(w, "Request body is too large.", manager.ErrTypeInvalidRequest, http.StatusRequestEntityTooLarge)
+		jsonError(w, manager.ErrMsgBodyTooLarge, manager.ErrTypeInvalidRequest, http.StatusRequestEntityTooLarge)
 		return false
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
@@ -111,7 +111,7 @@ func limitRequestBody(w http.ResponseWriter, r *http.Request) bool {
 func writeRequestBodyError(w http.ResponseWriter, err error) {
 	var tooLarge *http.MaxBytesError
 	if errors.As(err, &tooLarge) {
-		jsonError(w, "Request body is too large.", manager.ErrTypeInvalidRequest, http.StatusRequestEntityTooLarge)
+		jsonError(w, manager.ErrMsgBodyTooLarge, manager.ErrTypeInvalidRequest, http.StatusRequestEntityTooLarge)
 		return
 	}
 	jsonError(w, fmt.Sprintf("Could not read request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)

--- a/main.go
+++ b/main.go
@@ -851,6 +851,14 @@ func main() {
 			if enclave == nil {
 				break
 			}
+			// A claimed probe must be dispatched: skipping its pick as
+			// overloaded would leave the claim unresolved and strand the
+			// breaker half-open (see Model.selectForDispatch). Overload
+			// spill applies to plain picks only.
+			if probeClaim != nil {
+				overloaded = false
+				break
+			}
 			if overloaded, retryAfter, waiting = enclave.ShouldReject(); !overloaded {
 				break
 			}

--- a/main.go
+++ b/main.go
@@ -37,14 +37,6 @@ var version = "dev"
 
 const maxRequestBodySize int64 = 64 * 1024 * 1024
 
-func bearerToken(header string) string {
-	const scheme = "bearer "
-	if len(header) < len(scheme) || !strings.EqualFold(header[:len(scheme)], scheme) {
-		return ""
-	}
-	return strings.TrimSpace(header[len(scheme):])
-}
-
 // rateLimitIdentity returns the identity used to key rate limiting. For OAuth
 // JWT access tokens it is the token's `sub` claim, so a user's bucket stays
 // stable across the short-lived token's ~15m refreshes (and across multiple
@@ -463,7 +455,7 @@ func main() {
 		var cacheRouteSettings cacheroute.Settings
 
 		// Extract API key early for rate limiting decisions
-		apiKey := bearerToken(r.Header.Get("Authorization"))
+		apiKey := manager.BearerToken(r.Header.Get("Authorization"))
 
 		if modelName, err = parseModelFromSubdomain(r, *domain); err != nil {
 			jsonError(w, fmt.Sprintf("Invalid request: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)

--- a/main.go
+++ b/main.go
@@ -35,6 +35,16 @@ var configFile []byte // Initial (attested) config
 // Set by build process
 var version = "dev"
 
+const maxRequestBodySize int64 = 64 * 1024 * 1024
+
+func bearerToken(header string) string {
+	const scheme = "bearer "
+	if len(header) < len(scheme) || !strings.EqualFold(header[:len(scheme)], scheme) {
+		return ""
+	}
+	return strings.TrimSpace(header[len(scheme):])
+}
+
 // rateLimitIdentity returns the identity used to key rate limiting. For OAuth
 // JWT access tokens it is the token's `sub` claim, so a user's bucket stays
 // stable across the short-lived token's ~15m refreshes (and across multiple
@@ -53,12 +63,24 @@ func rateLimitIdentity(apiKey string) string {
 	return apiKey
 }
 
-// jwtSubject returns the `sub` claim of a compact-JWS access token, or "" if s
-// is not a well-formed three-part JWT or carries no string subject. It inspects
-// the payload only; it does not verify the signature (see rateLimitIdentity).
+// jwtSubject returns the `sub` claim of an explicitly typed compact-JWS access
+// token, or "" if s is not an at+jwt token or carries no string subject. It
+// inspects the payload only; the outer shim verifies the same token type before
+// the request can reach this handler (see rateLimitIdentity).
 func jwtSubject(s string) string {
 	parts := strings.Split(s, ".")
-	if len(parts) != 3 {
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return ""
+	}
+	header, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return ""
+	}
+	var metadata struct {
+		Type string `json:"typ"`
+	}
+	if json.Unmarshal(header, &metadata) != nil ||
+		strings.TrimPrefix(strings.ToLower(metadata.Type), "application/") != "at+jwt" {
 		return ""
 	}
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
@@ -72,6 +94,27 @@ func jwtSubject(s string) string {
 		return ""
 	}
 	return claims.Sub
+}
+
+func limitRequestBody(w http.ResponseWriter, r *http.Request) bool {
+	if r.Body == nil || r.Body == http.NoBody {
+		return true
+	}
+	if r.ContentLength > maxRequestBodySize {
+		jsonError(w, "Request body is too large.", manager.ErrTypeInvalidRequest, http.StatusRequestEntityTooLarge)
+		return false
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+	return true
+}
+
+func writeRequestBodyError(w http.ResponseWriter, err error) {
+	var tooLarge *http.MaxBytesError
+	if errors.As(err, &tooLarge) {
+		jsonError(w, "Request body is too large.", manager.ErrTypeInvalidRequest, http.StatusRequestEntityTooLarge)
+		return
+	}
+	jsonError(w, fmt.Sprintf("Could not read request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 }
 
 // getEnvOrDefault returns the environment variable value if set, otherwise returns the default
@@ -407,6 +450,10 @@ func main() {
 	cacheRouteShadow := em.CacheRouteShadow()
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if !limitRequestBody(w, r) {
+			return
+		}
+
 		var modelName string
 		var err error
 
@@ -416,10 +463,7 @@ func main() {
 		var cacheRouteSettings cacheroute.Settings
 
 		// Extract API key early for rate limiting decisions
-		apiKey := ""
-		if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
-			apiKey = strings.TrimPrefix(auth, "Bearer ")
-		}
+		apiKey := bearerToken(r.Header.Get("Authorization"))
 
 		if modelName, err = parseModelFromSubdomain(r, *domain); err != nil {
 			jsonError(w, fmt.Sprintf("Invalid request: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
@@ -543,7 +587,7 @@ func main() {
 				var body map[string]any
 				bodyBytes, err := io.ReadAll(r.Body)
 				if err != nil {
-					jsonError(w, fmt.Sprintf("Could not read request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+					writeRequestBodyError(w, err)
 					return
 				}
 				r.Body.Close()
@@ -562,6 +606,11 @@ func main() {
 				var bodyBytes []byte
 				modelName, bodyBytes, err = extractModelFromMultipart(r)
 				if err != nil {
+					var tooLarge *http.MaxBytesError
+					if errors.As(err, &tooLarge) {
+						writeRequestBodyError(w, err)
+						return
+					}
 					jsonError(w, fmt.Sprintf("Invalid request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
@@ -576,7 +625,7 @@ func main() {
 				bodyBytes, err := io.ReadAll(r.Body)
 
 				if err != nil {
-					jsonError(w, fmt.Sprintf("Could not read request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+					writeRequestBodyError(w, err)
 					return
 				}
 				if err := json.Unmarshal(bodyBytes, &body); err != nil {
@@ -760,7 +809,12 @@ func main() {
 			}
 			mode, err := saltProxiedBody(r, apiKey, *cacheSaltEnabled)
 			if err != nil {
-				jsonError(w, fmt.Sprintf("Could not read request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+				var tooLarge *http.MaxBytesError
+				if errors.As(err, &tooLarge) {
+					writeRequestBodyError(w, err)
+					return
+				}
+				jsonError(w, fmt.Sprintf("Invalid request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 				return
 			}
 			recordCacheSaltInjection(modelName, mode)

--- a/main.go
+++ b/main.go
@@ -848,13 +848,14 @@ func main() {
 		// cascade into a 429 when others are healthy.
 		var (
 			enclave    *manager.Enclave
+			probeClaim *manager.ProbeClaim
 			overloaded bool
 			retryAfter time.Duration
 			waiting    float64
 			skip       = map[string]bool{}
 		)
 		for range model.EnclaveCount() {
-			enclave = model.NextEnclavePreferring(cacheRouteOrder, skip)
+			enclave, probeClaim = model.NextEnclavePreferring(cacheRouteOrder, skip)
 			if enclave == nil {
 				break
 			}
@@ -906,6 +907,13 @@ func main() {
 			cacheRouteShadow.ObserveLanding(modelName, cacheRouteReq, cacheRouteDecision, enclave.String(), cacheRouteSettings)
 		} else if cacheRouteReq != nil {
 			cacheRouteShadow.Observe(modelName, cacheRouteReq, model.CacheRoutePool(), enclave.String(), cacheRouteSettings)
+		}
+
+		// A claimed recovery probe travels with its request, so the
+		// enclave's outcome handlers can tell an owner's cancellation
+		// (which must release the claim) from an unrelated one.
+		if probeClaim != nil {
+			r = r.WithContext(manager.WithProbeClaim(r.Context(), probeClaim))
 		}
 
 		enclave.ServeHTTP(w, r)

--- a/main_test.go
+++ b/main_test.go
@@ -47,25 +47,6 @@ func TestRateLimitIdentity(t *testing.T) {
 	}
 }
 
-func TestBearerTokenMatchesShimParsing(t *testing.T) {
-	tests := []struct {
-		header string
-		want   string
-	}{
-		{"Bearer tk_test", "tk_test"},
-		{"bearer tk_test", "tk_test"},
-		{"BEARER   tk_test  ", "tk_test"},
-		{"Token tk_test", ""},
-		{"Bearer", ""},
-		{"", ""},
-	}
-	for _, tt := range tests {
-		if got := bearerToken(tt.header); got != tt.want {
-			t.Errorf("bearerToken(%q) = %q, want %q", tt.header, got, tt.want)
-		}
-	}
-}
-
 func TestLimitRequestBodyRejectsKnownOversize(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader("{}"))
 	req.ContentLength = maxRequestBodySize + 1

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/tinfoilsh/confidential-model-router/manager"
@@ -43,6 +44,45 @@ func TestRateLimitIdentity(t *testing.T) {
 				t.Errorf("rateLimitIdentity(%q) = %q, want %q", tt.apiKey, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBearerTokenMatchesShimParsing(t *testing.T) {
+	tests := []struct {
+		header string
+		want   string
+	}{
+		{"Bearer tk_test", "tk_test"},
+		{"bearer tk_test", "tk_test"},
+		{"BEARER   tk_test  ", "tk_test"},
+		{"Token tk_test", ""},
+		{"Bearer", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := bearerToken(tt.header); got != tt.want {
+			t.Errorf("bearerToken(%q) = %q, want %q", tt.header, got, tt.want)
+		}
+	}
+}
+
+func TestLimitRequestBodyRejectsKnownOversize(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader("{}"))
+	req.ContentLength = maxRequestBodySize + 1
+	rec := httptest.NewRecorder()
+	if limitRequestBody(rec, req) {
+		t.Fatal("oversized request was accepted")
+	}
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestWriteRequestBodyErrorClassifiesChunkedOversize(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeRequestBodyError(rec, &http.MaxBytesError{Limit: maxRequestBodySize})
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
 	}
 }
 

--- a/manager/bearer.go
+++ b/manager/bearer.go
@@ -1,0 +1,17 @@
+package manager
+
+import "strings"
+
+// BearerToken extracts the token from an Authorization header value,
+// accepting the scheme case-insensitively (RFC 7235) and trimming
+// surrounding whitespace, matching how the outer shim parses the header.
+// Every Authorization-header consumer (identity, cache salting, billing)
+// must share this parse: a stricter one would treat shim-authenticated
+// traffic as anonymous. Returns "" when the header carries no bearer token.
+func BearerToken(header string) string {
+	const scheme = "bearer "
+	if len(header) < len(scheme) || !strings.EqualFold(header[:len(scheme)], scheme) {
+		return ""
+	}
+	return strings.TrimSpace(header[len(scheme):])
+}

--- a/manager/bearer_test.go
+++ b/manager/bearer_test.go
@@ -1,0 +1,22 @@
+package manager
+
+import "testing"
+
+func TestBearerTokenMatchesShimParsing(t *testing.T) {
+	tests := []struct {
+		header string
+		want   string
+	}{
+		{"Bearer tk_test", "tk_test"},
+		{"bearer tk_test", "tk_test"},
+		{"BEARER   tk_test  ", "tk_test"},
+		{"Token tk_test", ""},
+		{"Bearer", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := BearerToken(tt.header); got != tt.want {
+			t.Errorf("BearerToken(%q) = %q, want %q", tt.header, got, tt.want)
+		}
+	}
+}

--- a/manager/circuitbreaker.go
+++ b/manager/circuitbreaker.go
@@ -85,11 +85,16 @@ func (cb *circuitBreaker) NeedProbe() bool {
 // AbortProbe returns a claimed recovery probe to the open state without
 // counting a client cancellation as a backend failure.
 func (cb *circuitBreaker) AbortProbe() bool {
-	if !cb.casState(cbHalfOpen, cbOpen) {
+	if cb.loadState() != cbHalfOpen {
 		return false
 	}
+	// Restart the cooldown before exposing the open state: a NeedProbe
+	// caller that observes cbOpen with the stale pre-probe timestamp would
+	// claim a fresh probe with no cooldown at all. A spurious store when
+	// the CAS below loses is harmless — the concurrent transition owns the
+	// timestamp from then on.
 	cb.lastFailureNano.Store(time.Now().UnixNano())
-	return true
+	return cb.casState(cbHalfOpen, cbOpen)
 }
 
 // State returns the current state for observability.

--- a/manager/circuitbreaker.go
+++ b/manager/circuitbreaker.go
@@ -82,6 +82,16 @@ func (cb *circuitBreaker) NeedProbe() bool {
 	return cb.casState(cbOpen, cbHalfOpen)
 }
 
+// AbortProbe returns a claimed recovery probe to the open state without
+// counting a client cancellation as a backend failure.
+func (cb *circuitBreaker) AbortProbe() bool {
+	if !cb.casState(cbHalfOpen, cbOpen) {
+		return false
+	}
+	cb.lastFailureNano.Store(time.Now().UnixNano())
+	return true
+}
+
 // State returns the current state for observability.
 func (cb *circuitBreaker) State() cbState {
 	return cb.loadState()

--- a/manager/circuitbreaker.go
+++ b/manager/circuitbreaker.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -27,8 +28,12 @@ type circuitBreaker struct {
 	state               atomic.Int32
 	consecutiveFailures atomic.Int64
 	lastFailureNano     atomic.Int64
-	retired             atomic.Bool
-	publishMu           sync.RWMutex
+	// probeGen counts probe claims; an AbortProbe caller must present the
+	// token of the current claim, so a stale holder cannot release a probe
+	// it no longer owns.
+	probeGen  atomic.Uint64
+	retired   atomic.Bool
+	publishMu sync.RWMutex
 }
 
 func newCircuitBreaker() *circuitBreaker {
@@ -68,33 +73,78 @@ func (cb *circuitBreaker) Closed() bool {
 	return cb.loadState() == cbClosed
 }
 
-// NeedProbe attempts to transition an open circuit breaker to half-open after
-// the cooldown has elapsed. Returns true if this caller won the CAS and should
-// send exactly one probe request to this enclave.
-func (cb *circuitBreaker) NeedProbe() bool {
+// ClaimProbe attempts to transition an open circuit breaker to half-open
+// after the cooldown has elapsed. When this caller wins the CAS it returns
+// (token, true): exactly one probe request must be dispatched for the claim,
+// resolving it via RecordSuccess or RecordFailure — or AbortProbe with the
+// token if the probe is cancelled before the backend answers.
+func (cb *circuitBreaker) ClaimProbe() (uint64, bool) {
 	if cb.loadState() != cbOpen {
-		return false
+		return 0, false
 	}
 	last := time.Unix(0, cb.lastFailureNano.Load())
 	if time.Since(last) < cbCooldown {
-		return false
+		return 0, false
 	}
-	return cb.casState(cbOpen, cbHalfOpen)
+	if !cb.casState(cbOpen, cbHalfOpen) {
+		return 0, false
+	}
+	return cb.probeGen.Add(1), true
 }
 
-// AbortProbe returns a claimed recovery probe to the open state without
-// counting a client cancellation as a backend failure.
-func (cb *circuitBreaker) AbortProbe() bool {
-	if cb.loadState() != cbHalfOpen {
+// AbortProbe returns the claimed recovery probe identified by token to the
+// open state without counting a client cancellation as a backend failure.
+// A token from a superseded claim is refused, so an unrelated in-flight
+// request's cancellation can never release a probe it does not own.
+func (cb *circuitBreaker) AbortProbe(token uint64) bool {
+	if cb.probeGen.Load() != token || cb.loadState() != cbHalfOpen {
 		return false
 	}
-	// Restart the cooldown before exposing the open state: a NeedProbe
+	// Restart the cooldown before exposing the open state: a ClaimProbe
 	// caller that observes cbOpen with the stale pre-probe timestamp would
 	// claim a fresh probe with no cooldown at all. A spurious store when
 	// the CAS below loses is harmless — the concurrent transition owns the
 	// timestamp from then on.
 	cb.lastFailureNano.Store(time.Now().UnixNano())
 	return cb.casState(cbHalfOpen, cbOpen)
+}
+
+// ProbeClaim ties a claimed recovery probe to the one request dispatched
+// for it. The request's terminal outcome resolves the breaker; a client
+// cancellation calls Abort instead, and only the claim holder may do so.
+type ProbeClaim struct {
+	cb        *circuitBreaker
+	token     uint64
+	modelName string
+	host      string
+}
+
+// Abort returns the claimed probe to the open state and restarts its
+// cooldown. Safe to call on a nil claim; reports whether the abort happened.
+func (pc *ProbeClaim) Abort() bool {
+	if pc == nil || !pc.cb.AbortProbe(pc.token) {
+		return false
+	}
+	publishBreakerState(pc.modelName, pc.host, pc.cb)
+	return true
+}
+
+// probeClaimContextKey carries the public proxy path's probe claim in the
+// request context, so the per-enclave error handler can tell whether a
+// cancelled request owns the in-flight probe.
+type probeClaimContextKey struct{}
+
+// WithProbeClaim attaches a probe claim to the request context of the one
+// request dispatched for it.
+func WithProbeClaim(ctx context.Context, claim *ProbeClaim) context.Context {
+	return context.WithValue(ctx, probeClaimContextKey{}, claim)
+}
+
+// ProbeClaimFromContext returns the request's probe claim, or nil when the
+// request does not own one.
+func ProbeClaimFromContext(ctx context.Context) *ProbeClaim {
+	claim, _ := ctx.Value(probeClaimContextKey{}).(*ProbeClaim)
+	return claim
 }
 
 // State returns the current state for observability.

--- a/manager/file_inputs.go
+++ b/manager/file_inputs.go
@@ -116,7 +116,7 @@ func (em *EnclaveManager) ConvertFile(
 		}
 	}
 
-	enclave := model.NextEnclave(nil)
+	enclave, _ := model.NextEnclave(nil)
 	if enclave == nil {
 		return nil, &FileConversionError{
 			StatusCode: http.StatusBadGateway,

--- a/manager/file_inputs.go
+++ b/manager/file_inputs.go
@@ -116,7 +116,10 @@ func (em *EnclaveManager) ConvertFile(
 		}
 	}
 
-	enclave, _ := model.NextEnclave(nil)
+	// This path uses its own client and records no breaker outcomes, so it
+	// must not claim a recovery probe — a claimed probe with no recorded
+	// outcome strands the breaker half-open until restart.
+	enclave, _ := model.nextEnclave(nil, false)
 	if enclave == nil {
 		return nil, &FileConversionError{
 			StatusCode: http.StatusBadGateway,

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -15,8 +15,12 @@ import (
 	"github.com/tinfoilsh/confidential-model-router/cacheroute"
 )
 
+// boundHTTPClientForModel picks a host for a caller-driven session (the MCP
+// tool transport). Those connections never reach postToEnclave, so no
+// breaker outcome is ever recorded for them: claiming a recovery probe here
+// would strand the breaker half-open until restart.
 func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *http.Client, error) {
-	enclave, client, _, err := em.boundHTTPClientPreferring(modelName, nil)
+	enclave, client, _, err := em.boundHTTPClientPreferring(modelName, nil, false)
 	if err != nil {
 		return "", nil, err
 	}
@@ -26,14 +30,15 @@ func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *ht
 // boundHTTPClientPreferring picks the serving enclave for an internal
 // dispatch — honoring a cache-aware host preference with overload spill (see
 // Model.SelectForDispatch) — and builds its attested client. A non-nil
-// ProbeClaim must travel with the dispatched request (see ProbeClaim).
-func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []string) (*Enclave, *http.Client, *ProbeClaim, error) {
+// ProbeClaim must travel with the dispatched request (see ProbeClaim);
+// claimProbes must be false for callers that record no breaker outcomes.
+func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []string, claimProbes bool) (*Enclave, *http.Client, *ProbeClaim, error) {
 	model, found := em.GetModel(modelName)
 	if !found {
 		return nil, nil, nil, fmt.Errorf("model %s not found", modelName)
 	}
 
-	enclave, claim := model.SelectForDispatch(order)
+	enclave, claim := model.selectForDispatch(order, claimProbes)
 	if enclave == nil {
 		return nil, nil, nil, fmt.Errorf("model %s has no available enclave", modelName)
 	}
@@ -61,7 +66,7 @@ func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []st
 // billing/usage hooks) so that internal callers can be responsible for their
 // own billing accounting without needing a trust-the-caller HTTP header.
 func (em *EnclaveManager) DoModelRequest(ctx context.Context, modelName, path string, body []byte, headers http.Header) (*http.Response, error) {
-	enclave, client, claim, err := em.boundHTTPClientPreferring(modelName, nil)
+	enclave, client, claim, err := em.boundHTTPClientPreferring(modelName, nil, true)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +96,7 @@ func (em *EnclaveManager) DoModelRequestJSON(ctx context.Context, modelName, pat
 		order = decision.Order
 	}
 
-	enclave, client, claim, err := em.boundHTTPClientPreferring(modelName, order)
+	enclave, client, claim, err := em.boundHTTPClientPreferring(modelName, order, true)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -94,14 +94,18 @@ func (em *EnclaveManager) DoModelRequestJSON(ctx context.Context, modelName, pat
 	if err != nil {
 		return nil, err
 	}
-	// Observed at dispatch, like the public proxy path, so the picked
-	// replica counts as warm from prefill start.
-	if decision != nil {
-		em.cacheRouteShadow.ObserveLanding(modelName, req, decision, enclave.host, settings)
-	} else if ok {
-		em.cacheRouteShadow.Observe(modelName, req, pool, enclave.host, settings)
+	resp, err := postToEnclave(ctx, client, enclave, path, bodyBytes, headers)
+	if err != nil {
+		return nil, err
 	}
-	return postToEnclave(ctx, client, enclave, path, bodyBytes, headers)
+	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+		if decision != nil {
+			em.cacheRouteShadow.ObserveLanding(modelName, req, decision, enclave.host, settings)
+		} else if ok {
+			em.cacheRouteShadow.Observe(modelName, req, pool, enclave.host, settings)
+		}
+	}
+	return resp, nil
 }
 
 // cacheRouteRequest classifies one internally dispatched request for the
@@ -148,7 +152,34 @@ func postToEnclave(ctx context.Context, client *http.Client, enclave *Enclave, p
 	resp, err := client.Do(req)
 	if err != nil {
 		enclave.inflight.Add(-1)
+		reason := classifyProxyError(err)
+		if reason == "canceled" {
+			ClientCancellationsTotal.WithLabelValues(enclave.modelName, enclave.host).Inc()
+			if enclave.cb != nil && enclave.cb.AbortProbe() {
+				publishBreakerState(enclave.modelName, enclave.host, enclave.cb)
+			}
+		} else {
+			ProxyFailureTotal.WithLabelValues(enclave.modelName, enclave.host, reason).Inc()
+			if enclave.cb != nil {
+				enclave.cb.RecordFailure()
+				publishBreakerState(enclave.modelName, enclave.host, enclave.cb)
+			}
+		}
 		return nil, err
+	}
+	if resp.StatusCode >= 500 {
+		ProxyFailureTotal.WithLabelValues(enclave.modelName, enclave.host, httpFailureReason(resp.StatusCode)).Inc()
+		if enclave.cb != nil {
+			enclave.cb.RecordFailure()
+		}
+	} else {
+		ProxySuccessTotal.WithLabelValues(enclave.modelName, enclave.host).Inc()
+		if enclave.cb != nil {
+			enclave.cb.RecordSuccess()
+		}
+	}
+	if enclave.cb != nil {
+		publishBreakerState(enclave.modelName, enclave.host, enclave.cb)
 	}
 	resp.Body = &inflightBody{ReadCloser: resp.Body, enclave: enclave}
 	return resp, nil

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *http.Client, error) {
-	enclave, client, err := em.boundHTTPClientPreferring(modelName, nil)
+	enclave, client, _, err := em.boundHTTPClientPreferring(modelName, nil)
 	if err != nil {
 		return "", nil, err
 	}
@@ -25,16 +25,17 @@ func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *ht
 
 // boundHTTPClientPreferring picks the serving enclave for an internal
 // dispatch — honoring a cache-aware host preference with overload spill (see
-// Model.SelectForDispatch) — and builds its attested client.
-func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []string) (*Enclave, *http.Client, error) {
+// Model.SelectForDispatch) — and builds its attested client. A non-nil
+// ProbeClaim must travel with the dispatched request (see ProbeClaim).
+func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []string) (*Enclave, *http.Client, *ProbeClaim, error) {
 	model, found := em.GetModel(modelName)
 	if !found {
-		return nil, nil, fmt.Errorf("model %s not found", modelName)
+		return nil, nil, nil, fmt.Errorf("model %s not found", modelName)
 	}
 
-	enclave := model.SelectForDispatch(order)
+	enclave, claim := model.SelectForDispatch(order)
 	if enclave == nil {
-		return nil, nil, fmt.Errorf("model %s has no available enclave", modelName)
+		return nil, nil, nil, fmt.Errorf("model %s has no available enclave", modelName)
 	}
 
 	// No client-level Timeout: it would cover the entire exchange including
@@ -52,7 +53,7 @@ func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []st
 		},
 	}
 
-	return enclave, client, nil
+	return enclave, client, claim, nil
 }
 
 // DoModelRequest performs an attested POST against the next available enclave
@@ -60,11 +61,11 @@ func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []st
 // billing/usage hooks) so that internal callers can be responsible for their
 // own billing accounting without needing a trust-the-caller HTTP header.
 func (em *EnclaveManager) DoModelRequest(ctx context.Context, modelName, path string, body []byte, headers http.Header) (*http.Response, error) {
-	enclave, client, err := em.boundHTTPClientPreferring(modelName, nil)
+	enclave, client, claim, err := em.boundHTTPClientPreferring(modelName, nil)
 	if err != nil {
 		return nil, err
 	}
-	return postToEnclave(ctx, client, enclave, path, body, headers)
+	return postToEnclave(ctx, client, enclave, path, body, headers, claim)
 }
 
 // DoModelRequestJSON marshals and dispatches a parsed request body the way
@@ -90,11 +91,11 @@ func (em *EnclaveManager) DoModelRequestJSON(ctx context.Context, modelName, pat
 		order = decision.Order
 	}
 
-	enclave, client, err := em.boundHTTPClientPreferring(modelName, order)
+	enclave, client, claim, err := em.boundHTTPClientPreferring(modelName, order)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := postToEnclave(ctx, client, enclave, path, bodyBytes, headers)
+	resp, err := postToEnclave(ctx, client, enclave, path, bodyBytes, headers, claim)
 	if err != nil {
 		return nil, err
 	}
@@ -135,9 +136,12 @@ func (em *EnclaveManager) cacheRouteRequest(modelName, path string, body map[str
 // it in the enclave's in-flight gauge for the lifetime of the response body
 // so internal dispatches are visible to least-loaded selection like proxied
 // requests are.
-func postToEnclave(ctx context.Context, client *http.Client, enclave *Enclave, path string, body []byte, headers http.Header) (*http.Response, error) {
+func postToEnclave(ctx context.Context, client *http.Client, enclave *Enclave, path string, body []byte, headers http.Header, claim *ProbeClaim) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://"+enclave.host+path, bytes.NewReader(body))
 	if err != nil {
+		// The claim resolves through the request's outcome; a request that
+		// was never built must release it or the breaker strands half-open.
+		claim.Abort()
 		return nil, err
 	}
 	for key, values := range headers {
@@ -155,9 +159,7 @@ func postToEnclave(ctx context.Context, client *http.Client, enclave *Enclave, p
 		reason := classifyProxyError(err)
 		if reason == "canceled" {
 			ClientCancellationsTotal.WithLabelValues(enclave.modelName, enclave.host).Inc()
-			if enclave.cb != nil && enclave.cb.AbortProbe() {
-				publishBreakerState(enclave.modelName, enclave.host, enclave.cb)
-			}
+			claim.Abort()
 		} else {
 			ProxyFailureTotal.WithLabelValues(enclave.modelName, enclave.host, reason).Inc()
 			if enclave.cb != nil {

--- a/manager/http_client_test.go
+++ b/manager/http_client_test.go
@@ -49,7 +49,11 @@ func TestPostToEnclaveInflight(t *testing.T) {
 	// waits on it, or a failed assertion deadlocks the test binary.
 	t.Cleanup(ts.Close)
 	t.Cleanup(releaseFn)
-	e := &Enclave{host: strings.TrimPrefix(ts.URL, "https://")}
+	e := &Enclave{
+		host:      strings.TrimPrefix(ts.URL, "https://"),
+		modelName: "test-model",
+		cb:        newCircuitBreaker(),
+	}
 
 	resp, err := postToEnclave(context.Background(), ts.Client(), e, "/v1/chat/completions", []byte("{}"), nil)
 	if err != nil {
@@ -57,6 +61,9 @@ func TestPostToEnclaveInflight(t *testing.T) {
 	}
 	if got := e.inflight.Load(); got != 1 {
 		t.Fatalf("in-flight after headers = %d, want 1 (body still open)", got)
+	}
+	if got := e.cb.ConsecutiveFailures(); got != 0 {
+		t.Fatalf("breaker failures after success = %d, want 0", got)
 	}
 	releaseFn()
 	if err := resp.Body.Close(); err != nil {
@@ -75,12 +82,42 @@ func TestPostToEnclaveInflight(t *testing.T) {
 	ts2 := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	client := ts2.Client()
 	ts2.Close()
-	e2 := &Enclave{host: strings.TrimPrefix(ts2.URL, "https://")}
+	e2 := &Enclave{
+		host:      strings.TrimPrefix(ts2.URL, "https://"),
+		modelName: "test-model",
+		cb:        newCircuitBreaker(),
+	}
 	if _, err := postToEnclave(context.Background(), client, e2, "/x", nil, nil); err == nil {
 		t.Fatal("expected transport error against closed server")
 	}
 	if got := e2.inflight.Load(); got != 0 {
 		t.Fatalf("in-flight after error = %d, want 0", got)
+	}
+	if got := e2.cb.ConsecutiveFailures(); got != 1 {
+		t.Fatalf("breaker failures after transport error = %d, want 1", got)
+	}
+}
+
+func TestPostToEnclaveCancellationReleasesRecoveryProbe(t *testing.T) {
+	cb := newCircuitBreaker()
+	cb.consecutiveFailures.Store(cbFailureThreshold)
+	cb.storeState(cbHalfOpen)
+	e := &Enclave{
+		host:      "example.invalid",
+		modelName: "test-model",
+		cb:        cb,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := postToEnclave(ctx, http.DefaultClient, e, "/x", nil, nil); err == nil {
+		t.Fatal("expected canceled request to fail")
+	}
+	if got := cb.State(); got != cbOpen {
+		t.Fatalf("breaker state = %d, want open", got)
+	}
+	if got := cb.ConsecutiveFailures(); got != cbFailureThreshold {
+		t.Fatalf("breaker failures = %d, want %d", got, cbFailureThreshold)
 	}
 }
 

--- a/manager/http_client_test.go
+++ b/manager/http_client_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // TestLocalMCPEndpointEnvVar pins the exact shape of the debug-bypass
@@ -55,7 +56,7 @@ func TestPostToEnclaveInflight(t *testing.T) {
 		cb:        newCircuitBreaker(),
 	}
 
-	resp, err := postToEnclave(context.Background(), ts.Client(), e, "/v1/chat/completions", []byte("{}"), nil)
+	resp, err := postToEnclave(context.Background(), ts.Client(), e, "/v1/chat/completions", []byte("{}"), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +88,7 @@ func TestPostToEnclaveInflight(t *testing.T) {
 		modelName: "test-model",
 		cb:        newCircuitBreaker(),
 	}
-	if _, err := postToEnclave(context.Background(), client, e2, "/x", nil, nil); err == nil {
+	if _, err := postToEnclave(context.Background(), client, e2, "/x", nil, nil, nil); err == nil {
 		t.Fatal("expected transport error against closed server")
 	}
 	if got := e2.inflight.Load(); got != 0 {
@@ -101,16 +102,21 @@ func TestPostToEnclaveInflight(t *testing.T) {
 func TestPostToEnclaveCancellationReleasesRecoveryProbe(t *testing.T) {
 	cb := newCircuitBreaker()
 	cb.consecutiveFailures.Store(cbFailureThreshold)
-	cb.storeState(cbHalfOpen)
+	cb.storeState(cbOpen)
+	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
 	e := &Enclave{
 		host:      "example.invalid",
 		modelName: "test-model",
 		cb:        cb,
 	}
+	claim := e.claimProbe()
+	if claim == nil {
+		t.Fatal("expected probe claim after cooldown")
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if _, err := postToEnclave(ctx, http.DefaultClient, e, "/x", nil, nil); err == nil {
+	if _, err := postToEnclave(ctx, http.DefaultClient, e, "/x", nil, nil, claim); err == nil {
 		t.Fatal("expected canceled request to fail")
 	}
 	if got := cb.State(); got != cbOpen {
@@ -118,6 +124,32 @@ func TestPostToEnclaveCancellationReleasesRecoveryProbe(t *testing.T) {
 	}
 	if got := cb.ConsecutiveFailures(); got != cbFailureThreshold {
 		t.Fatalf("breaker failures = %d, want %d", got, cbFailureThreshold)
+	}
+}
+
+// TestPostToEnclaveNonOwnerCancellationKeepsProbe pins that a cancelled
+// dispatch without the claim cannot release someone else's in-flight probe.
+func TestPostToEnclaveNonOwnerCancellationKeepsProbe(t *testing.T) {
+	cb := newCircuitBreaker()
+	cb.consecutiveFailures.Store(cbFailureThreshold)
+	cb.storeState(cbOpen)
+	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
+	e := &Enclave{
+		host:      "example.invalid",
+		modelName: "test-model",
+		cb:        cb,
+	}
+	if e.claimProbe() == nil {
+		t.Fatal("expected probe claim after cooldown")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := postToEnclave(ctx, http.DefaultClient, e, "/x", nil, nil, nil); err == nil {
+		t.Fatal("expected canceled request to fail")
+	}
+	if got := cb.State(); got != cbHalfOpen {
+		t.Fatalf("breaker state = %d, want half-open (probe still owned)", got)
 	}
 }
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -323,16 +323,31 @@ func (em *EnclaveManager) Shutdown() {
 	})
 }
 
+// claimProbe attempts to claim the enclave's due recovery probe, returning
+// the claim the dispatched request must carry, or nil when no probe is due.
+func (e *Enclave) claimProbe() *ProbeClaim {
+	if e.cb == nil {
+		return nil
+	}
+	token, ok := e.cb.ClaimProbe()
+	if !ok {
+		return nil
+	}
+	return &ProbeClaim{cb: e.cb, token: token, modelName: e.modelName, host: e.host}
+}
+
 // NextEnclave picks a uniformly random enclave with a closed circuit breaker,
 // preferring those that are not currently overloaded and not in skip. If an
 // open breaker is past its cooldown, it sends a probe to that enclave. Falls
 // back to any closed enclave, then any enclave (degraded > unavailable).
-func (m *Model) NextEnclave(skip map[string]bool) *Enclave {
+// A non-nil ProbeClaim means the pick is a claimed recovery probe: the
+// request dispatched to it must carry the claim (see ProbeClaim).
+func (m *Model) NextEnclave(skip map[string]bool) (*Enclave, *ProbeClaim) {
 	return m.nextEnclave(skip, true)
 }
 
 // nextEnclave is NextEnclave with probe claiming optional.
-func (m *Model) nextEnclave(skip map[string]bool, claimProbes bool) *Enclave {
+func (m *Model) nextEnclave(skip map[string]bool, claimProbes bool) (*Enclave, *ProbeClaim) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -341,8 +356,10 @@ func (m *Model) nextEnclave(skip map[string]bool, claimProbes bool) *Enclave {
 	for _, enclave := range m.Enclaves {
 		all = append(all, enclave)
 		if enclave.cb != nil && !enclave.cb.Closed() {
-			if claimProbes && enclave.cb.NeedProbe() {
-				return enclave
+			if claimProbes {
+				if claim := enclave.claimProbe(); claim != nil {
+					return enclave, claim
+				}
 			}
 			continue
 		}
@@ -357,13 +374,13 @@ func (m *Model) nextEnclave(skip map[string]bool, claimProbes bool) *Enclave {
 
 	switch {
 	case len(preferred) > 0:
-		return preferred[rand.IntN(len(preferred))]
+		return preferred[rand.IntN(len(preferred))], nil
 	case len(closed) > 0:
-		return closed[rand.IntN(len(closed))]
+		return closed[rand.IntN(len(closed))], nil
 	case len(all) > 0:
-		return all[rand.IntN(len(all))]
+		return all[rand.IntN(len(all))], nil
 	}
-	return nil
+	return nil, nil
 }
 
 // NextEnclavePreferring picks like NextEnclave, but serves the first
@@ -374,11 +391,11 @@ func (m *Model) nextEnclave(skip map[string]bool, claimProbes bool) *Enclave {
 // caller must step aside per request via ShouldReject and skip (main.go's
 // retry loop, SelectForDispatch for internal dispatches), so a flapping
 // load signal can never move a key's home.
-func (m *Model) NextEnclavePreferring(order []string, skip map[string]bool) *Enclave {
+func (m *Model) NextEnclavePreferring(order []string, skip map[string]bool) (*Enclave, *ProbeClaim) {
 	return m.nextEnclavePreferring(order, skip, true)
 }
 
-func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, claimProbes bool) *Enclave {
+func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, claimProbes bool) (*Enclave, *ProbeClaim) {
 	if len(order) == 0 {
 		return m.nextEnclave(skip, claimProbes)
 	}
@@ -386,9 +403,11 @@ func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, clai
 	if claimProbes {
 		m.mu.RLock()
 		for _, enclave := range m.Enclaves {
-			if enclave.cb != nil && !enclave.cb.Closed() && enclave.cb.NeedProbe() {
-				m.mu.RUnlock()
-				return enclave
+			if enclave.cb != nil && !enclave.cb.Closed() {
+				if claim := enclave.claimProbe(); claim != nil {
+					m.mu.RUnlock()
+					return enclave, claim
+				}
 			}
 		}
 		m.mu.RUnlock()
@@ -403,7 +422,7 @@ func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, clai
 			continue
 		}
 		m.mu.RUnlock()
-		return enclave
+		return enclave, nil
 	}
 	m.mu.RUnlock()
 	return m.nextEnclave(skip, claimProbes)
@@ -417,14 +436,27 @@ func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, clai
 // warmest one — never at a breaker-open host, which is reachable only when
 // no closed replica exists at all. Internal dispatches record their outcomes,
 // so they may also claim a due recovery probe.
-func (m *Model) SelectForDispatch(order []string) *Enclave {
+func (m *Model) SelectForDispatch(order []string) (*Enclave, *ProbeClaim) {
+	return m.selectForDispatch(order, true)
+}
+
+// selectForDispatch is SelectForDispatch with probe claiming optional, for
+// callers that hand the connection to a transport that records no breaker
+// outcomes (a claimed probe there would strand the breaker half-open).
+func (m *Model) selectForDispatch(order []string, claimProbes bool) (*Enclave, *ProbeClaim) {
 	skip := map[string]bool{}
 	var firstOverloaded *Enclave
 	var enclave *Enclave
 	for range m.EnclaveCount() {
-		enclave = m.nextEnclavePreferring(order, skip, true)
+		var claim *ProbeClaim
+		enclave, claim = m.nextEnclavePreferring(order, skip, claimProbes)
 		if enclave == nil {
 			break
+		}
+		// A claimed probe must be dispatched: preferring an overloaded
+		// pick over it would leave the claim unresolved.
+		if claim != nil {
+			return enclave, claim
 		}
 		if enclave.cb != nil && !enclave.cb.Closed() {
 			// Selection is down to non-closed last resorts: every
@@ -432,7 +464,7 @@ func (m *Model) SelectForDispatch(order []string) *Enclave {
 			break
 		}
 		if overloaded, _, _ := enclave.ShouldReject(); !overloaded {
-			return enclave
+			return enclave, nil
 		}
 		if firstOverloaded == nil {
 			firstOverloaded = enclave
@@ -440,9 +472,9 @@ func (m *Model) SelectForDispatch(order []string) *Enclave {
 		skip[enclave.String()] = true
 	}
 	if firstOverloaded != nil {
-		return firstOverloaded
+		return firstOverloaded, nil
 	}
-	return enclave
+	return enclave, nil
 }
 
 // EnclaveCount returns the number of configured enclaves under the model lock.

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -331,10 +331,7 @@ func (m *Model) NextEnclave(skip map[string]bool) *Enclave {
 	return m.nextEnclave(skip, true)
 }
 
-// nextEnclave is NextEnclave with probe claiming optional: internal
-// dispatches never record breaker outcomes, so a probe they claim is a
-// probe that strands the breaker in half-open — only the public proxy
-// path, which records outcomes, may claim one.
+// nextEnclave is NextEnclave with probe claiming optional.
 func (m *Model) nextEnclave(skip map[string]bool, claimProbes bool) *Enclave {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -418,15 +415,14 @@ func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, clai
 // to the next-warmest host. Internal dispatches have no 429 path, so when
 // every live candidate is overloaded it serves through overload at the
 // warmest one — never at a breaker-open host, which is reachable only when
-// no closed replica exists at all. It also never claims recovery probes:
-// internal dispatches don't record breaker outcomes, so a probe claimed
-// here would strand the breaker in half-open.
+// no closed replica exists at all. Internal dispatches record their outcomes,
+// so they may also claim a due recovery probe.
 func (m *Model) SelectForDispatch(order []string) *Enclave {
 	skip := map[string]bool{}
 	var firstOverloaded *Enclave
 	var enclave *Enclave
 	for range m.EnclaveCount() {
-		enclave = m.nextEnclavePreferring(order, skip, false)
+		enclave = m.nextEnclavePreferring(order, skip, true)
 		if enclave == nil {
 			break
 		}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -581,19 +581,18 @@ func TestSelectForDispatchNeverPicksDeadHost(t *testing.T) {
 	}
 }
 
-// TestSelectForDispatchDoesNotClaimProbes pins that internal dispatches
-// leave recovery probes alone: they never record breaker outcomes, so a
-// probe claimed here would strand the breaker in half-open until restart.
-func TestSelectForDispatchDoesNotClaimProbes(t *testing.T) {
+// TestSelectForDispatchClaimsProbes pins that internal dispatches participate
+// in breaker recovery now that their outcomes are recorded.
+func TestSelectForDispatchClaimsProbes(t *testing.T) {
 	m := newTestModel("a", "b")
 	tripBreaker(m.Enclaves["b"])
 	m.Enclaves["b"].cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano()) // probe due
 
-	if got := m.SelectForDispatch([]string{"a"}); got == nil || got.host != "a" {
-		t.Fatalf("pick = %v, want a (probe must not be claimed)", got)
+	if got := m.SelectForDispatch([]string{"a"}); got == nil || got.host != "b" {
+		t.Fatalf("pick = %v, want due probe b", got)
 	}
-	if st := m.Enclaves["b"].cb.State(); st != cbOpen {
-		t.Fatalf("breaker state = %v, want still open (probe claim belongs to the public path)", st)
+	if st := m.Enclaves["b"].cb.State(); st != cbHalfOpen {
+		t.Fatalf("breaker state = %v, want half-open after probe claim", st)
 	}
 }
 

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -37,7 +37,7 @@ func TestNextEnclave_PrefersNonOverloaded(t *testing.T) {
 	m.Enclaves["a"].metrics.overloaded.Store(true)
 
 	for i := 0; i < 50; i++ {
-		if got := m.NextEnclave(nil); got == nil || got.host != "b" {
+		if got, _ := m.NextEnclave(nil); got == nil || got.host != "b" {
 			t.Fatalf("expected b, got %v", got)
 		}
 	}
@@ -45,7 +45,7 @@ func TestNextEnclave_PrefersNonOverloaded(t *testing.T) {
 
 func TestNextEnclave_SkipExcludesFromPreferred(t *testing.T) {
 	m := newTestModel("a", "b", "c")
-	got := m.NextEnclave(map[string]bool{"a": true, "b": true})
+	got, _ := m.NextEnclave(map[string]bool{"a": true, "b": true})
 	if got == nil || got.host != "c" {
 		t.Fatalf("expected c, got %v", got)
 	}
@@ -55,7 +55,7 @@ func TestNextEnclave_AllOverloadedFallsBack(t *testing.T) {
 	m := newTestModel("a", "b")
 	m.Enclaves["a"].metrics.overloaded.Store(true)
 	m.Enclaves["b"].metrics.overloaded.Store(true)
-	if got := m.NextEnclave(nil); got == nil {
+	if got, _ := m.NextEnclave(nil); got == nil {
 		t.Fatal("expected fallback pick, got nil")
 	}
 }
@@ -68,14 +68,18 @@ func TestNextEnclave_ProbeOverridesSkip(t *testing.T) {
 	}
 	probe.cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
 
-	if got := m.NextEnclave(map[string]bool{"probe": true}); got == nil || got.host != "probe" {
+	got, claim := m.NextEnclave(map[string]bool{"probe": true})
+	if got == nil || got.host != "probe" {
 		t.Fatalf("expected probe, got %v", got)
+	}
+	if claim == nil {
+		t.Fatal("probe pick must carry its claim")
 	}
 }
 
 func TestNextEnclave_EmptyModel(t *testing.T) {
 	m := &Model{Enclaves: map[string]*Enclave{}}
-	if got := m.NextEnclave(nil); got != nil {
+	if got, _ := m.NextEnclave(nil); got != nil {
 		t.Fatalf("expected nil, got %v", got)
 	}
 }
@@ -296,10 +300,10 @@ func TestNextEnclavePreferring(t *testing.T) {
 	m := newTestModel("a", "b", "c")
 	order := []string{"b", "c", "a"}
 
-	if got := m.NextEnclavePreferring(order, nil); got == nil || got.host != "b" {
+	if got, _ := m.NextEnclavePreferring(order, nil); got == nil || got.host != "b" {
 		t.Fatalf("pick = %v, want order head b", got)
 	}
-	if got := m.NextEnclavePreferring(order, map[string]bool{"b": true}); got == nil || got.host != "c" {
+	if got, _ := m.NextEnclavePreferring(order, map[string]bool{"b": true}); got == nil || got.host != "c" {
 		t.Fatalf("pick with b skipped = %v, want c", got)
 	}
 
@@ -307,7 +311,7 @@ func TestNextEnclavePreferring(t *testing.T) {
 	// never move a key's home — stepping aside is the caller's per-request
 	// job (skip / SelectForDispatch), not the selector's.
 	m.Enclaves["b"].metrics.overloaded.Store(true)
-	if got := m.NextEnclavePreferring(order, nil); got == nil || got.host != "b" {
+	if got, _ := m.NextEnclavePreferring(order, nil); got == nil || got.host != "b" {
 		t.Fatalf("pick with b overloaded = %v, want b (no overload veto)", got)
 	}
 	m.Enclaves["b"].metrics.overloaded.Store(false)
@@ -316,25 +320,25 @@ func TestNextEnclavePreferring(t *testing.T) {
 	// Keep the trip fresh so a stalled test runner cannot cross the probe
 	// cooldown and turn the open breaker into a served probe mid-test.
 	m.Enclaves["b"].cb.lastFailureNano.Store(time.Now().UnixNano())
-	if got := m.NextEnclavePreferring(order, nil); got == nil || got.host != "c" {
+	if got, _ := m.NextEnclavePreferring(order, nil); got == nil || got.host != "c" {
 		t.Fatalf("pick with b open = %v, want c", got)
 	}
 
 	// Order exhausted: fall back to random among the acceptable rest.
 	m.Enclaves["b"].cb.lastFailureNano.Store(time.Now().UnixNano())
-	if got := m.NextEnclavePreferring([]string{"b"}, nil); got == nil || got.host == "b" {
+	if got, _ := m.NextEnclavePreferring([]string{"b"}, nil); got == nil || got.host == "b" {
 		t.Fatalf("exhausted order = %v, want random fallback avoiding b", got)
 	}
 
 	// A due probe beats the cache preference.
 	probe := m.Enclaves["b"]
 	probe.cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
-	if got := m.NextEnclavePreferring([]string{"a", "c"}, nil); got == nil || got.host != "b" {
-		t.Fatalf("pick with due probe = %v, want probe b", got)
+	if got, claim := m.NextEnclavePreferring([]string{"a", "c"}, nil); got == nil || got.host != "b" || claim == nil {
+		t.Fatalf("pick with due probe = %v (claim %v), want claimed probe b", got, claim)
 	}
 
 	// Empty order behaves like NextEnclave.
-	if got := m.NextEnclavePreferring(nil, map[string]bool{"a": true, "b": true}); got == nil || got.host != "c" {
+	if got, _ := m.NextEnclavePreferring(nil, map[string]bool{"a": true, "b": true}); got == nil || got.host != "c" {
 		t.Fatalf("nil order = %v, want c", got)
 	}
 }
@@ -347,14 +351,14 @@ func TestSelectForDispatch(t *testing.T) {
 	m := newTestModel("a", "b", "c")
 	order := []string{"b", "c", "a"}
 
-	if got := m.SelectForDispatch(order); got == nil || got.host != "b" {
+	if got, _ := m.SelectForDispatch(order); got == nil || got.host != "b" {
 		t.Fatalf("pick = %v, want order head b", got)
 	}
 
 	m.Enclaves["b"].metrics.overloaded.Store(true)
 	m.Enclaves["b"].metrics.cfg = &config.OverloadConfig{MaxRequestsWaiting: 1, RetryAfterMinutes: 1}
 	m.Enclaves["b"].metrics.updateLatest(5, time.Now())
-	if got := m.SelectForDispatch(order); got == nil || got.host != "c" {
+	if got, _ := m.SelectForDispatch(order); got == nil || got.host != "c" {
 		t.Fatalf("pick with b overloaded = %v, want spill to c", got)
 	}
 
@@ -363,7 +367,7 @@ func TestSelectForDispatch(t *testing.T) {
 		m.Enclaves[h].metrics.cfg = &config.OverloadConfig{MaxRequestsWaiting: 1, RetryAfterMinutes: 1}
 		m.Enclaves[h].metrics.updateLatest(5, time.Now())
 	}
-	if got := m.SelectForDispatch(order); got == nil {
+	if got, _ := m.SelectForDispatch(order); got == nil {
 		t.Fatal("all-overloaded dispatch must still return an enclave")
 	}
 }
@@ -554,7 +558,7 @@ func TestSelectForDispatchAllOverloadedReturnsWarmest(t *testing.T) {
 		makeOverloaded(m.Enclaves[h])
 	}
 	for range 20 {
-		if got := m.SelectForDispatch([]string{"b", "c", "a"}); got == nil || got.host != "b" {
+		if got, _ := m.SelectForDispatch([]string{"b", "c", "a"}); got == nil || got.host != "b" {
 			t.Fatalf("all-overloaded pick = %v, want warmest b", got)
 		}
 	}
@@ -571,7 +575,7 @@ func TestSelectForDispatchNeverPicksDeadHost(t *testing.T) {
 	m.Enclaves["c"].cb.lastFailureNano.Store(time.Now().UnixNano()) // not probe-due
 
 	for range 200 {
-		got := m.SelectForDispatch([]string{"a", "b"})
+		got, _ := m.SelectForDispatch([]string{"a", "b"})
 		if got == nil || got.host == "c" {
 			t.Fatalf("pick = %v, must never be dead host c", got)
 		}
@@ -588,8 +592,12 @@ func TestSelectForDispatchClaimsProbes(t *testing.T) {
 	tripBreaker(m.Enclaves["b"])
 	m.Enclaves["b"].cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano()) // probe due
 
-	if got := m.SelectForDispatch([]string{"a"}); got == nil || got.host != "b" {
+	got, claim := m.SelectForDispatch([]string{"a"})
+	if got == nil || got.host != "b" {
 		t.Fatalf("pick = %v, want due probe b", got)
+	}
+	if claim == nil {
+		t.Fatal("probe pick must carry its claim")
 	}
 	if st := m.Enclaves["b"].cb.State(); st != cbHalfOpen {
 		t.Fatalf("breaker state = %v, want half-open after probe claim", st)

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -604,6 +604,26 @@ func TestSelectForDispatchClaimsProbes(t *testing.T) {
 	}
 }
 
+// TestSelectForDispatchWithoutClaimingLeavesProbes pins the selection used
+// by callers that record no breaker outcomes (MCP sessions, file
+// conversion): a due probe must be left for a path that can resolve it.
+func TestSelectForDispatchWithoutClaimingLeavesProbes(t *testing.T) {
+	m := newTestModel("a", "b")
+	tripBreaker(m.Enclaves["b"])
+	m.Enclaves["b"].cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano()) // probe due
+
+	got, claim := m.selectForDispatch([]string{"a"}, false)
+	if got == nil || got.host != "a" {
+		t.Fatalf("pick = %v, want a", got)
+	}
+	if claim != nil {
+		t.Fatal("non-claiming selection must not return a probe claim")
+	}
+	if st := m.Enclaves["b"].cb.State(); st != cbOpen {
+		t.Fatalf("breaker state = %v, want still open (probe left unclaimed)", st)
+	}
+}
+
 // TestShouldRejectNonClosedBreaker pins that overload rejection only applies
 // to healthy replicas: a probe or last-resort pick must dispatch.
 func TestShouldRejectNonClosedBreaker(t *testing.T) {

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -250,8 +250,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 		apiKey := ""
 		if authHeader != "" {
 			// Extract API key from "Bearer <api_key>" format
-			if strings.HasPrefix(authHeader, "Bearer ") {
-				apiKey = strings.TrimPrefix(authHeader, "Bearer ")
+			if apiKey = BearerToken(authHeader); apiKey != "" {
 				// For user ID, we can use a placeholder or the API key itself
 				userID = "authenticated_user"
 			}

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -146,9 +146,13 @@ func publishBreakerState(modelName, host string, cb *circuitBreaker) {
 func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Collector, cb *circuitBreaker) *httputil.ReverseProxy {
 	recordFailure := func(reason string) {
 		// Client cancellations aren't backend faults — track in a dedicated
-		// counter, don't trip the breaker.
+		// counter, don't trip the breaker. A cancelled recovery probe must
+		// still return the breaker to open, or it strands half-open forever.
 		if reason == "canceled" {
 			ClientCancellationsTotal.WithLabelValues(modelName, host).Inc()
+			if cb.AbortProbe() {
+				publishBreakerState(modelName, host, cb)
+			}
 			return
 		}
 		ProxyFailureTotal.WithLabelValues(modelName, host, reason).Inc()

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -146,16 +146,6 @@ func publishBreakerState(modelName, host string, cb *circuitBreaker) {
 
 func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Collector, cb *circuitBreaker) *httputil.ReverseProxy {
 	recordFailure := func(reason string) {
-		// Client cancellations aren't backend faults — track in a dedicated
-		// counter, don't trip the breaker. A cancelled recovery probe must
-		// still return the breaker to open, or it strands half-open forever.
-		if reason == "canceled" {
-			ClientCancellationsTotal.WithLabelValues(modelName, host).Inc()
-			if cb.AbortProbe() {
-				publishBreakerState(modelName, host, cb)
-			}
-			return
-		}
 		ProxyFailureTotal.WithLabelValues(modelName, host, reason).Inc()
 		cb.RecordFailure()
 		publishBreakerState(modelName, host, cb)
@@ -206,9 +196,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				"model":   modelName,
 				"enclave": host,
 			}).Warn("request body exceeded limit while proxying")
-			if cb.AbortProbe() {
-				publishBreakerState(modelName, host, cb)
-			}
+			ProbeClaimFromContext(r.Context()).Abort()
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusRequestEntityTooLarge)
 			json.NewEncoder(w).Encode(map[string]any{
@@ -227,7 +215,16 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 			"reason":  reason,
 			"error":   err.Error(),
 		}).Error("proxy error")
-		recordFailure(reason)
+		// Client cancellations aren't backend faults — track in a dedicated
+		// counter, don't trip the breaker. A cancelled recovery probe must
+		// still return the breaker to open, or it strands half-open forever;
+		// only the request that owns the claim may release it.
+		if reason == "canceled" {
+			ClientCancellationsTotal.WithLabelValues(modelName, host).Inc()
+			ProbeClaimFromContext(r.Context()).Abort()
+		} else {
+			recordFailure(reason)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)
 		json.NewEncoder(w).Encode(map[string]any{

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -94,6 +94,7 @@ const (
 	ErrMsgServerError   = "The server had an error while processing your request."
 	ErrMsgOverloaded    = "The engine is currently overloaded, please try again later."
 	ErrMsgModelNotFound = "The model does not exist."
+	ErrMsgBodyTooLarge  = "Request body is too large."
 )
 
 // billingCloser wraps a response body and emits a zero-token billing event
@@ -194,6 +195,31 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 	}
 	proxy.Transport = transport
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		// A body-limit trip during the outbound copy (chunked uploads pass
+		// the router's Content-Length pre-check) is a client fault: answer
+		// 413 and leave the breaker alone, or cheap oversized uploads could
+		// take a healthy backend out of rotation. Like a cancellation, a
+		// tripped recovery probe must still return the breaker to open.
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			log.WithFields(log.Fields{
+				"model":   modelName,
+				"enclave": host,
+			}).Warn("request body exceeded limit while proxying")
+			if cb.AbortProbe() {
+				publishBreakerState(modelName, host, cb)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]string{
+					"message": ErrMsgBodyTooLarge,
+					"type":    ErrTypeInvalidRequest,
+				},
+			})
+			return
+		}
+
 		reason := classifyProxyError(err)
 		log.WithFields(log.Fields{
 			"model":   modelName,

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -134,25 +134,25 @@ func TestCircuitBreaker_SuccessResetsClosed(t *testing.T) {
 	}
 }
 
-func TestCircuitBreaker_NeedProbeAfterCooldown(t *testing.T) {
+func TestCircuitBreaker_ClaimProbeAfterCooldown(t *testing.T) {
 	cb := newCircuitBreaker()
 	for i := 0; i < cbFailureThreshold; i++ {
 		cb.RecordFailure()
 	}
-	if cb.NeedProbe() {
+	if _, ok := cb.ClaimProbe(); ok {
 		t.Fatal("should not probe before cooldown")
 	}
 	// Simulate cooldown by backdating lastFailureNano
 	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
 
-	if !cb.NeedProbe() {
+	if _, ok := cb.ClaimProbe(); !ok {
 		t.Fatal("expected probe after cooldown")
 	}
 	if cb.State() != cbHalfOpen {
 		t.Fatalf("expected half-open, got %d", cb.State())
 	}
 	// Second call should return false (only one probe allowed)
-	if cb.NeedProbe() {
+	if _, ok := cb.ClaimProbe(); ok {
 		t.Fatal("expected no second probe while half-open")
 	}
 }
@@ -163,7 +163,7 @@ func TestCircuitBreaker_HalfOpenToClosedOnSuccess(t *testing.T) {
 		cb.RecordFailure()
 	}
 	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
-	cb.NeedProbe() // transition to half-open
+	cb.ClaimProbe() // transition to half-open
 
 	cb.RecordSuccess()
 	if cb.State() != cbClosed {
@@ -177,7 +177,7 @@ func TestCircuitBreaker_HalfOpenToOpenOnFailure(t *testing.T) {
 		cb.RecordFailure()
 	}
 	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
-	cb.NeedProbe() // transition to half-open
+	cb.ClaimProbe() // transition to half-open
 
 	cb.RecordFailure()
 	if cb.State() != cbOpen {
@@ -191,12 +191,16 @@ func TestCircuitBreaker_AbortProbeReturnsToOpen(t *testing.T) {
 		cb.RecordFailure()
 	}
 	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
-	if !cb.NeedProbe() {
+	token, ok := cb.ClaimProbe()
+	if !ok {
 		t.Fatal("expected probe after cooldown")
 	}
 	failures := cb.ConsecutiveFailures()
 
-	if !cb.AbortProbe() {
+	if cb.AbortProbe(token - 1) {
+		t.Fatal("a stale token must not abort the current probe")
+	}
+	if !cb.AbortProbe(token) {
 		t.Fatal("expected claimed probe to abort")
 	}
 	if cb.State() != cbOpen {
@@ -205,36 +209,50 @@ func TestCircuitBreaker_AbortProbeReturnsToOpen(t *testing.T) {
 	if cb.ConsecutiveFailures() != failures {
 		t.Fatalf("abort changed failure count: got %d, want %d", cb.ConsecutiveFailures(), failures)
 	}
-	if cb.NeedProbe() {
+	if _, ok := cb.ClaimProbe(); ok {
 		t.Fatal("should restart cooldown after abort")
 	}
 }
 
 // TestProxyCancellationReleasesRecoveryProbe pins that a client
 // cancellation on the public proxy path returns a claimed recovery probe
-// to open instead of stranding the breaker half-open forever.
+// to open instead of stranding the breaker half-open forever — but only
+// when the cancelled request owns the claim.
 func TestProxyCancellationReleasesRecoveryProbe(t *testing.T) {
 	cb := newCircuitBreaker()
 	for i := 0; i < cbFailureThreshold; i++ {
 		cb.RecordFailure()
 	}
 	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
-	if !cb.NeedProbe() {
+	token, ok := cb.ClaimProbe()
+	if !ok {
 		t.Fatal("expected probe claim after cooldown")
 	}
+	claim := &ProbeClaim{cb: cb, token: token, modelName: "probe-model", host: "probe-host.test"}
 
 	collector := billing.NewCollector("", "", "")
 	t.Cleanup(collector.Stop)
 	proxy := newProxy("probe-host.test", "", "probe-model", collector, cb)
 
+	// A cancelled request that does not own the claim must leave the
+	// in-flight probe alone.
 	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
 	rec := httptest.NewRecorder()
+	proxy.ErrorHandler(rec, req, context.Canceled)
+	if cb.State() != cbHalfOpen {
+		t.Fatalf("breaker state = %d, want half-open (probe not owned by canceller)", cb.State())
+	}
+
+	// The owning request's cancellation releases it.
+	req = httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req = req.WithContext(WithProbeClaim(req.Context(), claim))
+	rec = httptest.NewRecorder()
 	proxy.ErrorHandler(rec, req, context.Canceled)
 
 	if cb.State() != cbOpen {
 		t.Fatalf("breaker state = %d, want open after cancelled probe", cb.State())
 	}
-	if cb.NeedProbe() {
+	if _, ok := cb.ClaimProbe(); ok {
 		t.Fatal("cooldown must restart after a cancelled probe")
 	}
 }

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -239,6 +239,30 @@ func TestProxyCancellationReleasesRecoveryProbe(t *testing.T) {
 	}
 }
 
+// TestProxyOversizedBodyIsClientError pins that a MaxBytesReader trip
+// during the outbound copy answers 413 and records no backend failure, so
+// cheap oversized uploads cannot open a healthy enclave's breaker.
+func TestProxyOversizedBodyIsClientError(t *testing.T) {
+	cb := newCircuitBreaker()
+	collector := billing.NewCollector("", "", "")
+	t.Cleanup(collector.Stop)
+	proxy := newProxy("oversize-host.test", "", "oversize-model", collector, cb)
+
+	req := httptest.NewRequest("POST", "/v1/audio/transcriptions", nil)
+	rec := httptest.NewRecorder()
+	proxy.ErrorHandler(rec, req, &http.MaxBytesError{Limit: 1})
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+	if got := cb.ConsecutiveFailures(); got != 0 {
+		t.Fatalf("breaker failures = %d, want 0 (client fault)", got)
+	}
+	if cb.State() != cbClosed {
+		t.Fatalf("breaker state = %d, want closed", cb.State())
+	}
+}
+
 func TestCircuitBreaker_SuccessResetsFailureCount(t *testing.T) {
 	cb := newCircuitBreaker()
 	cb.RecordFailure()

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -185,6 +185,60 @@ func TestCircuitBreaker_HalfOpenToOpenOnFailure(t *testing.T) {
 	}
 }
 
+func TestCircuitBreaker_AbortProbeReturnsToOpen(t *testing.T) {
+	cb := newCircuitBreaker()
+	for i := 0; i < cbFailureThreshold; i++ {
+		cb.RecordFailure()
+	}
+	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
+	if !cb.NeedProbe() {
+		t.Fatal("expected probe after cooldown")
+	}
+	failures := cb.ConsecutiveFailures()
+
+	if !cb.AbortProbe() {
+		t.Fatal("expected claimed probe to abort")
+	}
+	if cb.State() != cbOpen {
+		t.Fatalf("expected open after abort, got %d", cb.State())
+	}
+	if cb.ConsecutiveFailures() != failures {
+		t.Fatalf("abort changed failure count: got %d, want %d", cb.ConsecutiveFailures(), failures)
+	}
+	if cb.NeedProbe() {
+		t.Fatal("should restart cooldown after abort")
+	}
+}
+
+// TestProxyCancellationReleasesRecoveryProbe pins that a client
+// cancellation on the public proxy path returns a claimed recovery probe
+// to open instead of stranding the breaker half-open forever.
+func TestProxyCancellationReleasesRecoveryProbe(t *testing.T) {
+	cb := newCircuitBreaker()
+	for i := 0; i < cbFailureThreshold; i++ {
+		cb.RecordFailure()
+	}
+	cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano())
+	if !cb.NeedProbe() {
+		t.Fatal("expected probe claim after cooldown")
+	}
+
+	collector := billing.NewCollector("", "", "")
+	t.Cleanup(collector.Stop)
+	proxy := newProxy("probe-host.test", "", "probe-model", collector, cb)
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	proxy.ErrorHandler(rec, req, context.Canceled)
+
+	if cb.State() != cbOpen {
+		t.Fatalf("breaker state = %d, want open after cancelled probe", cb.State())
+	}
+	if cb.NeedProbe() {
+		t.Fatal("cooldown must restart after a cancelled probe")
+	}
+}
+
 func TestCircuitBreaker_SuccessResetsFailureCount(t *testing.T) {
 	cb := newCircuitBreaker()
 	cb.RecordFailure()

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -258,9 +258,7 @@ func toolSessionHeaders(r *http.Request, requestID, modelName string, body map[s
 	apiKey := ""
 	if auth := r.Header.Get("Authorization"); auth != "" {
 		headers.Set("Authorization", auth)
-		if strings.HasPrefix(auth, "Bearer ") {
-			apiKey = strings.TrimSpace(strings.TrimPrefix(auth, "Bearer "))
-		}
+		apiKey = manager.BearerToken(auth)
 	}
 	if usageContextSecret != "" {
 		if err := usagereporting.SetHeaders(headers, usagereporting.Context{
@@ -457,12 +455,7 @@ func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested boo
 }
 
 func emitBillingEvent(em *manager.EnclaveManager, r *http.Request, response *upstreamJSONResponse, modelName string, streaming bool) {
-	authHeader := r.Header.Get("Authorization")
-	if !strings.HasPrefix(authHeader, "Bearer ") {
-		return
-	}
-
-	apiKey := strings.TrimPrefix(authHeader, "Bearer ")
+	apiKey := manager.BearerToken(r.Header.Get("Authorization"))
 	if apiKey == "" {
 		return
 	}


### PR DESCRIPTION
## Summary
Hardens the prompt cache path for production: rejects malformed bodies, caps request sizes, and tightens circuit-breaker handling so cache warmth and backend health stay accurate. Authentication is enforced at the model endpoint, so no router-side shim auth config is included.

- **Bug Fixes**
  - Subdomain routes now require one JSON object; reject non-JSON and trailing data so router-owned cache fields cannot bypass stripping.
  - Enforce a 64 MB body limit with early Content-Length checks and `http.MaxBytesReader`; return clear 413s and classify chunked oversize as client errors (never as backend faults, so oversized uploads cannot trip a healthy enclave's breaker).
  - Parse bearer tokens consistently via `manager.BearerToken` across proxy, billing, and tool paths; identity hardening: only `at+jwt` access tokens yield a subject, opaque API keys stay opaque.
  - Circuit breaker: probe claims are token-based (`ProbeClaim`) and travel with the dispatched request; only the owning request may abort a claimed probe, the cooldown restarts before the breaker reopens, and state updates are published.
  - Record outcomes for internal dispatches (success/failure/cancel); only successes update cache warmth; cancellations do not trip breakers; paths that don't track outcomes (MCP sessions, file conversion) never claim probes.

- **Migration**
  - OAuth tokens must be typed `at+jwt` to anchor identity by subject; other tokens are treated as opaque keys.
  - Bodies on cache-scoped endpoints must be one JSON object; malformed or trailing-data bodies now return 400.
  - Requests over 64 MB return 413; reduce size or stream where possible.
