### PR TITLE
chore: add gpt-oss-120b replicas on inf14

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -55,6 +55,8 @@ models:
     enclaves:
       - gpt-oss-120b-0.inf6.tinfoil.sh
       - gpt-oss-120b-1.inf10.tinfoil.sh
+      - gpt-oss-120b-inf14-0.tinfoil.containers.tinfoil.dev
+      - gpt-oss-120b-inf14-1.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 120
     overload:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add two `gpt-oss-120b` replicas on inf14—`gpt-oss-120b-inf14-0.tinfoil.containers.tinfoil.dev` and `gpt-oss-120b-inf14-1.tinfoil.containers.tinfoil.dev`—to increase capacity and improve resilience.

<sup>Written for commit c748ec6afc789561ddc0aa1a45e7960791099f49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

