### PR TITLE
chore: remove glm-5-2-inf12 from enclaves list

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -43,7 +43,6 @@ models:
     enclaves:
       - glm-5-2-inf7.tinfoil.containers.tinfoil.dev
       - glm-5-2-inf11.tinfoil.containers.tinfoil.dev
-      - glm-5-2-inf12.tinfoil.containers.tinfoil.dev
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed `glm-5-2-inf12.tinfoil.containers.tinfoil.dev` from the enclaves list to stop routing traffic to a decommissioned instance. This avoids misrouted requests and keeps load balancing healthy.

<sup>Written for commit 9fa1cc1b3e753a984ceaf5ae5bf0fca155159441. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

