### PR TITLE
chore: remove unused router configurations

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,10 +1,6 @@
 # Trust anchor only (model -> repo pinning, requires a router release).
 # Live config with domain and settings is set in the tinfoil backend.
 
-routers:
-  inference.tinfoil.sh:
-  router.inf6.tinfoil.sh:
-
 models:
   nomic-embed-text:
     repo: tinfoilsh/confidential-nomic-embed-text


### PR DESCRIPTION
Removed router entries from the configuration file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unused router entries from config.yml since routing is handled in the tinfoil backend. Pure cleanup; no runtime or model behavior changes.

<sup>Written for commit ee2af9afb1ed87864a5f1b1c34b1c9356d965439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

