### PR TITLE
feat: reserved pools

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,13 +37,22 @@ type CacheRouteConfig struct {
 	SplitThresholdRPM      float64 `yaml:"split_threshold_rpm,omitempty"`
 }
 
+// ReservationConfig dedicates a subset of a model's enclaves to the listed
+// orgs: only their traffic may use those enclaves, spilling to the shared
+// pool when they are overloaded or unhealthy.
+type ReservationConfig struct {
+	OrgIDs   []string `yaml:"org_ids" json:"org_ids"`
+	Enclaves []string `yaml:"enclaves" json:"enclaves"`
+}
+
 // Model represents the configuration for a single model
 type Model struct {
-	Repo       string            `yaml:"repo"`
-	Hostnames  []string          `yaml:"enclaves"`
-	Overload   *OverloadConfig   `yaml:"overload,omitempty"`
-	RateLimit  *RateLimitConfig  `yaml:"rate_limit,omitempty"`
-	CacheRoute *CacheRouteConfig `yaml:"cache_route,omitempty"`
+	Repo         string              `yaml:"repo"`
+	Hostnames    []string            `yaml:"enclaves"`
+	Overload     *OverloadConfig     `yaml:"overload,omitempty"`
+	RateLimit    *RateLimitConfig    `yaml:"rate_limit,omitempty"`
+	CacheRoute   *CacheRouteConfig   `yaml:"cache_route,omitempty"`
+	Reservations []ReservationConfig `yaml:"reservations,omitempty"`
 }
 
 // OverloadConfig describes optional overload thresholds for a model.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -82,3 +82,35 @@ models:
 		t.Fatal("absent cache_route must stay nil")
 	}
 }
