### PR TITLE
router: observe streaming TTFT and inter-token latency by priority class

### DIFF
--- a/latency.go
+++ b/latency.go
@@ -56,7 +56,9 @@ func (lw *latencyWriter) now() time.Time {
 }
 
 func (lw *latencyWriter) WriteHeader(code int) {
-	if lw.status == 0 {
+	// 1xx headers are interim (the proxy forwards them ahead of the real
+	// status), so keep updating until the first non-informational code.
+	if lw.status < 200 {
 		lw.status = code
 	}
 	lw.ResponseWriter.WriteHeader(code)

--- a/latency.go
+++ b/latency.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/tinfoilsh/confidential-model-router/manager"
+)
+
+// latencyMetricPaths are the endpoints where streaming TTFT and inter-token
+// gaps are meaningful SLA signals.
+var latencyMetricPaths = map[string]bool{
+	"/v1/chat/completions": true,
+	"/v1/completions":      true,
+	"/v1/responses":        true,
+}
+
+func priorityClass(hasConfiguredPriority bool) string {
+	if hasConfiguredPriority {
+		return "configured"
+	}
+	return "none"
+}
+
+// latencyWriter wraps http.ResponseWriter to observe time-to-first-byte and
+// inter-chunk gaps on streaming responses. Only 2xx responses are observed,
+// so proxy error bodies don't register as fast first tokens. It deliberately
+// does not implement io.ReaderFrom: a delegating ReadFrom would bypass Write
+// and drop the per-chunk timing.
+type latencyWriter struct {
+	http.ResponseWriter
+	model   string
+	class   string
+	status  int
+	start   time.Time
+	last    time.Time
+	nowFunc func() time.Time
+}
+
+func newLatencyWriter(w http.ResponseWriter, model, class string) *latencyWriter {
+	return &latencyWriter{
+		ResponseWriter: w,
+		model:          model,
+		class:          class,
+		start:          time.Now(),
+	}
+}
+
+func (lw *latencyWriter) now() time.Time {
+	if lw.nowFunc != nil {
+		return lw.nowFunc()
+	}
+	return time.Now()
+}
+
+func (lw *latencyWriter) WriteHeader(code int) {
+	if lw.status == 0 {
+		lw.status = code
+	}
+	lw.ResponseWriter.WriteHeader(code)
+}
+
+func (lw *latencyWriter) Write(b []byte) (int, error) {
+	// status 0 means an implicit 200 from a Write without WriteHeader
+	if lw.status < 300 {
+		now := lw.now()
+		if lw.last.IsZero() {
+			manager.TTFTSeconds.WithLabelValues(lw.model, lw.class).Observe(now.Sub(lw.start).Seconds())
+		} else {
+			manager.InterTokenSeconds.WithLabelValues(lw.model, lw.class).Observe(now.Sub(lw.last).Seconds())
+		}
+		lw.last = now
+	}
+	return lw.ResponseWriter.Write(b)
+}
+
+// Flush implements http.Flusher
+func (lw *latencyWriter) Flush() {
+	if flusher, ok := lw.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// Hijack implements http.Hijacker when supported by the underlying ResponseWriter.
+func (lw *latencyWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := lw.ResponseWriter.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+	return nil, nil, http.ErrNotSupported
+}
+
+// Push implements http.Pusher when supported by the underlying ResponseWriter.
+func (lw *latencyWriter) Push(target string, opts *http.PushOptions) error {
+	if pusher, ok := lw.ResponseWriter.(http.Pusher); ok {
+		return pusher.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
+
+// Unwrap returns the underlying ResponseWriter (for http.ResponseController)
+func (lw *latencyWriter) Unwrap() http.ResponseWriter {
+	return lw.ResponseWriter
+}

--- a/latency_test.go
+++ b/latency_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -9,6 +10,19 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/tinfoilsh/confidential-model-router/manager"
 )
+
+// sinkResponseWriter accepts any write sequence. httptest.ResponseRecorder
+// can't be used for 1xx tests: it latches the informational code as the
+// final status and then rejects the body, which a real server would accept.
+type sinkResponseWriter struct{ header http.Header }
+
+func newSinkResponseWriter() *sinkResponseWriter {
+	return &sinkResponseWriter{header: make(http.Header)}
+}
+
+func (s *sinkResponseWriter) Header() http.Header         { return s.header }
+func (s *sinkResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (s *sinkResponseWriter) WriteHeader(int)             {}
 
 func histogramState(t *testing.T, o prometheus.Observer) (count uint64, sum float64) {
 	t.Helper()
@@ -73,6 +87,44 @@ func TestLatencyWriterSkipsErrorResponses(t *testing.T) {
 
 	if count, _ := histogramState(t, manager.TTFTSeconds.WithLabelValues(model, "none")); count != 0 {
 		t.Fatalf("error response must not observe TTFT, got count=%d", count)
+	}
+}
+
+func TestLatencyWriterInformationalThenError(t *testing.T) {
+	const model = "latency-test-1xx-error"
+	lw := &latencyWriter{
+		ResponseWriter: newSinkResponseWriter(),
+		model:          model,
+		class:          "none",
+		start:          time.Now(),
+	}
+
+	lw.WriteHeader(100)
+	lw.WriteHeader(502)
+	if _, err := lw.Write([]byte(`{"error":{}}`)); err != nil {
+		t.Fatal(err)
+	}
+	if count, _ := histogramState(t, manager.TTFTSeconds.WithLabelValues(model, "none")); count != 0 {
+		t.Fatalf("error response behind a 1xx must not observe TTFT, got count=%d", count)
+	}
+}
+
+func TestLatencyWriterInformationalThenSuccess(t *testing.T) {
+	const model = "latency-test-1xx-ok"
+	lw := &latencyWriter{
+		ResponseWriter: newSinkResponseWriter(),
+		model:          model,
+		class:          "none",
+		start:          time.Now(),
+	}
+
+	lw.WriteHeader(100)
+	lw.WriteHeader(200)
+	if _, err := lw.Write([]byte("chunk")); err != nil {
+		t.Fatal(err)
+	}
+	if count, _ := histogramState(t, manager.TTFTSeconds.WithLabelValues(model, "none")); count != 1 {
+		t.Fatalf("success behind a 1xx must observe TTFT, got count=%d", count)
 	}
 }
 

--- a/latency_test.go
+++ b/latency_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/tinfoilsh/confidential-model-router/manager"
+)
+
+func histogramState(t *testing.T, o prometheus.Observer) (count uint64, sum float64) {
+	t.Helper()
+	m, ok := o.(prometheus.Metric)
+	if !ok {
+		t.Fatalf("observer is not a metric: %T", o)
+	}
+	pb := &dto.Metric{}
+	if err := m.Write(pb); err != nil {
+		t.Fatalf("failed to read histogram: %v", err)
+	}
+	return pb.GetHistogram().GetSampleCount(), pb.GetHistogram().GetSampleSum()
+}
+
+func TestLatencyWriterObservesStreaming(t *testing.T) {
+	const model = "latency-test-streaming"
+	now := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	lw := &latencyWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		model:          model,
+		class:          "configured",
+		start:          now,
+		nowFunc:        func() time.Time { return now },
+	}
+
+	// First byte 500ms after dispatch, then three chunks at 20ms gaps
+	now = now.Add(500 * time.Millisecond)
+	lw.WriteHeader(200)
+	if _, err := lw.Write([]byte("chunk")); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		now = now.Add(20 * time.Millisecond)
+		if _, err := lw.Write([]byte("chunk")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ttftCount, ttftSum := histogramState(t, manager.TTFTSeconds.WithLabelValues(model, "configured"))
+	if ttftCount != 1 || ttftSum != 0.5 {
+		t.Fatalf("expected one TTFT observation of 0.5s, got count=%d sum=%v", ttftCount, ttftSum)
+	}
+	itlCount, itlSum := histogramState(t, manager.InterTokenSeconds.WithLabelValues(model, "configured"))
+	if itlCount != 3 || itlSum < 0.0599 || itlSum > 0.0601 {
+		t.Fatalf("expected three 20ms inter-token observations, got count=%d sum=%v", itlCount, itlSum)
+	}
+}
+
+func TestLatencyWriterSkipsErrorResponses(t *testing.T) {
+	const model = "latency-test-error"
+	lw := &latencyWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		model:          model,
+		class:          "none",
+		start:          time.Now(),
+	}
+
+	lw.WriteHeader(502)
+	if _, err := lw.Write([]byte(`{"error":{}}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	if count, _ := histogramState(t, manager.TTFTSeconds.WithLabelValues(model, "none")); count != 0 {
+		t.Fatalf("error response must not observe TTFT, got count=%d", count)
+	}
+}
+
+func TestLatencyWriterImplicit200(t *testing.T) {
+	const model = "latency-test-implicit"
+	lw := &latencyWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		model:          model,
+		class:          "none",
+		start:          time.Now(),
+	}
+
+	// Write without WriteHeader is an implicit 200 and must be observed
+	if _, err := lw.Write([]byte("chunk")); err != nil {
+		t.Fatal(err)
+	}
+	if count, _ := histogramState(t, manager.TTFTSeconds.WithLabelValues(model, "none")); count != 1 {
+		t.Fatalf("implicit 200 must observe TTFT, got count=%d", count)
+	}
+}
+
+func TestLatencyWriterForwardsFlush(t *testing.T) {
+	rec := httptest.NewRecorder()
+	lw := newLatencyWriter(rec, "latency-test-flush", "none")
+	lw.Flush()
+	if !rec.Flushed {
+		t.Fatal("Flush was not forwarded to the underlying writer")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -492,6 +492,10 @@ func main() {
 		// caller; such callers are exempt from overload shedding.
 		hasConfiguredPriority := false
 
+		// Set when the parsed body requests a streaming response; gates
+		// the TTFT / inter-token SLA observation at dispatch.
+		isStreaming := false
+
 		// Extract API key early for rate limiting decisions
 		apiKey := manager.BearerToken(r.Header.Get("Authorization"))
 
@@ -789,6 +793,7 @@ func main() {
 
 				// If streaming request, ensure upstream usage is available for billing.
 				if stream, ok := body["stream"].(bool); ok && stream {
+					isStreaming = true
 					ensureStreamingUsageOptions(body, r.Header)
 					log.Debugf("Modified streaming request body to include usage for billing, client requested usage: %v",
 						r.Header.Get("X-Tinfoil-Client-Requested-Usage") == "true")
@@ -980,7 +985,11 @@ func main() {
 			r = r.WithContext(manager.WithProbeClaim(r.Context(), probeClaim))
 		}
 
-		enclave.ServeHTTP(w, r)
+		rw := http.ResponseWriter(w)
+		if isStreaming && latencyMetricPaths[r.URL.Path] {
+			rw = newLatencyWriter(w, modelName, priorityClass(hasConfiguredPriority))
+		}
+		enclave.ServeHTTP(rw, r)
 	})
 
 	// Setup graceful shutdown

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -25,6 +25,28 @@ var (
 		[]string{"model"},
 	)
 
+	// TTFTSeconds tracks time to first response body byte for streaming
+	// requests, split by caller priority class for SLA tracking
+	TTFTSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "router_ttft_seconds",
+			Help:    "Time to first response body byte for streaming requests",
+			Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 7.5, 10, 15, 30, 60},
+		},
+		[]string{"model", "priority"},
+	)
+
+	// InterTokenSeconds tracks gaps between streamed response chunks,
+	// split by caller priority class for SLA tracking
+	InterTokenSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "router_inter_token_seconds",
+			Help:    "Gap between streamed response body chunks",
+			Buckets: []float64{0.005, 0.01, 0.015, 0.02, 0.025, 0.03, 0.04, 0.05, 0.075, 0.1, 0.15, 0.25, 0.5, 1},
+		},
+		[]string{"model", "priority"},
+	)
+
 	// BackendQueueDepth tracks the current queue depth at each backend enclave
 	BackendQueueDepth = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
The router has no per-caller latency signal today — vLLM's TTFT/ITL histograms are per-pool, so a priority caller's experience is invisible inside pool percentiles whenever background traffic dominates them. This wraps the proxy's ResponseWriter for streaming requests on the chat/completions/responses paths and records time-to-first-byte plus inter-chunk gaps into two new histograms, `router_ttft_seconds` and `router_inter_token_seconds`, labeled by model and by whether the caller has a control-plane configured priority (two values, so no cardinality risk). Only 2xx responses are observed so proxy error bodies don't register as fast first tokens, non-streaming requests are excluded, and the wrapper mirrors the existing usage-writer's Flush/Hijack/Unwrap passthroughs — verified end-to-end against a live enclave: streaming intact, one TTFT and per-chunk gap observations recorded, non-streaming and error paths silent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-caller streaming latency metrics (TTFT and inter-token gaps) by model and priority, and fixes status gating so 1xx headers don’t let later errors register as fast first tokens.

- **New Features**
  - Wraps http.ResponseWriter on streaming requests to `/v1/chat/completions`, `/v1/completions`, and `/v1/responses` to record TTFT and inter-chunk gaps.
  - Publishes Prometheus histograms `router_ttft_seconds` and `router_inter_token_seconds`, labeled by `model` and `priority` (`configured`|`none`), and only for streaming 2xx responses.
  - Preserves streaming behavior: forwards Flush/Hijack/Push/Unwrap and avoids io.ReaderFrom to keep per-chunk timing.

- **Bug Fixes**
  - Latches the first non-informational status to gate observation, preventing 1xx-then-error responses from recording TTFT; adds tests for 1xx success/error, implicit 200, and Flush forwarding.

<sup>Written for commit df68aa121250ed5388598bac9e2a89902c0e7ae8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

