### PR TITLE
feat: move config to controlplane

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -13,6 +13,7 @@ containers:
       - CACHE_SALT_ENABLED: "true"
       - USAGE_REPORTER_ID: "model-router"
       - CONTROL_PLANE_URL: "https://api.tinfoil.sh"
+      - UPDATE_CONFIG_URL: "https://api.tinfoil.sh/api/shim/router-config"
     secrets:
       - USAGE_REPORTER_SECRET
       - USAGE_CONTEXT_SECRET


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move router config to the control plane by adding `UPDATE_CONFIG_URL` to `tinfoil-config.yml`. The router now fetches config updates from https://api.tinfoil.sh/api/shim/router-config.

<sup>Written for commit 50598b846af8ae43c675b7b6cf84594422303a42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

