### PR TITLE
chore: add gpt replica

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -58,6 +58,7 @@ models:
       - gpt-oss-120b-1.inf10.tinfoil.sh
       - gpt-oss-120b-inf14-0.tinfoil.containers.tinfoil.dev
       - gpt-oss-120b-inf14-1.tinfoil.containers.tinfoil.dev
+      - gpt-oss-120b-inf14-2.tinfoil.containers.tinfoil.dev
     rate_limit:
       max_requests_per_minute: 120
     overload:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a third inf14 replica for the gpt-oss-120b model to increase capacity and resilience. New host added to config: gpt-oss-120b-inf14-2.tinfoil.containers.tinfoil.dev.

<sup>Written for commit 60bb9867aeeba14bef94ac749058d43a7df052b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

