### PR TITLE
chore: trim config.yml to trusted repos

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,5 @@
 # Trust anchor only (model -> repo pinning, requires a router release).
-# Live config (replicas, rate limits, ...) is served by the control plane:
-# edit it in the backoffice under Router Config.
+# Live config with domain and settings is set in the tinfoil backend.
 
 routers:
   inference.tinfoil.sh:

--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,7 @@
+# Trust anchor only (model -> repo pinning, requires a router release).
+# Live config (replicas, rate limits, ...) is served by the control plane:
+# edit it in the backoffice under Router Config.
+
 routers:
   inference.tinfoil.sh:
   router.inf6.tinfoil.sh:
@@ -5,108 +9,42 @@ routers:
 models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text
-    enclaves:
-      - nomic.inf10.tinfoil.sh
 
   doc-upload:
     repo: tinfoilsh/confidential-doc-upload
-    enclaves:
-      - doc-upload.tinfoil.containers.tinfoil.dev
 
   whisper-large-v3-turbo:
     repo: tinfoilsh/confidential-realtime-models
-    enclaves:
-      - whisper-large-v3-turbo.realtime.inf10.tinfoil.sh
 
   voxtral-small-24b:
     repo: tinfoilsh/confidential-voxtral-small-24b
-    enclaves:
-      - voxtral-small-24b.inf10.tinfoil.sh
 
   voxtral-mini-4b-realtime:
     repo: tinfoilsh/confidential-realtime-models
-    enclaves:
-      - voxtral-mini-4b-realtime.realtime.inf10.tinfoil.sh
 
   voxtral-tts:
     repo: tinfoilsh/confidential-realtime-models
-    enclaves:
-      - voxtral-tts.realtime.inf10.tinfoil.sh
 
   llama3-3-70b:
     repo: tinfoilsh/confidential-llama3-3-70b
-    enclaves:
-      - llama3-3-70b.tinfoil.containers.tinfoil.dev
 
   glm-5-2:
     repo: tinfoilsh/confidential-glm5-2
-    enclaves:
-      - glm-5-2-inf7.tinfoil.containers.tinfoil.dev
-      - glm-5-2-inf11.tinfoil.containers.tinfoil.dev
-      - glm-5-2-inf12.tinfoil.containers.tinfoil.dev
-    overload:
-      max_requests_waiting: 8
-      retry_after_minutes: 1
-    cache_route:
-      mode: enforced
-      split_threshold_rpm: 5
 
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
-    enclaves:
-      - gpt-oss-120b-0.inf6.tinfoil.sh
-      - gpt-oss-120b-1.inf10.tinfoil.sh
-      - gpt-oss-120b-inf14-0.tinfoil.containers.tinfoil.dev
-      - gpt-oss-120b-inf14-1.tinfoil.containers.tinfoil.dev
-      - gpt-oss-120b-inf14-2.tinfoil.containers.tinfoil.dev
-    rate_limit:
-      max_requests_per_minute: 120
-    overload:
-      max_requests_waiting: 8
-      retry_after_minutes: 1
-    cache_route:
-      mode: enforced
 
   gpt-oss-safeguard-120b:
     repo: tinfoilsh/confidential-gpt-oss-safeguard-120b
-    enclaves:
-      - gpt-oss-safeguard-120b.tinfoil.containers.tinfoil.dev
 
   qwen3-tts:
     repo: tinfoilsh/confidential-realtime-models
-    enclaves:
-      - qwen3-tts.realtime.inf10.tinfoil.sh
 
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6-b200
-    enclaves:
-      - kimi-k2-6-inf13.tinfoil.containers.tinfoil.dev
-    rate_limit:
-      max_requests_per_minute: 4
-    overload:
-      max_requests_waiting: 16
-      retry_after_minutes: 1
 
   websearch:
     repo: tinfoilsh/confidential-websearch
-    enclaves:
-      - websearch.tinfoil.sh
 
   gemma4-31b:
     repo: tinfoilsh/confidential-gemma4-31b
-    enclaves:
-      - gemma4-31b-inf6.tinfoil.containers.tinfoil.dev
-      - gemma4-31b-1.inf10.tinfoil.sh
-      - gemma4-31b-2.inf10.tinfoil.sh
-      - gemma4-31b-3.inf10.tinfoil.sh
-      - gemma4-31b-4.inf10.tinfoil.sh
-      - gemma4-31b-inf14-0.tinfoil.containers.tinfoil.dev
-      - gemma4-31b-inf14-1.tinfoil.containers.tinfoil.dev
-      - gemma4-31b-inf14-2.tinfoil.containers.tinfoil.dev
-      - gemma4-31b-inf14-3.tinfoil.containers.tinfoil.dev
-      - gemma4-31b-inf14-4.tinfoil.containers.tinfoil.dev
-    overload:
-      max_requests_waiting: 32
-      retry_after_minutes: 1
-    cache_route:
-      mode: shadow


### PR DESCRIPTION
## Summary
- config.yml is now the trust anchor only: model -> repo pinning (embedded/attested, changes require a release)
- Enclave lists and runtime knobs were moved to the control plane (#424) and are edited in the backoffice Router Config tab; header comment points there
- Removing the stale copies here avoids confusion about which config is live

## Test plan
- [x] go build + config/manager tests pass (embedded config with repo-only models loads fine; enclaves have always been sourced from the update URL at runtime)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed config.yml to a trust anchor with model-to-repo pinning only. Enclave lists and runtime settings now live in the control plane; edit them in Backoffice > Router Config to avoid drift.

- **Refactors**
  - Removed enclaves, rate_limit, overload, and cache_route from config.yml.
  - Added a header comment pointing to Backoffice > Router Config.
  - Verified build and config manager tests; repo-only config loads and enclaves resolve at runtime.

- **Migration**
  - Make operational changes in Backoffice > Router Config.
  - Model-to-repo changes still require a router release.

<sup>Written for commit 0fca770b2914984c5ead9e35cf3d741a1f0652e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

