### PR TITLE
router: exempt configured-priority callers from overload shedding

### DIFF
--- a/main.go
+++ b/main.go
@@ -488,6 +488,10 @@ func main() {
 		var cacheRouteReq *cacheroute.Request
 		var cacheRouteSettings cacheroute.Settings
 
+		// Set when the control plane configured a vLLM priority for this
+		// caller; such callers are exempt from overload shedding.
+		hasConfiguredPriority := false
+
 		// Extract API key early for rate limiting decisions
 		apiKey := manager.BearerToken(r.Header.Get("Authorization"))
 
@@ -747,7 +751,6 @@ func main() {
 				mode, _ := applyCacheSalt(body, r.URL.Path, apiKey, *cacheSaltEnabled)
 				recordCacheSaltInjection(modelName, mode)
 
-				hasConfiguredPriority := false
 				if routeCtx, ok := routeContextClient.Lookup(r.Context(), apiKey, modelName); ok && routeCtx.Priority != nil {
 					body["priority"] = *routeCtx.Priority
 					hasConfiguredPriority = true
@@ -880,23 +883,35 @@ func main() {
 			waiting    float64
 			skip       = map[string]bool{}
 		)
-		for range model.EnclaveCount() {
-			enclave, probeClaim = model.NextEnclavePreferring(cacheRouteOrder, skip)
-			if enclave == nil {
-				break
+		if hasConfiguredPriority {
+			// Configured-priority callers have no 429 path: like internal
+			// dispatches they serve through overload at the warmest host,
+			// where their injected priority jumps the backend queue.
+			enclave, probeClaim = model.SelectForDispatch(cacheRouteOrder)
+			if enclave != nil && probeClaim == nil {
+				if ov, _, _ := enclave.ShouldReject(); ov {
+					manager.PriorityOverloadAdmitsTotal.WithLabelValues(modelName).Inc()
+				}
 			}
-			// A claimed probe must be dispatched: skipping its pick as
-			// overloaded would leave the claim unresolved and strand the
-			// breaker half-open (see Model.selectForDispatch). Overload
-			// spill applies to plain picks only.
-			if probeClaim != nil {
-				overloaded = false
-				break
+		} else {
+			for range model.EnclaveCount() {
+				enclave, probeClaim = model.NextEnclavePreferring(cacheRouteOrder, skip)
+				if enclave == nil {
+					break
+				}
+				// A claimed probe must be dispatched: skipping its pick as
+				// overloaded would leave the claim unresolved and strand the
+				// breaker half-open (see Model.selectForDispatch). Overload
+				// spill applies to plain picks only.
+				if probeClaim != nil {
+					overloaded = false
+					break
+				}
+				if overloaded, retryAfter, waiting = enclave.ShouldReject(); !overloaded {
+					break
+				}
+				skip[enclave.String()] = true
 			}
-			if overloaded, retryAfter, waiting = enclave.ShouldReject(); !overloaded {
-				break
-			}
-			skip[enclave.String()] = true
 		}
 		if enclave == nil {
 			jsonError(w, manager.ErrMsgOverloaded, manager.ErrTypeServer, http.StatusServiceUnavailable)

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -79,6 +79,15 @@ var (
 		[]string{"model"},
 	)
 
+	// PriorityOverloadAdmitsTotal tracks configured-priority requests admitted while all backends reported overload
+	PriorityOverloadAdmitsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_priority_overload_admits_total",
+			Help: "Total number of configured-priority requests admitted despite backend overload",
+		},
+		[]string{"model"},
+	)
+
 	// CacheSaltInjectionsTotal tracks requests injected with a derived cache_salt
 	CacheSaltInjectionsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
A caller's configured priority currently works everywhere except the one place it matters most: the overload guard. Priority gets a request scheduled first *inside* vLLM, but when every enclave trips the queue-depth mark, the router's 429 turns away all arrivals indiscriminately — so a contracted tenant can be shed because of another tenant's burst. During the Jul 15 gpt-oss-120b burst, ~13% of the ~1,450 rejections hit a steady ~45 req/min priority tenant that did not cause the queue buildup (share estimated from the arrival mix during the nine rejection minutes; the tenant's own delivered throughput held steady, confirming priority works once admitted).

This gives configured-priority callers the same semantics internal dispatches already have (`SelectForDispatch`): prefer a healthy sibling, and when every candidate is overloaded, serve through at the warmest host — where the injected priority jumps the queue. Best-effort traffic sheds exactly as before.

Review pointers: the new branch in the enclave-selection block in `main.go` is the whole behavior change; `hasConfiguredPriority` is hoisted to handler scope (only the body-parsed OpenAI path can set it, so subdomain-routed requests are unaffected). `router_requests_rejected_total` now counts only best-effort rejections; the new `router_priority_overload_admits_total` counts priority admissions through overload.

Complements #419: the soft limit reduces how often overload trips; this fixes who pays when it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exempts configured‑priority callers from overload shedding so they avoid 429s during global overload, using internal-dispatch semantics to route to the warmest host. Adds a metric to track these admits while best‑effort traffic continues to shed as before.

- **New Features**
  - Route configured‑priority requests via `SelectForDispatch`: prefer a healthy sibling; otherwise serve through overload at the warmest host (no 429 path).
  - Hoist `hasConfiguredPriority` to handler scope; only the body‑parsed OpenAI path sets it (subdomain‑routed requests unchanged).
  - Add `router_priority_overload_admits_total` to count priority admits during overload; `router_requests_rejected_total` now reflects best‑effort rejections only.

<sup>Written for commit 2107969bd12c2e343d75ee99a4aaf3e53402be51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

