### PR TITLE
Add a routing secret to cache-route key derivation

### DIFF
--- a/cacheroute/cacheroute.go
+++ b/cacheroute/cacheroute.go
@@ -13,6 +13,7 @@ package cacheroute
 import (
 	"slices"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/tinfoilsh/confidential-model-router/cachesalt"
@@ -22,6 +23,26 @@ import (
 // KeyDomainTag namespaces routing-key derivation. Tags are hashed unframed,
 // so no tag in the router may be a prefix of another.
 const KeyDomainTag = "tinfoil/route-key/v1"
+
+// keySecret is the process-wide routing secret (see SetSecret), stored
+// atomically so startup wiring can't race request handling.
+var keySecret atomic.Value // string
+
+// SetSecret installs the process-wide secret mixed into routing keys.
+// Every other derivation input is known to the caller who sent the request;
+// the secret is what keeps key→replica placement from being computable
+// offline. It must be identical across all router replicas — instances
+// that disagree silently derive different keys for the same request — and
+// changing it re-homes every key.
+func SetSecret(secret string) {
+	keySecret.Store(secret)
+}
+
+// currentSecret returns the installed routing secret, "" when none.
+func currentSecret() string {
+	s, _ := keySecret.Load().(string)
+	return s
+}
 
 // prefixWindowCap bounds how much prompt prefix feeds the routing key
 // (~256 tokens). A routing hint only: the engine's byte-exact prefix cache
@@ -72,6 +93,7 @@ type Settings struct {
 	Retention         time.Duration // how long a replica stays warm for a key
 	MinPromptBytes    int           // eligibility floor on whole-prompt bytes
 	SplitThresholdRPM float64       // per-key rpm per replica of warm set
+	Secret            string        // routing secret from SetSecret; "" when none installed
 }
 
 // SettingsFrom resolves a config block (nil means unconfigured), applying
@@ -82,6 +104,7 @@ func SettingsFrom(c *config.CacheRouteConfig) Settings {
 		Retention:         DefaultRetention,
 		MinPromptBytes:    DefaultMinPromptBytes,
 		SplitThresholdRPM: DefaultSplitThresholdRPM,
+		Secret:            currentSecret(),
 	}
 	if c == nil {
 		return s
@@ -171,27 +194,28 @@ func ExtractRequest(body map[string]any, path, salt string, s Settings) (req *Re
 		req.Outcome = OutcomeBelowFloor
 	default:
 		req.Outcome = OutcomeKeyed
-		req.Key = deriveKey(salt, promptCacheKey, tools, system, user)
+		req.Key = deriveKey(s.Secret, salt, promptCacheKey, tools, system, user)
 	}
 	return req
 }
 
 // deriveKey computes
 //
-//	Sum(tag, salt, prompt_cache_key, tools, system, first user message)
+//	Sum(tag, secret, salt, prompt_cache_key, tools, system, first user message)
 //
 // with the three prompt fields flattened and capped to prefixWindowCap
 // across their total. Sum length-prefixes every field, so boundaries can't
-// shift. The construction is pinned by test vectors: changing any detail
-// re-homes every key, a fleet-wide cache cold-start once routing acts.
-func deriveKey(salt, promptCacheKey string, tools, system, user any) Key {
+// shift; an uninstalled secret contributes lp(""). The construction is
+// pinned by test vectors: changing any detail re-homes every key, a
+// fleet-wide cache cold-start once routing acts.
+func deriveKey(secret, salt, promptCacheKey string, tools, system, user any) Key {
 	budget := prefixWindowCap
 	toolsB := flattenValue(tools, budget)
 	budget -= len(toolsB)
 	systemB := flattenValue(system, budget)
 	budget -= len(systemB)
 	userB := flattenValue(user, budget)
-	return Key(cachesalt.Sum(KeyDomainTag, salt, promptCacheKey, string(toolsB), string(systemB), string(userB)))
+	return Key(cachesalt.Sum(KeyDomainTag, secret, salt, promptCacheKey, string(toolsB), string(systemB), string(userB)))
 }
 
 // promptFields pulls the routing-relevant fields out of the parsed body in

--- a/cacheroute/cacheroute_test.go
+++ b/cacheroute/cacheroute_test.go
@@ -280,20 +280,84 @@ func TestDeriveKeyPinned(t *testing.T) {
 	}
 
 	// Hand-framed reference: string contents flatten to lp(content); the
-	// window fields are Sum'd as separate lp() fields after salt and
-	// prompt_cache_key, under the routing-key domain tag.
+	// window fields are Sum'd as separate lp() fields after the routing
+	// secret (empty here: none installed), salt, and prompt_cache_key,
+	// under the routing-key domain tag.
 	lp := func(s string) string {
 		n := len(s)
 		return string([]byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}) + s
 	}
-	want := Key(cachesalt.Sum(KeyDomainTag, testSalt, "group-1", "", lp("sys prompt"), lp("user prompt")))
+	want := Key(cachesalt.Sum(KeyDomainTag, "", testSalt, "group-1", "", lp("sys prompt"), lp("user prompt")))
 	if got.Key != want {
 		t.Fatalf("key = %x, want hand-framed %x", got.Key, want)
 	}
 
-	const golden = "fac9e3d0f3dda00695b7ecab7dd7dc7a4d569d49cc5145b71bfcc1eae53978e4"
+	const golden = "f3f6287264aaf4d7fe1a8ded41fdf7e78b7ebac31ebe0e15fc029599ccd6b4e4"
 	if h := hex.EncodeToString(got.Key[:]); h != golden {
 		t.Fatalf("key = %s, want golden %s (changing the construction re-homes every key)", h, golden)
+	}
+}
+
+// TestDeriveKeyPinnedSecret pins the construction with a routing secret
+// installed the same two ways: hand-framed reference and a golden from an
+// independent implementation. Distinct secrets must derive distinct keys.
+func TestDeriveKeyPinnedSecret(t *testing.T) {
+	const secret = "test-routing-secret-0123456789abcdef"
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "system", "content": "sys prompt"},
+			map[string]any{"role": "user", "content": "user prompt"},
+		},
+		"prompt_cache_key": "group-1",
+	}
+	settings := Settings{Mode: ModeShadow, MinPromptBytes: 1, Retention: DefaultRetention, SplitThresholdRPM: DefaultSplitThresholdRPM, Secret: secret}
+	got := ExtractRequest(body, "/v1/chat/completions", testSalt, settings)
+	if got.Outcome != OutcomeKeyed {
+		t.Fatalf("outcome = %s, want keyed", got.Outcome)
+	}
+
+	lp := func(s string) string {
+		n := len(s)
+		return string([]byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}) + s
+	}
+	want := Key(cachesalt.Sum(KeyDomainTag, secret, testSalt, "group-1", "", lp("sys prompt"), lp("user prompt")))
+	if got.Key != want {
+		t.Fatalf("key = %x, want hand-framed %x", got.Key, want)
+	}
+
+	// Golden from an independent implementation (Python hashlib):
+	// Sum(tag, secret, salt, "group-1", "", lp("sys prompt"),
+	// lp("user prompt")).
+	const golden = "6e6be0988ec76eb2e5d4c4b23ae0a4cecadcf4fbd27911570e164b894b6bf0a3"
+	if h := hex.EncodeToString(got.Key[:]); h != golden {
+		t.Fatalf("key = %s, want golden %s (changing the construction re-homes every key)", h, golden)
+	}
+
+	other := settings
+	other.Secret = "other-routing-secret-0123456789abcdef"
+	if r := ExtractRequest(body, "/v1/chat/completions", testSalt, other); r.Key == got.Key {
+		t.Fatal("different secrets must derive different keys")
+	}
+}
+
+// TestSettingsFromSecret verifies SettingsFrom resolves the installed
+// process-wide secret for configured and unconfigured models alike, and
+// that clearing it restores unkeyed derivation.
+func TestSettingsFromSecret(t *testing.T) {
+	const secret = "test-routing-secret-0123456789abcdef"
+	SetSecret(secret)
+	t.Cleanup(func() { SetSecret("") })
+
+	if s := SettingsFrom(nil); s.Secret != secret {
+		t.Fatalf("nil config must resolve the secret, got %q", s.Secret)
+	}
+	if s := SettingsFrom(&config.CacheRouteConfig{Mode: "enforced"}); s.Secret != secret {
+		t.Fatalf("configured model must resolve the secret, got %q", s.Secret)
+	}
+
+	SetSecret("")
+	if s := SettingsFrom(nil); s.Secret != "" {
+		t.Fatalf("cleared secret must resolve empty, got %q", s.Secret)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -121,6 +121,13 @@ var (
 	// Off by default for rollout; once enabled, disabling it re-opens
 	// cross-user cache sharing — an emergency lever, not a tuning knob.
 	cacheSaltEnabled = flag.Bool("cache-salt", getEnvBool("CACHE_SALT_ENABLED"), "inject per-principal cache_salt into requests (env: CACHE_SALT_ENABLED)")
+	// cacheRouteSecret keys cache-route routing keys so key→replica
+	// placement isn't computable offline by callers. Must be identical
+	// across all router replicas; changing it re-homes every key. The env
+	// var is resolved after parse, not as the flag default: defaults are
+	// printed verbatim by -h and any flag-parse error, and the secret must
+	// never reach a log.
+	cacheRouteSecret = flag.String("cache-route-secret", "", "secret mixed into cache-route routing keys, must match across router replicas (env: CACHE_ROUTE_SECRET)")
 )
 
 func jsonError(w http.ResponseWriter, message string, errType string, code int) {
@@ -385,6 +392,22 @@ func main() {
 	}
 	if *usageContextSecret == "" {
 		log.Fatal("USAGE_CONTEXT_SECRET is required")
+	}
+
+	// A routing-secret skew between replicas silently re-homes keys on only
+	// the skewed instance, so tolerate the classic source — a trailing
+	// newline from secret tooling — but refuse a value that is set yet
+	// unusable: booting unkeyed on a garbage secret would be that same
+	// silent skew.
+	if secret := *cacheRouteSecret; secret != "" || os.Getenv("CACHE_ROUTE_SECRET") != "" {
+		if secret == "" {
+			secret = os.Getenv("CACHE_ROUTE_SECRET")
+		}
+		secret = strings.TrimSpace(secret)
+		if len(secret) < 32 {
+			log.Fatal("CACHE_ROUTE_SECRET must be at least 32 bytes (e.g. openssl rand -base64 32)")
+		}
+		cacheroute.SetSecret(secret)
 	}
 
 	em, err := manager.NewEnclaveManager(configFile, *controlPlaneURL, *usageReporterID, *usageReporterSecret, *usageContextSecret, *initConfigURL, *updateConfigURL, *refreshInterval)

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -16,6 +16,7 @@ containers:
     secrets:
       - USAGE_REPORTER_SECRET
       - USAGE_CONTEXT_SECRET
+      - CACHE_ROUTE_SECRET
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8089/health"]
       interval: 30s


### PR DESCRIPTION
Routing keys were a pure function of inputs the caller already knows (cache salt, `prompt_cache_key`, prompt prefix), so anyone could compute offline which replica a given prompt homes to. This mixes a process-wide secret (`CACHE_ROUTE_SECRET`, ≥32 bytes, declared in tinfoil-config secrets) into the derivation as its leading field, so placement can only be probed online.

The secret must be identical across router replicas, and changing it re-homes every key; unset, routing keeps working without the secrecy. The env var is resolved after flag parse so the secret can't leak through flag usage output. Derivation goldens re-pinned from an independent implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mix a process-wide routing secret into cache-route key derivation to prevent offline probing of key→replica placement. Adds `CACHE_ROUTE_SECRET`/`--cache-route-secret`; changing it re-homes all keys, and leaving it unset keeps routing working without secrecy.

- **New Features**
  - `cacheroute`: key derivation now includes a process-wide secret; added `SetSecret` and `Settings.Secret` to wire it in.
  - `main`: reads `CACHE_ROUTE_SECRET` or `--cache-route-secret` after flag parse, trims whitespace, enforces ≥32 bytes, and installs via `cacheroute.SetSecret`; tests re-pinned and `tinfoil-config.yml` now lists `CACHE_ROUTE_SECRET`.

- **Migration**
  - Generate a secret ≥32 bytes (e.g., openssl rand -base64 32) and set `CACHE_ROUTE_SECRET` identically on all router replicas.
  - Roll out cluster-wide; expect all cache-route keys to be re-homed.
  - If unset, routing remains deterministic but not secret-keyed.

<sup>Written for commit f2df490eb941b72570ec14161d50eb14c6b0d560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

