### PR TITLE
Add pii-filter to config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -47,3 +47,6 @@ models:
 
   gemma4-31b:
     repo: tinfoilsh/confidential-gemma4-31b
+
+  pii-filter:
+    repo: tinfoilsh/confidential-pii-cpu


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `pii-filter` model to `config.yml`, pointing to `tinfoilsh/confidential-pii-cpu`, so services can reference `pii-filter` for PII redaction in pipelines.

<sup>Written for commit d7fce3fe0cc969085f2d2745d8178be335d520a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

