### PR TITLE
router: poll backend metrics every 1s instead of 15s

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -37,7 +37,7 @@ type Enclave struct {
 
 	// inflight counts requests currently proxied through this enclave —
 	// a live load signal, unlike the polled queue depth, which can be up
-	// to ~45s stale.
+	// to sampleStalenessLimit stale when scrapes fail.
 	inflight atomic.Int64
 }
 

--- a/manager/metrics.go
+++ b/manager/metrics.go
@@ -17,7 +17,11 @@ import (
 	"github.com/tinfoilsh/confidential-model-router/config"
 )
 
-const defaultMetricsPollInterval = 15 * time.Second
+// vLLM updates its queue-depth gauge every engine step (tens of ms), so a
+// 1s poll reads fresh data each time. A scrape that outlives the interval
+// blocks the loop and the ticker coalesces missed ticks, so a slow backend
+// is polled at scrape-duration cadence rather than piling up requests.
+const defaultMetricsPollInterval = time.Second
 
 // pollAPIKey, when set, is sent as a bearer token on backend /metrics
 // scrapes (enclaves require an admin key). Stored atomically so startup
@@ -246,7 +250,13 @@ func (m *enclaveMetrics) latestSample() (float64, time.Time) {
 	return m.latestWaiting, m.latestCollected
 }
 
-const sampleStalenessLimit = 3 * defaultMetricsPollInterval
+// sampleStalenessLimit bounds how long the overload flag keeps driving
+// shouldReject without a fresh sample. It is a fixed window rather than a
+// multiple of the poll interval: at a 1s cadence, deriving it from the
+// interval would fail open after a single slow scrape (the scrape client
+// timeout alone is 5s). 15s means roughly three consecutive timed-out
+// scrapes must elapse before the safety net is dropped.
+const sampleStalenessLimit = 15 * time.Second
 
 // evaluateThresholds updates the overload flag from the latest queue depth
 // with hysteresis: trip at the high mark, clear at the lower mark, hold the


### PR DESCRIPTION
## What

- `defaultMetricsPollInterval`: 15s → 1s (`manager/metrics.go`)
- `sampleStalenessLimit`: decoupled from the poll interval (was `3 × interval` = 45s), now a fixed 15s
- Updated the stale-depth comment on `Enclave.inflight` to match

## Why

The overload/spill machinery keys off `vllm:num_requests_waiting`, but vLLM refreshes that gauge every engine step (tens of ms) — the 15s poll was the only thing making the signal stale. During a burst, a replica absorbs up to a full poll interval of arrivals before the router notices it tripped, so spill and 429 decisions consistently react one cycle late. This is most visible on glm-5-2 (enforced cache routing, 3-replica pool, slow-draining agentic requests).

Scrape cost is not a concern at 1s: vLLM v1 renders `/metrics` in the frontend/API-server process (deliberately off the engine-core hot path) in single-digit ms, and the poll loop is per-enclave with a coalescing ticker — a scrape that outlives the interval simply blocks its own loop, so a slow backend self-limits to scrape-duration cadence (~5s with the current client timeout) instead of piling up requests.

The staleness decoupling is required for the interval change to be safe: at `3 × 1s`, a single timed-out scrape (client timeout is 5s) would mark the sample stale, and `shouldReject` fails open on stale samples — the overload safety net would vanish exactly when the backend is struggling. A fixed 15s preserves the old "roughly three consecutive missed scrapes before failing open" semantics.

## Behavior notes

- Trip/clear hysteresis now evaluates ~15× more often. The band (trip/clear marks) is unchanged, but short queue spikes that the 15s poll used to sample right past will now be caught — expect `router_overload_events_total` to tick up somewhat on bursty models. That's the signal doing its job; if it proves noisy, smoothing (EWMA or N-consecutive-samples trip) is the follow-up, not a slower poll.
- Per-scrape logging is Debug-level, so log volume at Info is unchanged.
- Scrape traffic: one authenticated HTTPS GET per enclave per second per router instance, on a keep-alive connection.

## Testing

- `go build ./...` and `go test ./...` pass.
- `manager/metrics_test.go` staleness test is expressed relative to `sampleStalenessLimit`, so it covers the new constant unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Poll backend `/metrics` every 1s (was 15s) so overload and spill decisions react in near real time. Staleness is now fixed at 15s to avoid failing open on a single slow scrape.

- **Refactors**
  - Set `defaultMetricsPollInterval` to 1s.
  - Make `sampleStalenessLimit` a fixed 15s (not tied to the interval).
  - Update `Enclave.inflight` comment to reference `sampleStalenessLimit`.

<sup>Written for commit 5a59379f898510d67373e8b22b6560addb768951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