+
+func TestReservationConfigParsing(t *testing.T) {
+	cfg, err := FromBytes([]byte(`
+models:
+  reserved:
+    repo: org/repo
+    enclaves: [a.example, b.example, c.example]
+    reservations:
+      - org_ids: [org_abc123, org_def456]
+        enclaves: [c.example]
+  plain:
+    repo: org/repo
+    enclaves: [d.example]
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reservations := cfg.Models["reserved"].Reservations
+	if len(reservations) != 1 {
+		t.Fatalf("reservations = %+v, want one entry", reservations)
+	}
+	if len(reservations[0].OrgIDs) != 2 || reservations[0].OrgIDs[0] != "org_abc123" || reservations[0].OrgIDs[1] != "org_def456" {
+		t.Fatalf("reservation orgs = %+v", reservations[0])
+	}
+	if len(reservations[0].Enclaves) != 1 || reservations[0].Enclaves[0] != "c.example" {
+		t.Fatalf("reservation = %+v", reservations[0])
+	}
+	if cfg.Models["plain"].Reservations != nil {
+		t.Fatal("absent reservations must stay nil")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -717,6 +717,27 @@ func main() {
 				hasAutoContinueTools := toolruntime.HasAutoContinueTools(r.URL.Path, body)
 				rateLimitModel := modelName
 
+				// Strip any user-supplied priority to prevent circumventing rate limits
+				// or jumping ahead of other users.
+				delete(body, "priority")
+
+				// Resolved before any internal dispatch (file conversion,
+				// tool loop) so they all select from the caller's
+				// reservation pools.
+				if routeCtx, ok := routeContextClient.Lookup(r.Context(), apiKey, modelName); ok {
+					callerOrgID = routeCtx.OrgID
+					callerOrgResolved = true
+					r = r.WithContext(manager.WithCallerOrg(r.Context(), routeCtx.OrgID))
+					if routeCtx.Priority != nil {
+						body["priority"] = *routeCtx.Priority
+						hasConfiguredPriority = true
+						manager.PriorityAssignmentsTotal.WithLabelValues(modelName).Inc()
+						log.WithFields(log.Fields{
+							"model": modelName,
+						}).Debug("injecting configured vLLM priority")
+					}
+				}
+
 				if r.URL.Path == "/v1/responses" || r.URL.Path == "/v1/chat/completions" {
 					switch r.URL.Path {
 					case "/v1/responses":
@@ -746,10 +767,6 @@ func main() {
 					}
 				}
 
-				// Strip any user-supplied priority to prevent circumventing rate limits
-				// or jumping ahead of other users.
-				delete(body, "priority")
-
 				// Identify the caller for rate limiting (see rateLimitIdentity).
 				rateLimitID := rateLimitIdentity(apiKey)
 
@@ -759,22 +776,6 @@ func main() {
 				// on endpoints that support it.
 				mode, _ := applyCacheSalt(body, r.URL.Path, apiKey, *cacheSaltEnabled)
 				recordCacheSaltInjection(modelName, mode)
-
-				if routeCtx, ok := routeContextClient.Lookup(r.Context(), apiKey, modelName); ok {
-					callerOrgID = routeCtx.OrgID
-					callerOrgResolved = true
-					// So the tool loop's internal dispatches select from
-					// the same reservation pools as the public path.
-					r = r.WithContext(manager.WithCallerOrg(r.Context(), routeCtx.OrgID))
-					if routeCtx.Priority != nil {
-						body["priority"] = *routeCtx.Priority
-						hasConfiguredPriority = true
-						manager.PriorityAssignmentsTotal.WithLabelValues(modelName).Inc()
-						log.WithFields(log.Fields{
-							"model": modelName,
-						}).Debug("injecting configured vLLM priority")
-					}
-				}
 
 				// Check per-key rate limits: reject with 429 over the hard
 				// budget, inject lower vLLM priority over the soft budget.

--- a/main.go
+++ b/main.go
@@ -496,6 +496,11 @@ func main() {
 		// the TTFT / inter-token SLA observation at dispatch.
 		isStreaming := false
 
+		// The caller's org from route-context; only consulted for models
+		// with enclave reservations.
+		callerOrgID := ""
+		callerOrgResolved := false
+
 		// Extract API key early for rate limiting decisions
 		apiKey := manager.BearerToken(r.Header.Get("Authorization"))
 
@@ -755,13 +760,20 @@ func main() {
 				mode, _ := applyCacheSalt(body, r.URL.Path, apiKey, *cacheSaltEnabled)
 				recordCacheSaltInjection(modelName, mode)
 
-				if routeCtx, ok := routeContextClient.Lookup(r.Context(), apiKey, modelName); ok && routeCtx.Priority != nil {
-					body["priority"] = *routeCtx.Priority
-					hasConfiguredPriority = true
-					manager.PriorityAssignmentsTotal.WithLabelValues(modelName).Inc()
-					log.WithFields(log.Fields{
-						"model": modelName,
-					}).Debug("injecting configured vLLM priority")
+				if routeCtx, ok := routeContextClient.Lookup(r.Context(), apiKey, modelName); ok {
+					callerOrgID = routeCtx.OrgID
+					callerOrgResolved = true
+					// So the tool loop's internal dispatches select from
+					// the same reservation pools as the public path.
+					r = r.WithContext(manager.WithCallerOrg(r.Context(), routeCtx.OrgID))
+					if routeCtx.Priority != nil {
+						body["priority"] = *routeCtx.Priority
+						hasConfiguredPriority = true
+						manager.PriorityAssignmentsTotal.WithLabelValues(modelName).Inc()
+						log.WithFields(log.Fields{
+							"model": modelName,
+						}).Debug("injecting configured vLLM priority")
+					}
 				}
 
 				// Check per-key rate limits: reject with 429 over the hard
@@ -875,67 +887,77 @@ func main() {
 			return
 		}
 
+		// Resolve the caller's reservation pools. Only reserved models pay
+		// for org resolution; a failed lookup fails closed to shared.
+		var poolPrimary, poolSpill map[string]bool
+		if model.HasReservations() {
+			if !callerOrgResolved {
+				if routeCtx, ok := routeContextClient.Lookup(r.Context(), apiKey, modelName); ok {
+					callerOrgID = routeCtx.OrgID
+					callerOrgResolved = true
+				}
+			}
+			poolPrimary, poolSpill = model.ReservationPools(callerOrgID)
+		}
+
 		// On enforced pools, keyed requests are served in cache-aware
 		// preference order: the key's pick first, then the rest of its
 		// ranking, so an overloaded pick spills to the next-warmest host
 		// via the skip loop below instead of a random sibling. The
 		// decision carries its pool snapshot and replication factor to
 		// the landing observation, so the metrics describe the decision
-		// that actually routed the request.
+		// that actually routed the request. The pool is scoped to the
+		// caller's primary reservation pool.
 		var cacheRouteDecision *cacheroute.Decision
 		var cacheRouteOrder []string
 		if cacheRouteReq != nil && cacheRouteSettings.Mode == cacheroute.ModeEnforced {
-			cacheRouteDecision = cacheRouteShadow.Decide(modelName, cacheRouteReq, model.CacheRoutePool(), cacheRouteSettings)
+			cacheRouteDecision = cacheRouteShadow.Decide(modelName, cacheRouteReq, model.CacheRoutePoolIn(poolPrimary), cacheRouteSettings)
 			if cacheRouteDecision != nil {
 				cacheRouteOrder = cacheRouteDecision.Order
 			}
 		}
 
-		// Try up to N picks (N = number of configured enclaves). Each pick
-		// that turns out overloaded goes into skip, so the next iteration
-		// prefers a sibling. Bounded so a single backed-up enclave doesn't
-		// cascade into a 429 when others are healthy.
 		var (
 			enclave    *manager.Enclave
 			probeClaim *manager.ProbeClaim
 			overloaded bool
 			retryAfter time.Duration
 			waiting    float64
-			skip       = map[string]bool{}
 		)
 		if hasConfiguredPriority {
 			// Configured-priority callers have no 429 path: like internal
 			// dispatches they serve through overload at the warmest host,
 			// where their injected priority jumps the backend queue.
-			enclave, probeClaim = model.SelectForDispatch(cacheRouteOrder)
+			enclave, probeClaim = model.SelectForDispatchPools(cacheRouteOrder, poolPrimary, poolSpill)
 			if enclave != nil && probeClaim == nil {
 				if ov, _, _ := enclave.ShouldReject(); ov {
 					manager.PriorityOverloadAdmitsTotal.WithLabelValues(modelName).Inc()
 				}
 			}
 		} else {
-			for range model.EnclaveCount() {
-				enclave, probeClaim = model.NextEnclavePreferring(cacheRouteOrder, skip)
-				if enclave == nil {
-					break
-				}
-				// A claimed probe must be dispatched: skipping its pick as
-				// overloaded would leave the claim unresolved and strand the
-				// breaker half-open (see Model.selectForDispatch). Overload
-				// spill applies to plain picks only.
-				if probeClaim != nil {
-					overloaded = false
-					break
-				}
-				if overloaded, retryAfter, waiting = enclave.ShouldReject(); !overloaded {
-					break
-				}
-				skip[enclave.String()] = true
-			}
+			enclave, probeClaim, overloaded, retryAfter, waiting = model.SelectServing(cacheRouteOrder, poolPrimary, poolSpill)
 		}
 		if enclave == nil {
 			jsonError(w, manager.ErrMsgOverloaded, manager.ErrTypeServer, http.StatusServiceUnavailable)
 			return
+		}
+
+		// Meter landing pools on reserved models; poolSpill is only
+		// non-nil for reserved callers.
+		if poolPrimary != nil && !overloaded {
+			pool := "shared"
+			if poolSpill != nil {
+				if poolPrimary[enclave.String()] {
+					pool = "reserved"
+				} else {
+					pool = "spilled"
+					log.WithFields(log.Fields{
+						"model":   modelName,
+						"enclave": enclave.String(),
+					}).Debug("reserved pool exhausted; spilling to shared pool")
+				}
+			}
+			manager.ReservedPoolServesTotal.WithLabelValues(modelName, pool).Inc()
 		}
 
 		if overloaded {
@@ -975,7 +997,7 @@ func main() {
 		if cacheRouteDecision != nil {
 			cacheRouteShadow.ObserveLanding(modelName, cacheRouteReq, cacheRouteDecision, enclave.String(), cacheRouteSettings)
 		} else if cacheRouteReq != nil {
-			cacheRouteShadow.Observe(modelName, cacheRouteReq, model.CacheRoutePool(), enclave.String(), cacheRouteSettings)
+			cacheRouteShadow.Observe(modelName, cacheRouteReq, model.CacheRoutePoolIn(poolPrimary), enclave.String(), cacheRouteSettings)
 		}
 
 		// A claimed recovery probe travels with its request, so the

--- a/manager/caller_org.go
+++ b/manager/caller_org.go
@@ -1,0 +1,22 @@
+package manager
+
+import "context"
+
+// callerOrgContextKey carries the caller's org through internal dispatches
+// (the tool loop) so reservation pools apply to them without threading the
+// org through every toolruntime signature.
+type callerOrgContextKey struct{}
+
+// WithCallerOrg attaches the caller's org id to the request context.
+func WithCallerOrg(ctx context.Context, orgID string) context.Context {
+	if orgID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, callerOrgContextKey{}, orgID)
+}
+
+// CallerOrgFromContext returns the caller's org id, or "" when absent.
+func CallerOrgFromContext(ctx context.Context) string {
+	orgID, _ := ctx.Value(callerOrgContextKey{}).(string)
+	return orgID
+}

--- a/manager/file_inputs.go
+++ b/manager/file_inputs.go
@@ -118,8 +118,10 @@ func (em *EnclaveManager) ConvertFile(
 
 	// This path uses its own client and records no breaker outcomes, so it
 	// must not claim a recovery probe — a claimed probe with no recorded
-	// outcome strands the breaker half-open until restart.
-	enclave, _ := model.nextEnclave(nil, false, nil)
+	// outcome strands the breaker half-open until restart. Reservation
+	// pools apply via the caller org in ctx.
+	primary, spill := model.ReservationPools(CallerOrgFromContext(ctx))
+	enclave, _ := model.selectForDispatchPools(nil, false, primary, spill)
 	if enclave == nil {
 		return nil, &FileConversionError{
 			StatusCode: http.StatusBadGateway,

--- a/manager/file_inputs.go
+++ b/manager/file_inputs.go
@@ -119,7 +119,7 @@ func (em *EnclaveManager) ConvertFile(
 	// This path uses its own client and records no breaker outcomes, so it
 	// must not claim a recovery probe — a claimed probe with no recorded
 	// outcome strands the breaker half-open until restart.
-	enclave, _ := model.nextEnclave(nil, false)
+	enclave, _ := model.nextEnclave(nil, false, nil)
 	if enclave == nil {
 		return nil, &FileConversionError{
 			StatusCode: http.StatusBadGateway,

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -20,7 +20,7 @@ import (
 // breaker outcome is ever recorded for them: claiming a recovery probe here
 // would strand the breaker half-open until restart.
 func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *http.Client, error) {
-	enclave, client, _, err := em.boundHTTPClientPreferring(modelName, nil, false)
+	enclave, client, _, err := em.boundHTTPClientPreferring(context.Background(), modelName, nil, false)
 	if err != nil {
 		return "", nil, err
 	}
@@ -29,16 +29,19 @@ func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *ht
 
 // boundHTTPClientPreferring picks the serving enclave for an internal
 // dispatch — honoring a cache-aware host preference with overload spill (see
-// Model.SelectForDispatch) — and builds its attested client. A non-nil
-// ProbeClaim must travel with the dispatched request (see ProbeClaim);
-// claimProbes must be false for callers that record no breaker outcomes.
-func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []string, claimProbes bool) (*Enclave, *http.Client, *ProbeClaim, error) {
+// Model.SelectForDispatch) — and builds its attested client. Reservation
+// pools apply via the caller org in ctx (see WithCallerOrg); no org means
+// the shared pool. A non-nil ProbeClaim must travel with the dispatched
+// request (see ProbeClaim); claimProbes must be false for callers that
+// record no breaker outcomes.
+func (em *EnclaveManager) boundHTTPClientPreferring(ctx context.Context, modelName string, order []string, claimProbes bool) (*Enclave, *http.Client, *ProbeClaim, error) {
 	model, found := em.GetModel(modelName)
 	if !found {
 		return nil, nil, nil, fmt.Errorf("model %s not found", modelName)
 	}
 
-	enclave, claim := model.selectForDispatch(order, claimProbes)
+	primary, spill := model.ReservationPools(CallerOrgFromContext(ctx))
+	enclave, claim := model.selectForDispatchPools(order, claimProbes, primary, spill)
 	if enclave == nil {
 		return nil, nil, nil, fmt.Errorf("model %s has no available enclave", modelName)
 	}
@@ -66,7 +69,7 @@ func (em *EnclaveManager) boundHTTPClientPreferring(modelName string, order []st
 // billing/usage hooks) so that internal callers can be responsible for their
 // own billing accounting without needing a trust-the-caller HTTP header.
 func (em *EnclaveManager) DoModelRequest(ctx context.Context, modelName, path string, body []byte, headers http.Header) (*http.Response, error) {
-	enclave, client, claim, err := em.boundHTTPClientPreferring(modelName, nil, true)
+	enclave, client, claim, err := em.boundHTTPClientPreferring(ctx, modelName, nil, true)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +89,7 @@ func (em *EnclaveManager) DoModelRequestJSON(ctx context.Context, modelName, pat
 		return nil, err
 	}
 
-	req, settings, pool, ok := em.cacheRouteRequest(modelName, path, body)
+	req, settings, pool, ok := em.cacheRouteRequest(ctx, modelName, path, body)
 	var decision *cacheroute.Decision
 	if ok && settings.Mode == cacheroute.ModeEnforced {
 		decision = em.cacheRouteShadow.Decide(modelName, req, pool, settings)
@@ -96,7 +99,7 @@ func (em *EnclaveManager) DoModelRequestJSON(ctx context.Context, modelName, pat
 		order = decision.Order
 	}
 
-	enclave, client, claim, err := em.boundHTTPClientPreferring(modelName, order, true)
+	enclave, client, claim, err := em.boundHTTPClientPreferring(ctx, modelName, order, true)
 	if err != nil {
 		return nil, err
 	}
@@ -116,11 +119,12 @@ func (em *EnclaveManager) DoModelRequestJSON(ctx context.Context, modelName, pat
 
 // cacheRouteRequest classifies one internally dispatched request for the
 // cache-route pipeline, with the same gating as the public path, returning
-// the pool snapshot the decision should be made over. Callers only dispatch
-// to cache_salt-capable endpoints, so no endpoint allowlist is re-checked
+// the pool snapshot the decision should be made over — scoped to the
+// caller's primary reservation pool. Callers only dispatch to
+// cache_salt-capable endpoints, so no endpoint allowlist is re-checked
 // here. ok is false when the pipeline is off for the model (or the manager
 // has no shadow, as in tests).
-func (em *EnclaveManager) cacheRouteRequest(modelName, path string, body map[string]any) (*cacheroute.Request, cacheroute.Settings, cacheroute.Pool, bool) {
+func (em *EnclaveManager) cacheRouteRequest(ctx context.Context, modelName, path string, body map[string]any) (*cacheroute.Request, cacheroute.Settings, cacheroute.Pool, bool) {
 	if em.cacheRouteShadow == nil {
 		return nil, cacheroute.Settings{}, cacheroute.Pool{}, false
 	}
@@ -134,7 +138,8 @@ func (em *EnclaveManager) cacheRouteRequest(modelName, path string, body map[str
 	}
 	salt, _ := body["cache_salt"].(string)
 	req := cacheroute.ExtractRequest(body, path, salt, settings)
-	return req, settings, model.CacheRoutePool(), true
+	primary, _ := model.ReservationPools(CallerOrgFromContext(ctx))
+	return req, settings, model.CacheRoutePoolIn(primary), true
 }
 
 // postToEnclave builds and sends an attested POST to one enclave, counting

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -19,8 +19,8 @@ import (
 // tool transport). Those connections never reach postToEnclave, so no
 // breaker outcome is ever recorded for them: claiming a recovery probe here
 // would strand the breaker half-open until restart.
-func (em *EnclaveManager) boundHTTPClientForModel(modelName string) (string, *http.Client, error) {
-	enclave, client, _, err := em.boundHTTPClientPreferring(context.Background(), modelName, nil, false)
+func (em *EnclaveManager) boundHTTPClientForModel(ctx context.Context, modelName string) (string, *http.Client, error) {
+	enclave, client, _, err := em.boundHTTPClientPreferring(ctx, modelName, nil, false)
 	if err != nil {
 		return "", nil, err
 	}
@@ -217,7 +217,10 @@ func (b *inflightBody) Close() error {
 	return b.ReadCloser.Close()
 }
 
-func (em *EnclaveManager) MCPServerEndpoint(modelName string) (string, *http.Client, error) {
+// MCPServerEndpoint resolves the attested MCP endpoint for a tool-server
+// model. Reservation pools apply via the caller org in ctx (see
+// WithCallerOrg), so a reserved caller's tool sessions use its pool.
+func (em *EnclaveManager) MCPServerEndpoint(ctx context.Context, modelName string) (string, *http.Client, error) {
 	// LOCAL_MCP_ENDPOINT_<MODEL_NAME> bypasses attested TLS pinning
 	// and connects to an arbitrary URL (typically http://127.0.0.1).
 	// Honored only when --debug / DEBUG is explicitly enabled so a
@@ -231,7 +234,7 @@ func (em *EnclaveManager) MCPServerEndpoint(modelName string) (string, *http.Cli
 		}
 	}
 
-	host, client, err := em.boundHTTPClientForModel(modelName)
+	host, client, err := em.boundHTTPClientForModel(ctx, modelName)
 	if err != nil {
 		return "", nil, err
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -49,9 +49,88 @@ type Model struct {
 	Overload          *config.OverloadConfig   `json:"overload,omitempty"`
 	RateLimit         *config.RateLimitConfig  `json:"rate_limit,omitempty"`
 	CacheRoute        *config.CacheRouteConfig `json:"cache_route,omitempty"`
+	// Reservations is excluded from JSON: Status() feeds the public
+	// /.well-known/tinfoil-proxy endpoint, and org ids must not be
+	// exposed there.
+	Reservations []config.ReservationConfig `json:"-"`
 
 	expectedHosts int // number of configured hostnames; 0 means no backends expected
-	mu            sync.RWMutex
+
+	// Derived from Reservations (see applyReservations); replaced wholesale
+	// and never mutated after publish, so safe to return under RLock.
+	reservedByOrg map[string]map[string]bool // org id -> its reserved host set
+	sharedHosts   map[string]bool            // unreserved hosts; nil when no reservations
+
+	mu sync.RWMutex
+}
+
+// applyReservations rebuilds the derived reservation lookup sets. The caller
+// must hold m.mu or have exclusive access (addModel, before publish).
+func (m *Model) applyReservations(reservations []config.ReservationConfig, hostnames []string) {
+	m.Reservations = reservations
+
+	byOrg := make(map[string]map[string]bool, len(reservations))
+	reserved := make(map[string]bool)
+	for _, res := range reservations {
+		if len(res.OrgIDs) == 0 || len(res.Enclaves) == 0 {
+			continue
+		}
+		for _, orgID := range res.OrgIDs {
+			if orgID == "" {
+				continue
+			}
+			set := byOrg[orgID]
+			if set == nil {
+				set = make(map[string]bool, len(res.Enclaves))
+				byOrg[orgID] = set
+			}
+			for _, host := range res.Enclaves {
+				set[host] = true
+				reserved[host] = true
+			}
+		}
+	}
+	if len(byOrg) == 0 {
+		m.reservedByOrg = nil
+		m.sharedHosts = nil
+		return
+	}
+
+	shared := make(map[string]bool, len(hostnames))
+	for _, host := range hostnames {
+		if !reserved[host] {
+			shared[host] = true
+		}
+	}
+	m.reservedByOrg = byOrg
+	m.sharedHosts = shared
+}
+
+// HasReservations reports whether any of this model's enclaves are reserved,
+// letting the hot path skip caller-org resolution for unreserved models.
+func (m *Model) HasReservations() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.reservedByOrg) > 0
+}
+
+// ReservationPools returns the caller's pool filters: primary is the host
+// set selection must draw from, spill what it may widen to when the primary
+// is exhausted. A reserved org gets its hosts + shared spill; everyone else
+// gets the shared hosts with no spill — reserved capacity is exclusive. Both
+// nil when the model has no reservations.
+func (m *Model) ReservationPools(orgID string) (primary, spill map[string]bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.reservedByOrg) == 0 {
+		return nil, nil
+	}
+	if orgID != "" {
+		if hosts, ok := m.reservedByOrg[orgID]; ok {
+			return hosts, m.sharedHosts
+		}
+	}
+	return m.sharedHosts, nil
 }
 
 type EnclaveManager struct {
@@ -343,17 +422,22 @@ func (e *Enclave) claimProbe() *ProbeClaim {
 // A non-nil ProbeClaim means the pick is a claimed recovery probe: the
 // request dispatched to it must carry the claim (see ProbeClaim).
 func (m *Model) NextEnclave(skip map[string]bool) (*Enclave, *ProbeClaim) {
-	return m.nextEnclave(skip, true)
+	return m.nextEnclave(skip, true, nil)
 }
 
-// nextEnclave is NextEnclave with probe claiming optional.
-func (m *Model) nextEnclave(skip map[string]bool, claimProbes bool) (*Enclave, *ProbeClaim) {
+// nextEnclave is NextEnclave with probe claiming optional and an optional
+// allowed host filter (nil = all hosts). The filter is hard: it applies to
+// every bucket including the degraded last resort and probe claiming.
+func (m *Model) nextEnclave(skip map[string]bool, claimProbes bool, allowed map[string]bool) (*Enclave, *ProbeClaim) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	all := make([]*Enclave, 0, len(m.Enclaves))
 	var closed, preferred []*Enclave
 	for _, enclave := range m.Enclaves {
+		if allowed != nil && !allowed[enclave.host] {
+			continue
+		}
 		all = append(all, enclave)
 		if enclave.cb != nil && !enclave.cb.Closed() {
 			if claimProbes {
@@ -392,17 +476,20 @@ func (m *Model) nextEnclave(skip map[string]bool, claimProbes bool) (*Enclave, *
 // retry loop, SelectForDispatch for internal dispatches), so a flapping
 // load signal can never move a key's home.
 func (m *Model) NextEnclavePreferring(order []string, skip map[string]bool) (*Enclave, *ProbeClaim) {
-	return m.nextEnclavePreferring(order, skip, true)
+	return m.nextEnclavePreferring(order, skip, true, nil)
 }
 
-func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, claimProbes bool) (*Enclave, *ProbeClaim) {
+func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, claimProbes bool, allowed map[string]bool) (*Enclave, *ProbeClaim) {
 	if len(order) == 0 {
-		return m.nextEnclave(skip, claimProbes)
+		return m.nextEnclave(skip, claimProbes, allowed)
 	}
 
 	if claimProbes {
 		m.mu.RLock()
 		for _, enclave := range m.Enclaves {
+			if allowed != nil && !allowed[enclave.host] {
+				continue
+			}
 			if enclave.cb != nil && !enclave.cb.Closed() {
 				if claim := enclave.claimProbe(); claim != nil {
 					m.mu.RUnlock()
@@ -414,6 +501,9 @@ func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, clai
 	}
 	m.mu.RLock()
 	for _, host := range order {
+		if allowed != nil && !allowed[host] {
+			continue
+		}
 		enclave := m.Enclaves[host]
 		if enclave == nil || skip[host] {
 			continue
@@ -425,7 +515,7 @@ func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, clai
 		return enclave, nil
 	}
 	m.mu.RUnlock()
-	return m.nextEnclave(skip, claimProbes)
+	return m.nextEnclave(skip, claimProbes, allowed)
 }
 
 // SelectForDispatch picks the serving enclave for an internal dispatch (the
@@ -437,19 +527,57 @@ func (m *Model) nextEnclavePreferring(order []string, skip map[string]bool, clai
 // no closed replica exists at all. Internal dispatches record their outcomes,
 // so they may also claim a due recovery probe.
 func (m *Model) SelectForDispatch(order []string) (*Enclave, *ProbeClaim) {
-	return m.selectForDispatch(order, true)
+	return m.selectForDispatch(order, true, nil)
+}
+
+// SelectForDispatchPools picks like SelectForDispatch over the caller's
+// reservation pools: primary first, spill only when every primary candidate
+// is overloaded or unhealthy. Both exhausted serves through overload at the
+// primary pick (no-429 contract).
+func (m *Model) SelectForDispatchPools(order []string, primary, spill map[string]bool) (*Enclave, *ProbeClaim) {
+	return m.selectForDispatchPools(order, true, primary, spill)
+}
+
+func (m *Model) selectForDispatchPools(order []string, claimProbes bool, primary, spill map[string]bool) (*Enclave, *ProbeClaim) {
+	enclave, claim := m.selectForDispatch(order, claimProbes, primary)
+	// A claimed probe must be dispatched.
+	if len(spill) == 0 || claim != nil {
+		return enclave, claim
+	}
+	if enclave != nil && enclave.breakerClosed() {
+		if overloaded, _, _ := enclave.ShouldReject(); !overloaded {
+			return enclave, nil
+		}
+	}
+	spillEnclave, spillClaim := m.selectForDispatch(order, claimProbes, spill)
+	if spillEnclave != nil {
+		if spillClaim != nil {
+			return spillEnclave, spillClaim
+		}
+		if spillEnclave.breakerClosed() {
+			if overloaded, _, _ := spillEnclave.ShouldReject(); !overloaded {
+				return spillEnclave, nil
+			}
+		}
+	}
+	// Both pools exhausted: serve through overload at the primary pick.
+	if enclave != nil {
+		return enclave, nil
+	}
+	return spillEnclave, nil
 }
 
 // selectForDispatch is SelectForDispatch with probe claiming optional, for
 // callers that hand the connection to a transport that records no breaker
-// outcomes (a claimed probe there would strand the breaker half-open).
-func (m *Model) selectForDispatch(order []string, claimProbes bool) (*Enclave, *ProbeClaim) {
+// outcomes (a claimed probe there would strand the breaker half-open), and
+// an optional allowed host filter (see nextEnclave).
+func (m *Model) selectForDispatch(order []string, claimProbes bool, allowed map[string]bool) (*Enclave, *ProbeClaim) {
 	skip := map[string]bool{}
 	var firstOverloaded *Enclave
 	var enclave *Enclave
 	for range m.EnclaveCount() {
 		var claim *ProbeClaim
-		enclave, claim = m.nextEnclavePreferring(order, skip, claimProbes)
+		enclave, claim = m.nextEnclavePreferring(order, skip, claimProbes, allowed)
 		if enclave == nil {
 			break
 		}
@@ -477,6 +605,55 @@ func (m *Model) selectForDispatch(order []string, claimProbes bool) (*Enclave, *
 	return enclave, nil
 }
 
+// SelectServing picks the serving enclave for a public proxied request: the
+// overload skip loop over the caller's primary pool, widening to spill only
+// when every primary candidate is overloaded or unhealthy (nil primary =
+// all enclaves, no reservations). A nil enclave means 503; overloaded=true
+// is the 429 verdict with retryAfter/waiting; a non-nil ProbeClaim must
+// travel with the dispatched request.
+func (m *Model) SelectServing(order []string, primary, spill map[string]bool) (enclave *Enclave, claim *ProbeClaim, overloaded bool, retryAfter time.Duration, waiting float64) {
+	enclave, claim, overloaded, retryAfter, waiting = m.selectServingFrom(order, primary)
+	// A claimed probe must be dispatched. Breaker-open last resorts do
+	// spill: an all-dead reserved pool should fail over to shared capacity,
+	// not serve at a dead host.
+	if len(spill) == 0 || claim != nil {
+		return
+	}
+	if enclave != nil && !overloaded && enclave.breakerClosed() {
+		return
+	}
+	spillEnclave, spillClaim, spillOverloaded, spillRetryAfter, spillWaiting := m.selectServingFrom(order, spill)
+	if spillEnclave == nil {
+		return
+	}
+	if enclave == nil || spillClaim != nil || (!spillOverloaded && spillEnclave.breakerClosed()) {
+		return spillEnclave, spillClaim, spillOverloaded, spillRetryAfter, spillWaiting
+	}
+	// Both pools exhausted: surface the primary pool's overload verdict.
+	return
+}
+
+func (m *Model) selectServingFrom(order []string, allowed map[string]bool) (enclave *Enclave, claim *ProbeClaim, overloaded bool, retryAfter time.Duration, waiting float64) {
+	skip := map[string]bool{}
+	for range m.EnclaveCount() {
+		enclave, claim = m.nextEnclavePreferring(order, skip, true, allowed)
+		if enclave == nil {
+			return
+		}
+		// A claimed probe must be dispatched or the breaker strands
+		// half-open; overload skip applies to plain picks only.
+		if claim != nil {
+			overloaded = false
+			return
+		}
+		if overloaded, retryAfter, waiting = enclave.ShouldReject(); !overloaded {
+			return
+		}
+		skip[enclave.String()] = true
+	}
+	return
+}
+
 // EnclaveCount returns the number of configured enclaves under the model lock.
 // Callers that need to bound a retry loop on enclave cardinality should use
 // this rather than reading len(m.Enclaves) directly.
@@ -492,15 +669,29 @@ func (m *Model) EnclaveCount() int {
 // flag is deliberately ignored — membership must stay stable so a flapping
 // load signal can't move a key's home.
 func (m *Model) CacheRoutePool() cacheroute.Pool {
+	return m.CacheRoutePoolIn(nil)
+}
+
+// CacheRoutePoolIn is CacheRoutePool restricted to the caller's reservation
+// pool (nil = all), keeping HRW ranking — and a key's warm home — inside it.
+func (m *Model) CacheRoutePoolIn(allowed map[string]bool) cacheroute.Pool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	// Size comes from the config, not the live enclave map: during a
 	// release the map is cleared and re-attested one host at a time, and a
 	// multi-replica pool must not reclassify as pool_too_small (skipping
-	// warmth tracking) for that window.
-	pool := cacheroute.Pool{Size: m.expectedHosts}
+	// warmth tracking) for that window. A restricted pool's size is the
+	// configured size of that pool for the same reason.
+	size := m.expectedHosts
+	if allowed != nil {
+		size = len(allowed)
+	}
+	pool := cacheroute.Pool{Size: size}
 	for _, enclave := range m.Enclaves {
+		if allowed != nil && !allowed[enclave.host] {
+			continue
+		}
 		if enclave.cb != nil && !enclave.cb.Closed() {
 			continue
 		}
@@ -511,6 +702,9 @@ func (m *Model) CacheRoutePool() cacheroute.Pool {
 	}
 	if len(pool.Candidates) == 0 {
 		for _, enclave := range m.Enclaves {
+			if allowed != nil && !allowed[enclave.host] {
+				continue
+			}
 			pool.Candidates = append(pool.Candidates, cacheroute.Candidate{
 				Host:     enclave.host,
 				InFlight: int(enclave.inflight.Load()),
@@ -563,6 +757,12 @@ func (em *EnclaveManager) ResolvePreferredModel(candidates []string) string {
 
 func (e *Enclave) isOverloaded() bool {
 	return e != nil && e.metrics != nil && e.metrics.overloaded.Load()
+}
+
+// breakerClosed reports whether the circuit breaker is closed (nil counts
+// as closed, matching selection's treatment).
+func (e *Enclave) breakerClosed() bool {
+	return e.cb == nil || e.cb.Closed()
 }
 
 func (e *Enclave) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -664,7 +864,7 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterI
 }
 
 func (em *EnclaveManager) addModel(modelName string, modelConfig config.Model) {
-	em.models.Store(modelName, &Model{
+	model := &Model{
 		Repo:              modelConfig.Repo,
 		Tag:               "",
 		SourceMeasurement: nil,
@@ -673,7 +873,9 @@ func (em *EnclaveManager) addModel(modelName string, modelConfig config.Model) {
 		RateLimit:         modelConfig.RateLimit,
 		CacheRoute:        modelConfig.CacheRoute,
 		expectedHosts:     len(modelConfig.Hostnames),
-	})
+	}
+	model.applyReservations(modelConfig.Reservations, modelConfig.Hostnames)
+	em.models.Store(modelName, model)
 	cacheroute.SetMode(modelName, modelConfig.CacheRoute)
 	cacheroute.SetPoolInfo(modelName, modelConfig.Hostnames)
 }
@@ -755,6 +957,7 @@ func (em *EnclaveManager) sync() error {
 				log.Warnf("model %s no longer in config", modelName)
 				model.mu.Lock()
 				model.expectedHosts = 0
+				model.applyReservations(nil, nil)
 				for _, enclave := range model.Enclaves {
 					enclave.shutdown()
 				}
@@ -781,6 +984,7 @@ func (em *EnclaveManager) sync() error {
 			model.Overload = configModel.Overload
 			model.RateLimit = configModel.RateLimit
 			model.CacheRoute = configModel.CacheRoute
+			model.applyReservations(configModel.Reservations, configModel.Hostnames)
 			for _, enclave := range model.Enclaves {
 				enclave.updateOverloadConfig(model.Overload)
 			}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -64,11 +64,18 @@ type Model struct {
 	mu sync.RWMutex
 }
 
-// applyReservations rebuilds the derived reservation lookup sets. The caller
-// must hold m.mu or have exclusive access (addModel, before publish).
+// applyReservations rebuilds the derived reservation lookup sets. Reserved
+// hosts not present in the configured hostnames are dropped with a warning:
+// counting them would silently shrink an org's effective pool (or leave it
+// empty, routing all its traffic to spill). The caller must hold m.mu or
+// have exclusive access (addModel, before publish).
 func (m *Model) applyReservations(reservations []config.ReservationConfig, hostnames []string) {
 	m.Reservations = reservations
 
+	known := make(map[string]bool, len(hostnames))
+	for _, host := range hostnames {
+		known[host] = true
+	}
 	byOrg := make(map[string]map[string]bool, len(reservations))
 	reserved := make(map[string]bool)
 	for _, res := range reservations {
@@ -85,8 +92,15 @@ func (m *Model) applyReservations(reservations []config.ReservationConfig, hostn
 				byOrg[orgID] = set
 			}
 			for _, host := range res.Enclaves {
+				if !known[host] {
+					log.Warnf("reservation for org %s references unknown enclave %s, ignoring", orgID, host)
+					continue
+				}
 				set[host] = true
 				reserved[host] = true
+			}
+			if len(set) == 0 {
+				delete(byOrg, orgID)
 			}
 		}
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -270,7 +271,7 @@ func TestCacheRouteRequest(t *testing.T) {
 	}
 	base := keyed()
 
-	req, settings, pool, ok := em.cacheRouteRequest("tool-observed", "/v1/chat/completions", body)
+	req, settings, pool, ok := em.cacheRouteRequest(context.Background(), "tool-observed", "/v1/chat/completions", body)
 	if !ok || req == nil || pool.Size != 2 {
 		t.Fatalf("gate = (%v, %+v, %+v), want open with 2-replica pool", ok, req, pool)
 	}
@@ -281,13 +282,13 @@ func TestCacheRouteRequest(t *testing.T) {
 
 	// Mode off gates out.
 	model.CacheRoute = nil
-	if _, _, _, stillOK := em.cacheRouteRequest("tool-observed", "/v1/chat/completions", body); stillOK {
+	if _, _, _, stillOK := em.cacheRouteRequest(context.Background(), "tool-observed", "/v1/chat/completions", body); stillOK {
 		t.Fatal("mode off must gate out")
 	}
 
 	// No shadow (tests construct managers without one) gates out.
 	em.cacheRouteShadow = nil
-	if _, _, _, stillOK := em.cacheRouteRequest("tool-observed", "/v1/chat/completions", body); stillOK {
+	if _, _, _, stillOK := em.cacheRouteRequest(context.Background(), "tool-observed", "/v1/chat/completions", body); stillOK {
 		t.Fatal("missing shadow must gate out")
 	}
 }
@@ -612,7 +613,7 @@ func TestSelectForDispatchWithoutClaimingLeavesProbes(t *testing.T) {
 	tripBreaker(m.Enclaves["b"])
 	m.Enclaves["b"].cb.lastFailureNano.Store(time.Now().Add(-cbCooldown - time.Second).UnixNano()) // probe due
 
-	got, claim := m.selectForDispatch([]string{"a"}, false)
+	got, claim := m.selectForDispatch([]string{"a"}, false, nil)
 	if got == nil || got.host != "a" {
 		t.Fatalf("pick = %v, want a", got)
 	}

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -119,6 +119,17 @@ var (
 		[]string{"model"},
 	)
 
+	// ReservedPoolServesTotal tracks serves on models with reservations by
+	// landing pool: reserved, spilled (reserved org overflowing to shared),
+	// or shared.
+	ReservedPoolServesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_reserved_pool_serves_total",
+			Help: "Total serves on models with enclave reservations, by landing pool (reserved, spilled, shared)",
+		},
+		[]string{"model", "pool"},
+	)
+
 	// CacheSaltInjectionsTotal tracks requests injected with a derived cache_salt
 	CacheSaltInjectionsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/manager/reservations_test.go
+++ b/manager/reservations_test.go
@@ -68,6 +68,35 @@ func TestReservationPoolsIgnoreDegenerateEntries(t *testing.T) {
 	}
 }
 
+// Reserved hosts missing from the configured enclave list are dropped, and
+// an org left with no valid hosts is treated as unreserved rather than
+// pinned to an empty pool.
+func TestReservationPoolsDropUnknownHosts(t *testing.T) {
+	m := newTestModel("a", "b")
+	m.applyReservations(
+		[]config.ReservationConfig{
+			{OrgIDs: []string{"org-x"}, Enclaves: []string{"b", "typo-host"}},
+			{OrgIDs: []string{"org-y"}, Enclaves: []string{"stale-host"}},
+		},
+		[]string{"a", "b"},
+	)
+
+	primary, spill := m.ReservationPools("org-x")
+	if len(primary) != 1 || !primary["b"] {
+		t.Fatalf("primary = %v, want {b} with typo-host dropped", primary)
+	}
+	if len(spill) != 1 || !spill["a"] {
+		t.Fatalf("spill = %v, want {a}", spill)
+	}
+
+	// org-y's only host is unknown: it must fall back to the shared pool,
+	// not an empty primary.
+	primary, spill = m.ReservationPools("org-y")
+	if len(primary) != 1 || !primary["a"] || spill != nil {
+		t.Fatalf("pools for org-y = (%v, %v), want shared ({a}, nil)", primary, spill)
+	}
+}
+
 // One reservation entry can dedicate a pool to several orgs.
 func TestReservationPoolsMultiOrg(t *testing.T) {
 	m := newTestModel("a", "b", "c")

--- a/manager/reservations_test.go
+++ b/manager/reservations_test.go
@@ -1,0 +1,270 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/tinfoilsh/confidential-model-router/config"
+)
+
+// newReservedTestModel builds a model with hosts a, b, c where c is reserved
+// for org-reserved. a and b form the shared pool.
+func newReservedTestModel() *Model {
+	m := newTestModel("a", "b", "c")
+	m.applyReservations(
+		[]config.ReservationConfig{{OrgIDs: []string{"org-reserved"}, Enclaves: []string{"c"}}},
+		[]string{"a", "b", "c"},
+	)
+	return m
+}
+
+func TestReservationPools(t *testing.T) {
+	m := newTestModel("a", "b")
+	if m.HasReservations() {
+		t.Fatal("model without reservations must report none")
+	}
+	if primary, spill := m.ReservationPools("org-any"); primary != nil || spill != nil {
+		t.Fatalf("pools without reservations = (%v, %v), want (nil, nil)", primary, spill)
+	}
+
+	m = newReservedTestModel()
+	if !m.HasReservations() {
+		t.Fatal("reserved model must report reservations")
+	}
+
+	// The reserved org gets its hosts as primary, the shared pool as spill.
+	primary, spill := m.ReservationPools("org-reserved")
+	if len(primary) != 1 || !primary["c"] {
+		t.Fatalf("reserved primary = %v, want {c}", primary)
+	}
+	if len(spill) != 2 || !spill["a"] || !spill["b"] {
+		t.Fatalf("reserved spill = %v, want {a, b}", spill)
+	}
+
+	// Everyone else gets the shared pool with no spill.
+	for _, org := range []string{"", "org-other"} {
+		primary, spill = m.ReservationPools(org)
+		if len(primary) != 2 || !primary["a"] || !primary["b"] {
+			t.Fatalf("shared primary for %q = %v, want {a, b}", org, primary)
+		}
+		if spill != nil {
+			t.Fatalf("shared spill for %q = %v, want nil", org, spill)
+		}
+	}
+}
+
+// Reservations with no orgs or no enclaves are dropped.
+func TestReservationPoolsIgnoreDegenerateEntries(t *testing.T) {
+	m := newTestModel("a", "b")
+	m.applyReservations(
+		[]config.ReservationConfig{
+			{OrgIDs: nil, Enclaves: []string{"a"}},
+			{OrgIDs: []string{""}, Enclaves: []string{"a"}},
+			{OrgIDs: []string{"org-x"}, Enclaves: nil},
+		},
+		[]string{"a", "b"},
+	)
+	if m.HasReservations() {
+		t.Fatal("degenerate reservations must leave the model unreserved")
+	}
+}
+
+// One reservation entry can dedicate a pool to several orgs.
+func TestReservationPoolsMultiOrg(t *testing.T) {
+	m := newTestModel("a", "b", "c")
+	m.applyReservations(
+		[]config.ReservationConfig{{OrgIDs: []string{"org-reserved", "org-partner"}, Enclaves: []string{"b", "c"}}},
+		[]string{"a", "b", "c"},
+	)
+
+	for _, org := range []string{"org-reserved", "org-partner"} {
+		primary, spill := m.ReservationPools(org)
+		if len(primary) != 2 || !primary["b"] || !primary["c"] {
+			t.Fatalf("primary for %q = %v, want {b, c}", org, primary)
+		}
+		if len(spill) != 1 || !spill["a"] {
+			t.Fatalf("spill for %q = %v, want {a}", org, spill)
+		}
+	}
+
+	primary, spill := m.ReservationPools("org-other")
+	if len(primary) != 1 || !primary["a"] || spill != nil {
+		t.Fatalf("shared pools = (%v, %v), want ({a}, nil)", primary, spill)
+	}
+}
+
+// The allowed set is a hard filter: even the degraded last-resort buckets
+// never leak a host outside it.
+func TestNextEnclaveHonorsAllowedFilter(t *testing.T) {
+	m := newTestModel("a", "b", "c")
+	allowed := map[string]bool{"c": true}
+
+	for range 50 {
+		if got, _ := m.nextEnclave(nil, true, allowed); got == nil || got.host != "c" {
+			t.Fatalf("pick = %v, want c", got)
+		}
+	}
+
+	// The filter holds even for overloaded and breaker-open last resorts.
+	makeOverloaded(m.Enclaves["c"])
+	tripBreaker(m.Enclaves["c"])
+	for range 50 {
+		if got, _ := m.nextEnclave(nil, false, allowed); got == nil || got.host != "c" {
+			t.Fatalf("degraded pick = %v, want c", got)
+		}
+	}
+
+	// An empty allowed set selects nothing.
+	if got, _ := m.nextEnclave(nil, true, map[string]bool{}); got != nil {
+		t.Fatalf("empty-pool pick = %v, want nil", got)
+	}
+}
+
+// Cache-order hosts outside the allowed set are skipped, not served.
+func TestNextEnclavePreferringHonorsAllowedFilter(t *testing.T) {
+	m := newTestModel("a", "b", "c")
+	allowed := map[string]bool{"b": true, "c": true}
+
+	if got, _ := m.nextEnclavePreferring([]string{"a", "b"}, nil, true, allowed); got == nil || got.host != "b" {
+		t.Fatalf("pick = %v, want b (a is outside the pool)", got)
+	}
+}
+
+// Reserved org: reserved host first, spill to shared on overload, 429
+// verdict when both pools are exhausted.
+func TestSelectServingReservedCaller(t *testing.T) {
+	m := newReservedTestModel()
+	primary, spill := m.ReservationPools("org-reserved")
+
+	// Healthy reserved host serves.
+	enclave, _, overloaded, _, _ := m.SelectServing(nil, primary, spill)
+	if enclave == nil || enclave.host != "c" || overloaded {
+		t.Fatalf("pick = (%v, overloaded=%v), want reserved c", enclave, overloaded)
+	}
+
+	// Reserved host overloaded: spill to the shared pool, no 429.
+	makeOverloaded(m.Enclaves["c"])
+	for range 50 {
+		enclave, _, overloaded, _, _ = m.SelectServing(nil, primary, spill)
+		if enclave == nil || enclave.host == "c" || overloaded {
+			t.Fatalf("spill pick = (%v, overloaded=%v), want shared a or b", enclave, overloaded)
+		}
+	}
+
+	// Both pools overloaded: overload verdict (429), not a silent serve.
+	makeOverloaded(m.Enclaves["a"])
+	makeOverloaded(m.Enclaves["b"])
+	enclave, _, overloaded, _, _ = m.SelectServing(nil, primary, spill)
+	if enclave == nil || !overloaded {
+		t.Fatalf("exhausted pick = (%v, overloaded=%v), want overload verdict", enclave, overloaded)
+	}
+}
+
+// An all-breaker-open reserved pool fails over to shared capacity instead
+// of serving at a dead host.
+func TestSelectServingReservedCallerSpillsFromDeadPool(t *testing.T) {
+	m := newReservedTestModel()
+	primary, spill := m.ReservationPools("org-reserved")
+
+	tripBreaker(m.Enclaves["c"])
+	for range 50 {
+		enclave, claim, overloaded, _, _ := m.SelectServing(nil, primary, spill)
+		// A due recovery probe for c is fine; a plain pick must spill.
+		if claim != nil {
+			continue
+		}
+		if enclave == nil || enclave.host == "c" || overloaded {
+			t.Fatalf("pick with dead reserved pool = (%v, overloaded=%v), want shared a or b", enclave, overloaded)
+		}
+	}
+}
+
+// Exclusivity: shared traffic 429s on an exhausted shared pool rather than
+// touching the reserved host.
+func TestSelectServingSharedCallerNeverUsesReservedHost(t *testing.T) {
+	m := newReservedTestModel()
+	primary, spill := m.ReservationPools("org-other")
+
+	makeOverloaded(m.Enclaves["a"])
+	makeOverloaded(m.Enclaves["b"])
+	for range 50 {
+		enclave, _, overloaded, _, _ := m.SelectServing(nil, primary, spill)
+		if enclave == nil || enclave.host == "c" {
+			t.Fatalf("shared pick = %v, must never be reserved c", enclave)
+		}
+		if !overloaded {
+			t.Fatalf("shared pick with exhausted shared pool must carry the overload verdict")
+		}
+	}
+}
+
+// Nil pools behave like the pre-reservation loop over all enclaves.
+func TestSelectServingNoReservations(t *testing.T) {
+	m := newTestModel("a", "b")
+	makeOverloaded(m.Enclaves["a"])
+
+	for range 50 {
+		enclave, _, overloaded, _, _ := m.SelectServing(nil, nil, nil)
+		if enclave == nil || enclave.host != "b" || overloaded {
+			t.Fatalf("pick = (%v, overloaded=%v), want healthy b", enclave, overloaded)
+		}
+	}
+}
+
+// No-429 dispatch path: spill on primary overload, serve through overload
+// at the primary when both pools are exhausted.
+func TestSelectForDispatchPools(t *testing.T) {
+	m := newReservedTestModel()
+	primary, spill := m.ReservationPools("org-reserved")
+
+	if got, _ := m.SelectForDispatchPools(nil, primary, spill); got == nil || got.host != "c" {
+		t.Fatalf("pick = %v, want reserved c", got)
+	}
+
+	makeOverloaded(m.Enclaves["c"])
+	for range 50 {
+		if got, _ := m.SelectForDispatchPools(nil, primary, spill); got == nil || got.host == "c" {
+			t.Fatalf("spill pick = %v, want shared a or b", got)
+		}
+	}
+
+	makeOverloaded(m.Enclaves["a"])
+	makeOverloaded(m.Enclaves["b"])
+	for range 50 {
+		if got, _ := m.SelectForDispatchPools(nil, primary, spill); got == nil || got.host != "c" {
+			t.Fatalf("exhausted pick = %v, want serve-through at reserved c", got)
+		}
+	}
+}
+
+func TestCacheRoutePoolIn(t *testing.T) {
+	m := newReservedTestModel()
+	primary, _ := m.ReservationPools("org-other")
+
+	pool := m.CacheRoutePoolIn(primary)
+	if pool.Size != 2 || len(pool.Candidates) != 2 {
+		t.Fatalf("pool = %+v, want size 2 with shared candidates a, b", pool)
+	}
+	for _, c := range pool.Candidates {
+		if c.Host == "c" {
+			t.Fatalf("shared cache-route pool must not contain reserved c: %+v", pool)
+		}
+	}
+
+	// All allowed breakers open: the fallback stays inside the filter.
+	tripBreaker(m.Enclaves["a"])
+	tripBreaker(m.Enclaves["b"])
+	pool = m.CacheRoutePoolIn(primary)
+	if len(pool.Candidates) != 2 {
+		t.Fatalf("fallback pool = %+v, want a and b", pool)
+	}
+	for _, c := range pool.Candidates {
+		if c.Host == "c" {
+			t.Fatalf("fallback must not leak reserved c: %+v", pool)
+		}
+	}
+
+	// nil filter preserves the unrestricted behavior.
+	if pool := m.CacheRoutePoolIn(nil); pool.Size != 3 {
+		t.Fatalf("unrestricted pool = %+v, want size 3", pool)
+	}
+}

--- a/route_context.go
+++ b/route_context.go
@@ -40,7 +40,8 @@ type routeContextRequest struct {
 }
 
 type routeContext struct {
-	Priority *int `json:"priority,omitempty"`
+	Priority *int   `json:"priority,omitempty"`
+	OrgID    string `json:"org_id,omitempty"`
 }
 
 func newRouteContextClient(controlPlaneURL string) *routeContextClient {

--- a/route_context_test.go
+++ b/route_context_test.go
@@ -31,6 +31,7 @@ func TestRouteContextClientLookupCachesSuccess(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(routeContext{
 			Priority: &priority,
+			OrgID:    "org_test",
 		})
 	}))
 	defer server.Close()
@@ -50,6 +51,9 @@ func TestRouteContextClientLookupCachesSuccess(t *testing.T) {
 	}
 	if second.Priority == nil || *second.Priority != priority {
 		t.Fatalf("second context = %#v, want high priority", second)
+	}
+	if first.OrgID != "org_test" || second.OrgID != "org_test" {
+		t.Fatalf("contexts = (%#v, %#v), want org_test org", first, second)
 	}
 	if requests != 1 {
 		t.Fatalf("requests = %d, want 1", requests)

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -210,7 +210,7 @@ func newToolSessionRequestID(_ *http.Request) string {
 // profile. buildSessionRegistry invokes it once per active profile
 // and aggregates the results into the per-request routing table.
 func connectToolSession(ctx context.Context, em *manager.EnclaveManager, profile Profile, r *http.Request, modelName string, body map[string]any, safety safetyOptIns) (*mcp.ClientSession, error) {
-	endpoint, httpClient, err := em.MCPServerEndpoint(profile.ToolServerModel)
+	endpoint, httpClient, err := em.MCPServerEndpoint(ctx, profile.ToolServerModel)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add per‑org enclave reservations for models. Reserved orgs use their own hosts and spill to shared on overload; everyone else stays on shared capacity.

- **New Features**
  - Add `reservations` to model config: `org_ids` mapped to reserved `enclaves`.
  - Selection logic:
    - Reserved orgs: serve on reserved → spill to shared on overload; 429 only if both pools are exhausted.
    - Non‑reserved callers: shared only; never use reserved hosts.
    - Internal dispatch uses the same pools with a no‑429 contract; spills, then serves through overload at the primary if both pools exhaust. Tool sessions (MCP) and file conversion now honor the caller’s pools via context.
  - Route context now returns `org_id`; used to resolve pools and propagated via request context so tool calls use the same pools.
  - Cache‑route decisions and observations are scoped to the caller’s primary pool; fallbacks stay within that pool.
  - Reservations referencing unknown enclaves are ignored with a warning; affected orgs fall back to shared.
  - Strip any user‑supplied `priority`; only control‑plane assigned priority is injected.
  - New metric `router_reserved_pool_serves_total{model,pool=reserved|spilled|shared}`.
  - Tests cover config parsing and pool behavior.

- **Migration**
  - To enable reservations, add under a model:
    - `reservations: - org_ids: [org_abc] enclaves: [c.example]`
  - Ensure the control plane’s route‑context API includes `org_id` (unresolved callers fall back to shared).
  - For internal calls to `EnclaveManager.DoModelRequest*` or `MCPServerEndpoint`, pass the caller org with `manager.WithCallerOrg(ctx, orgID)` so requests route via reserved pools; otherwise they use the shared pool. Note: `MCPServerEndpoint` now requires a context parameter.

<sup>Written for commit ecece00e98603951403264796ebaab4ddd988c2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

