### PR TITLE
Suggest hex encoding in the short-secret error

### DIFF
--- a/main.go
+++ b/main.go
@@ -405,7 +405,7 @@ func main() {
 		}
 		secret = strings.TrimSpace(secret)
 		if len(secret) < 32 {
-			log.Fatal("CACHE_ROUTE_SECRET must be at least 32 bytes (e.g. openssl rand -base64 32)")
+			log.Fatal("CACHE_ROUTE_SECRET must be at least 32 bytes (e.g. openssl rand -hex 32)")
 		}
 		cacheroute.SetSecret(secret)
 	}


### PR DESCRIPTION
Follow-up to #410: the too-short `CACHE_ROUTE_SECRET` error suggested `openssl rand -base64 32`; the secret convention is hex, so point the hint at `openssl rand -hex 32`. Message text only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the error shown when CACHE_ROUTE_SECRET is too short to suggest generating a hex-encoded secret with `openssl rand -hex 32` instead of base64. This aligns the hint with our hex secret convention and avoids confusion.

<sup>Written for commit 4ea412708676783f12b60bf997836ddc4b37e959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

