### PR TITLE
Authenticate metrics polling and lock down router shim paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,6 +128,10 @@ var (
 	// printed verbatim by -h and any flag-parse error, and the secret must
 	// never reach a log.
 	cacheRouteSecret = flag.String("cache-route-secret", "", "secret mixed into cache-route routing keys, must match across router replicas (env: CACHE_ROUTE_SECRET)")
+	// metricsAPIKey authenticates the overload poller's enclave /metrics
+	// scrapes. Env resolved after parse, like cache-route-secret, so the
+	// secret never reaches flag output.
+	metricsAPIKey = flag.String("metrics-api-key", "", "admin API key sent as a bearer token when polling enclave /metrics (env: METRICS_API_KEY)")
 )
 
 func jsonError(w http.ResponseWriter, message string, errType string, code int) {
@@ -408,6 +412,13 @@ func main() {
 			log.Fatal("CACHE_ROUTE_SECRET must be at least 32 bytes (e.g. openssl rand -hex 32)")
 		}
 		cacheroute.SetSecret(secret)
+	}
+
+	if key := *metricsAPIKey; key != "" || os.Getenv("METRICS_API_KEY") != "" {
+		if key == "" {
+			key = os.Getenv("METRICS_API_KEY")
+		}
+		manager.SetMetricsPollAPIKey(strings.TrimSpace(key))
 	}
 
 	em, err := manager.NewEnclaveManager(configFile, *controlPlaneURL, *usageReporterID, *usageReporterSecret, *usageContextSecret, *initConfigURL, *updateConfigURL, *refreshInterval)

--- a/manager/metrics.go
+++ b/manager/metrics.go
@@ -19,6 +19,16 @@ import (
 
 const defaultMetricsPollInterval = 15 * time.Second
 
+// pollAPIKey, when set, is sent as a bearer token on backend /metrics
+// scrapes (enclaves require an admin key). Stored atomically so startup
+// wiring can't race a running poller.
+var pollAPIKey atomic.Value // string
+
+// SetMetricsPollAPIKey installs the credential for backend /metrics polls.
+func SetMetricsPollAPIKey(key string) {
+	pollAPIKey.Store(key)
+}
+
 // enclaveMetrics polls backend metrics and logs queue depth for observability.
 type enclaveMetrics struct {
 	host  string
@@ -143,6 +153,9 @@ func (m *enclaveMetrics) scrape(ctx context.Context) {
 			"enclave": m.host,
 		}).Debugf("metrics request creation failed: %v", err)
 		return
+	}
+	if key, _ := pollAPIKey.Load().(string); key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
 	}
 
 	resp, err := m.client.Do(req)

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -17,6 +17,7 @@ containers:
       - USAGE_REPORTER_SECRET
       - USAGE_CONTEXT_SECRET
       - CACHE_ROUTE_SECRET
+      - METRICS_API_KEY
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8089/health"]
       interval: 30s
@@ -30,3 +31,13 @@ networks:
 shim:
   upstream-port: 8089
   tls-wildcard: true
+  paths:
+    - /
+    - /health
+    - /.well-known/tinfoil-proxy
+    - /.well-known/prometheus-targets
+    - /metrics
+    - /v1/*
+  authenticated: true
+  authenticated-endpoints:
+    - /metrics


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bearer auth to enclave `/metrics` polling via `METRICS_API_KEY` and tightens the router shim with an explicit path allowlist, making `/metrics` admin-only. Keeps queue-depth polling working when enclaves require auth and closes the public metrics endpoint.

- **Migration**
  - Set `METRICS_API_KEY` in the router env to the admin key used by enclaves for `/metrics` (optional if enclaves are still open).
  - Verify any non-`/v1` paths you need are in the shim allowlist before redeploying.

<sup>Written for commit aa0440b746000c91e2602a9b60bf68aef5fd4027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

