### PR TITLE
Revert "Enforce cache-aware routing on gemma4-31b"

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -99,4 +99,4 @@ models:
       max_requests_waiting: 32
       retry_after_minutes: 1
     cache_route:
-      mode: enforced
+      mode: shadow


### PR DESCRIPTION
Reverts tinfoilsh/confidential-model-router#407

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts cache-aware routing enforcement on `gemma4-31b` by setting `cache_route.mode` to `shadow`, allowing observation without affecting live traffic.

<sup>Written for commit 55f2c2237447aa3f508b1944bd6886b7a733c8f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

