### PR TITLE
chore: add gemma instances on inf14

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -95,6 +95,11 @@ models:
       - gemma4-31b-2.inf10.tinfoil.sh
       - gemma4-31b-3.inf10.tinfoil.sh
       - gemma4-31b-4.inf10.tinfoil.sh
+      - gemma4-31b-inf14-0.tinfoil.containers.tinfoil.dev
+      - gemma4-31b-inf14-1.tinfoil.containers.tinfoil.dev
+      - gemma4-31b-inf14-2.tinfoil.containers.tinfoil.dev
+      - gemma4-31b-inf14-3.tinfoil.containers.tinfoil.dev
+      - gemma4-31b-inf14-4.tinfoil.containers.tinfoil.dev
     overload:
       max_requests_waiting: 32
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add five new `gemma4-31b` instances on inf14 to the model pool to increase capacity and improve load distribution. Updates the config to include inf14 hosts alongside existing inf10 instances.

<sup>Written for commit a756472c31e37a700360224be2b25755bf9929ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

