### PR TITLE
chore: add glm52 inf12 back

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -43,6 +43,7 @@ models:
     enclaves:
       - glm-5-2-inf7.tinfoil.containers.tinfoil.dev
       - glm-5-2-inf11.tinfoil.containers.tinfoil.dev
+      - glm-5-2-inf12.tinfoil.containers.tinfoil.dev
     overload:
       max_requests_waiting: 16
       retry_after_minutes: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restored the glm-5-2 inf12 enclave in the routing config to increase capacity and improve failover. Requests for glm-5-2 can now spread across inf7, inf11, and inf12 to reduce queue times under load.

<sup>Written for commit 3a60d0d26db489ee7eefd0521e49d66938e5aa9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

