### PR TITLE
config: soft rate limit for gpt-oss-120b

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -55,6 +55,8 @@ models:
     enclaves:
       - gpt-oss-120b-0.inf6.tinfoil.sh
       - gpt-oss-120b-1.inf10.tinfoil.sh
+    rate_limit:
+      max_requests_per_minute: 120
     overload:
       max_requests_waiting: 8
       retry_after_minutes: 1


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable a per-key soft rate limit for gpt-oss-120b at 120 req/min to absorb burst traffic without rejecting requests. Requests over the cap are demoted to vLLM priority 1 so other tenants stay fast; priority-override orgs bypass this, and the change applies on config refresh (no redeploy).

<sup>Written for commit 1522c69c403b779f7c866af89f0449e822ba7fb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

