### PR TITLE
chore: Reduce max_requests_waiting from 16 to 8 for gym 5.2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -49,6 +49,7 @@ models:
       retry_after_minutes: 1
     cache_route:
       mode: enforced
+      split_threshold_rpm: 5
 
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b

--- a/config.yml
+++ b/config.yml
@@ -45,7 +45,7 @@ models:
       - glm-5-2-inf11.tinfoil.containers.tinfoil.dev
       - glm-5-2-inf12.tinfoil.containers.tinfoil.dev
     overload:
-      max_requests_waiting: 16
+      max_requests_waiting: 8
       retry_after_minutes: 1
     cache_route:
       mode: enforced


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lowered `max_requests_waiting` from 16 to 8 for the `glm-5-2` gym to reduce queue depth and improve tail latency. Added `cache_route.split_threshold_rpm: 5` to control when to split cached routes under load.

<sup>Written for commit f3e56d87663267e068197625f3e811cc03827b45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

