### PR TITLE
router: add hard per-key 429 tier to rate limiting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,10 @@ import (
 // RateLimitConfig describes optional per-API-key request rate limits for a
 // model. Requests over the soft per-minute budget are sent to vLLM with a
 // lower scheduling priority; requests over the hard budget are rejected with
-// HTTP 429. Either budget may be configured independently; zero disables it.
+// HTTP 429. Zero disables a budget. The hard check runs first, so when both
+// are set the hard budget must sit above the soft one — a hard budget at or
+// below the soft budget rejects requests before they can be demoted, turning
+// the soft tier off entirely.
 type RateLimitConfig struct {
 	MaxRequestsPerMinute     int64 `yaml:"max_requests_per_minute"`
 	HardMaxRequestsPerMinute int64 `yaml:"hard_max_requests_per_minute,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -13,11 +13,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// RateLimitConfig describes optional per-API-key request rate limits for a model.
-// When configured, requests from API keys that exceed the per-minute budget
-// are sent to vLLM with a lower scheduling priority.
+// RateLimitConfig describes optional per-API-key request rate limits for a
+// model. Requests over the soft per-minute budget are sent to vLLM with a
+// lower scheduling priority; requests over the hard budget are rejected with
+// HTTP 429. Either budget may be configured independently; zero disables it.
 type RateLimitConfig struct {
-	MaxRequestsPerMinute int64 `yaml:"max_requests_per_minute"`
+	MaxRequestsPerMinute     int64 `yaml:"max_requests_per_minute"`
+	HardMaxRequestsPerMinute int64 `yaml:"hard_max_requests_per_minute,omitempty"`
 }
 
 // CacheRouteConfig is the per-model cache-aware routing knob. Mode is the

--- a/main.go
+++ b/main.go
@@ -760,10 +760,24 @@ func main() {
 					}).Debug("injecting configured vLLM priority")
 				}
 
-				// Check rate limiting and inject lower vLLM priority if over budget.
-				// Org-priority callers bypass this soft demotion.
-				if rlCfg := em.GetRateLimitConfig(rateLimitModel); !hasConfiguredPriority && rlCfg != nil {
-					if rateLimitID != "" && em.RequestTracker().RecordAndCheck(rateLimitID, rateLimitModel, rlCfg.MaxRequestsPerMinute) {
+				// Check per-key rate limits: reject with 429 over the hard
+				// budget, inject lower vLLM priority over the soft budget.
+				// Org-priority callers bypass both.
+				if rlCfg := em.GetRateLimitConfig(rateLimitModel); !hasConfiguredPriority && rlCfg != nil && rateLimitID != "" {
+					count := em.RequestTracker().Record(rateLimitID, rateLimitModel)
+					if hard := rlCfg.HardMaxRequestsPerMinute; hard > 0 && count >= hard {
+						// The budget refills at the next fixed-window minute boundary.
+						secs := 60 - time.Now().Second()
+						w.Header().Set("Retry-After", strconv.Itoa(secs))
+						manager.RateLimitRejectionsTotal.WithLabelValues(rateLimitModel).Inc()
+						log.WithFields(log.Fields{
+							"model":               rateLimitModel,
+							"retry_after_seconds": secs,
+						}).Warn("rejecting request over hard per-key rate limit")
+						jsonError(w, fmt.Sprintf("Request rate exceeded. Retry after %d seconds.", secs), manager.ErrTypeInvalidRequest, http.StatusTooManyRequests)
+						return
+					}
+					if soft := rlCfg.MaxRequestsPerMinute; soft > 0 && count >= soft {
 						body["priority"] = 1
 						manager.RateLimitDemotionsTotal.WithLabelValues(rateLimitModel).Inc()
 						log.WithFields(log.Fields{

--- a/main.go
+++ b/main.go
@@ -764,10 +764,11 @@ func main() {
 				// budget, inject lower vLLM priority over the soft budget.
 				// Org-priority callers bypass both.
 				if rlCfg := em.GetRateLimitConfig(rateLimitModel); !hasConfiguredPriority && rlCfg != nil && rateLimitID != "" {
-					count := em.RequestTracker().Record(rateLimitID, rateLimitModel)
+					count, resetIn := em.RequestTracker().Record(rateLimitID, rateLimitModel)
 					if hard := rlCfg.HardMaxRequestsPerMinute; hard > 0 && count >= hard {
-						// The budget refills at the next fixed-window minute boundary.
-						secs := 60 - time.Now().Second()
+						// Round up: rounding down would point the client back
+						// inside the window it was just rejected in.
+						secs := int((resetIn + time.Second - 1) / time.Second)
 						w.Header().Set("Retry-After", strconv.Itoa(secs))
 						manager.RateLimitRejectionsTotal.WithLabelValues(rateLimitModel).Inc()
 						log.WithFields(log.Fields{

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -70,6 +70,15 @@ var (
 		[]string{"model"},
 	)
 
+	// RateLimitRejectionsTotal tracks requests rejected due to hard per-key rate limits
+	RateLimitRejectionsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_ratelimit_rejections_total",
+			Help: "Total number of requests rejected with 429 due to hard per-key rate limits",
+		},
+		[]string{"model"},
+	)
+
 	// PriorityAssignmentsTotal tracks requests assigned configured vLLM priority
 	PriorityAssignmentsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/ratelimit/tracker.go
+++ b/ratelimit/tracker.go
@@ -46,12 +46,12 @@ func bucketKey(apiKey, model string) string {
 	return apiKey + "\x00" + model
 }
 
-// RecordAndCheck atomically increments the request count and returns true
-// if the API key has exceeded the limit for the given model in the current
-// one-minute window.
-func (t *RequestTracker) RecordAndCheck(apiKey, model string, limit int64) bool {
+// Record atomically increments the request count for the API key and model
+// and returns the count in the current one-minute window. An empty API key
+// is not tracked and always returns 0.
+func (t *RequestTracker) Record(apiKey, model string) int64 {
 	if apiKey == "" {
-		return false
+		return 0
 	}
 
 	now := t.nowFunc()
@@ -83,10 +83,7 @@ func (t *RequestTracker) RecordAndCheck(apiKey, model string, limit int64) bool 
 		t.lastCleanup = now
 	}
 
-	if limit <= 0 {
-		return false
-	}
-	return b.count >= limit
+	return b.count
 }
 
 // cleanup removes entries whose windows are more than 2 minutes old.

--- a/ratelimit/tracker.go
+++ b/ratelimit/tracker.go
@@ -47,11 +47,12 @@ func bucketKey(apiKey, model string) string {
 }
 
 // Record atomically increments the request count for the API key and model
-// and returns the count in the current one-minute window. An empty API key
-// is not tracked and always returns 0.
-func (t *RequestTracker) Record(apiKey, model string) int64 {
+// and returns the count in the current one-minute window along with the time
+// remaining until the window resets. An empty API key is not tracked and
+// returns 0, 0.
+func (t *RequestTracker) Record(apiKey, model string) (int64, time.Duration) {
 	if apiKey == "" {
-		return 0
+		return 0, 0
 	}
 
 	now := t.nowFunc()
@@ -83,7 +84,7 @@ func (t *RequestTracker) Record(apiKey, model string) int64 {
 		t.lastCleanup = now
 	}
 
-	return b.count
+	return b.count, b.windowStart.Add(time.Minute).Sub(now)
 }
 
 // cleanup removes entries whose windows are more than 2 minutes old.

--- a/ratelimit/tracker.go
+++ b/ratelimit/tracker.go
@@ -48,8 +48,9 @@ func bucketKey(apiKey, model string) string {
 
 // Record atomically increments the request count for the API key and model
 // and returns the count in the current one-minute window along with the time
-// remaining until the window resets. An empty API key is not tracked and
-// returns 0, 0.
+// remaining until the window resets, always in (0, time.Minute]: a request
+// landing exactly on a minute boundary starts the next window. An empty API
+// key is not tracked and returns 0, 0.
 func (t *RequestTracker) Record(apiKey, model string) (int64, time.Duration) {
 	if apiKey == "" {
 		return 0, 0

--- a/ratelimit/tracker_test.go
+++ b/ratelimit/tracker_test.go
@@ -10,7 +10,7 @@ func TestRecordCounts(t *testing.T) {
 	tracker := NewRequestTracker()
 
 	for i := int64(1); i <= 4; i++ {
-		if got := tracker.Record("key1", "model1"); got != i {
+		if got, _ := tracker.Record("key1", "model1"); got != i {
 			t.Fatalf("expected count %d, got %d", i, got)
 		}
 	}
@@ -23,13 +23,13 @@ func TestDifferentKeysAreIndependent(t *testing.T) {
 		tracker.Record("key1", "model1")
 	}
 
-	if got := tracker.Record("key1", "model1"); got != 6 {
+	if got, _ := tracker.Record("key1", "model1"); got != 6 {
 		t.Fatalf("key1/model1 expected count 6, got %d", got)
 	}
-	if got := tracker.Record("key2", "model1"); got != 1 {
+	if got, _ := tracker.Record("key2", "model1"); got != 1 {
 		t.Fatalf("key2/model1 expected count 1, got %d", got)
 	}
-	if got := tracker.Record("key1", "model2"); got != 1 {
+	if got, _ := tracker.Record("key1", "model2"); got != 1 {
 		t.Fatalf("key1/model2 expected count 1, got %d", got)
 	}
 }
@@ -41,21 +41,41 @@ func TestWindowReset(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		tracker.Record("key1", "model1")
 	}
-	if got := tracker.Record("key1", "model1"); got != 6 {
+	if got, _ := tracker.Record("key1", "model1"); got != 6 {
 		t.Fatalf("expected count 6 in current window, got %d", got)
 	}
 
 	// Advance to next minute
 	now = time.Date(2025, 1, 1, 10, 31, 0, 0, time.UTC)
-	if got := tracker.Record("key1", "model1"); got != 1 {
+	if got, _ := tracker.Record("key1", "model1"); got != 1 {
 		t.Fatalf("expected count 1 after window reset, got %d", got)
+	}
+}
+
+func TestResetDuration(t *testing.T) {
+	now := time.Date(2025, 1, 1, 10, 30, 15, 0, time.UTC)
+	tracker := NewRequestTracker(WithNowFunc(func() time.Time { return now }))
+
+	if _, resetIn := tracker.Record("key1", "model1"); resetIn != 45*time.Second {
+		t.Fatalf("expected reset in 45s, got %v", resetIn)
+	}
+
+	now = time.Date(2025, 1, 1, 10, 30, 59, 5e8, time.UTC)
+	if _, resetIn := tracker.Record("key1", "model1"); resetIn != 500*time.Millisecond {
+		t.Fatalf("expected reset in 500ms, got %v", resetIn)
+	}
+
+	// A fresh window has the full minute remaining
+	now = time.Date(2025, 1, 1, 10, 31, 0, 0, time.UTC)
+	if _, resetIn := tracker.Record("key1", "model1"); resetIn != time.Minute {
+		t.Fatalf("expected reset in 1m for fresh window, got %v", resetIn)
 	}
 }
 
 func TestEmptyAPIKeyIgnored(t *testing.T) {
 	tracker := NewRequestTracker()
 
-	if got := tracker.Record("", "model1"); got != 0 {
+	if got, _ := tracker.Record("", "model1"); got != 0 {
 		t.Fatalf("empty API key should not be tracked, got count %d", got)
 	}
 }
@@ -91,7 +111,7 @@ func TestConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 
-	if got := tracker.Record("key1", "model1"); got != 101 {
+	if got, _ := tracker.Record("key1", "model1"); got != 101 {
 		t.Fatalf("expected count 101 after concurrent records, got %d", got)
 	}
 }

--- a/ratelimit/tracker_test.go
+++ b/ratelimit/tracker_test.go
@@ -6,25 +6,13 @@ import (
 	"time"
 )
 
-func TestRecordAndCheck(t *testing.T) {
+func TestRecordCounts(t *testing.T) {
 	tracker := NewRequestTracker()
 
-	// First two requests under limit of 3
-	if tracker.RecordAndCheck("key1", "model1", 3) {
-		t.Fatal("should not be rate limited at 1/3")
-	}
-	if tracker.RecordAndCheck("key1", "model1", 3) {
-		t.Fatal("should not be rate limited at 2/3")
-	}
-
-	// Third request hits limit
-	if !tracker.RecordAndCheck("key1", "model1", 3) {
-		t.Fatal("should be rate limited at 3/3")
-	}
-
-	// Over limit
-	if !tracker.RecordAndCheck("key1", "model1", 3) {
-		t.Fatal("should be rate limited at 4/3")
+	for i := int64(1); i <= 4; i++ {
+		if got := tracker.Record("key1", "model1"); got != i {
+			t.Fatalf("expected count %d, got %d", i, got)
+		}
 	}
 }
 
@@ -32,22 +20,17 @@ func TestDifferentKeysAreIndependent(t *testing.T) {
 	tracker := NewRequestTracker()
 
 	for i := 0; i < 5; i++ {
-		tracker.RecordAndCheck("key1", "model1", 100)
+		tracker.Record("key1", "model1")
 	}
-	tracker.RecordAndCheck("key2", "model1", 100)
-	tracker.RecordAndCheck("key1", "model2", 100)
 
-	// key1/model1 has 5 requests
-	if !tracker.RecordAndCheck("key1", "model1", 3) {
-		t.Fatal("key1/model1 should be rate limited")
+	if got := tracker.Record("key1", "model1"); got != 6 {
+		t.Fatalf("key1/model1 expected count 6, got %d", got)
 	}
-	// key2/model1 has 1 request
-	if tracker.RecordAndCheck("key2", "model1", 3) {
-		t.Fatal("key2/model1 should not be rate limited")
+	if got := tracker.Record("key2", "model1"); got != 1 {
+		t.Fatalf("key2/model1 expected count 1, got %d", got)
 	}
-	// key1/model2 has 1 request
-	if tracker.RecordAndCheck("key1", "model2", 3) {
-		t.Fatal("key1/model2 should not be rate limited")
+	if got := tracker.Record("key1", "model2"); got != 1 {
+		t.Fatalf("key1/model2 expected count 1, got %d", got)
 	}
 }
 
@@ -56,38 +39,24 @@ func TestWindowReset(t *testing.T) {
 	tracker := NewRequestTracker(WithNowFunc(func() time.Time { return now }))
 
 	for i := 0; i < 5; i++ {
-		tracker.RecordAndCheck("key1", "model1", 100)
+		tracker.Record("key1", "model1")
 	}
-	if !tracker.RecordAndCheck("key1", "model1", 3) {
-		t.Fatal("should be rate limited in current window")
+	if got := tracker.Record("key1", "model1"); got != 6 {
+		t.Fatalf("expected count 6 in current window, got %d", got)
 	}
 
 	// Advance to next minute
 	now = time.Date(2025, 1, 1, 10, 31, 0, 0, time.UTC)
-	if tracker.RecordAndCheck("key1", "model1", 3) {
-		t.Fatal("should not be rate limited after window reset")
+	if got := tracker.Record("key1", "model1"); got != 1 {
+		t.Fatalf("expected count 1 after window reset, got %d", got)
 	}
 }
 
 func TestEmptyAPIKeyIgnored(t *testing.T) {
 	tracker := NewRequestTracker()
 
-	if tracker.RecordAndCheck("", "model1", 1) {
-		t.Fatal("empty API key should never be rate limited")
-	}
-}
-
-func TestZeroLimitNeverRateLimits(t *testing.T) {
-	tracker := NewRequestTracker()
-	for i := 0; i < 100; i++ {
-		tracker.RecordAndCheck("key1", "model1", 100)
-	}
-
-	if tracker.RecordAndCheck("key1", "model1", 0) {
-		t.Fatal("zero limit should never rate limit")
-	}
-	if tracker.RecordAndCheck("key1", "model1", -1) {
-		t.Fatal("negative limit should never rate limit")
+	if got := tracker.Record("", "model1"); got != 0 {
+		t.Fatalf("empty API key should not be tracked, got count %d", got)
 	}
 }
 
@@ -95,11 +64,11 @@ func TestCleanup(t *testing.T) {
 	now := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	tracker := NewRequestTracker(WithNowFunc(func() time.Time { return now }))
 
-	tracker.RecordAndCheck("key1", "model1", 100)
+	tracker.Record("key1", "model1")
 
-	// Advance 3 minutes and trigger cleanup via RecordAndCheck
+	// Advance 3 minutes and trigger cleanup via Record
 	now = time.Date(2025, 1, 1, 10, 3, 1, 0, time.UTC)
-	tracker.RecordAndCheck("key2", "model1", 100) // triggers cleanup
+	tracker.Record("key2", "model1") // triggers cleanup
 
 	tracker.mu.Lock()
 	_, exists := tracker.buckets[bucketKey("key1", "model1")]
@@ -117,8 +86,12 @@ func TestConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			tracker.RecordAndCheck("key1", "model1", 100)
+			tracker.Record("key1", "model1")
 		}()
 	}
 	wg.Wait()
+
+	if got := tracker.Record("key1", "model1"); got != 101 {
+		t.Fatalf("expected count 101 after concurrent records, got %d", got)
+	}
 }


### PR DESCRIPTION
The per-key limiter currently only demotes over-budget requests to a lower vLLM scheduling priority — every request is still processed, so a single key flooding unique prompts can keep evicting other tenants' warm prefix-cache entries no matter how far back it is queued. This adds an optional second budget, `hard_max_requests_per_minute`, on the same per-(key, model) fixed one-minute window: past it the router rejects with 429 and a `Retry-After` hint pointing at the window boundary, counted by the new `router_ratelimit_rejections_total` metric. Callers with a control-plane configured priority are exempt, matching the soft tier, and either budget can be configured independently. Verified locally: soft demotion still fires at the soft mark, 429s begin at the hard mark with a counting-down Retry-After, and keys are isolated from each other.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hard per-key rate limit that returns 429 with a `Retry-After` header, while keeping the existing soft demotion. `Retry-After` now uses the tracker’s window clock for accurate reset timing.

- **New Features**
  - New config: `hard_max_requests_per_minute` per (key, model) fixed one-minute window; zero disables. The hard check runs before soft, so set hard > soft.
  - Over the hard budget, reject with 429 and `Retry-After` until the next window; computed from the tracker's reset time and counted by `router_ratelimit_rejections_total`.
  - Soft demotion unchanged; org-priority callers bypass both tiers. The tracker now returns the current window count and time until reset.

<sup>Written for commit c9ac3b66cc1d6da1158269374e90faafe4be2643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

