### PR TITLE
chore: remove gemma4-31b-inf6-1

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -90,7 +90,6 @@ models:
     repo: tinfoilsh/confidential-gemma4-31b
     enclaves:
       - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
-      - gemma4-31b-inf6-1.tinfoil.containers.tinfoil.dev
       - gemma4-31b-1.inf10.tinfoil.sh
       - gemma4-31b-2.inf10.tinfoil.sh
       - gemma4-31b-3.inf10.tinfoil.sh


### PR DESCRIPTION
Removed an enclave entry for gemma4-31b.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `gemma4-31b-inf6-1.tinfoil.containers.tinfoil.dev` enclave from `config.yml` to avoid routing traffic to a decommissioned host.

<sup>Written for commit 26806a301aaf9a15330dc4a5819c92469b2be4bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

