### PR TITLE
feat: expose cached token counts in usage response headers

### DIFF
--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -375,7 +375,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				usageHandler(jsonResp.Usage)
 
 				// Set usage header directly on response
-				resp.Header.Set(UsageMetricsResponseHeader, formatUsage(jsonResp.Usage, modelName))
+				resp.Header.Set(UsageMetricsResponseHeader, FormatUsage(jsonResp.Usage, modelName))
 			} else if billingCollector != nil && apiKey != "" {
 				emitZeroTokenEvent()
 			}
@@ -421,8 +421,10 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 	return proxy
 }
 
-// formatUsage formats token usage for the response header
-func formatUsage(usage *tokencount.Usage, model string) string {
+// FormatUsage formats token usage for the response header. It is the single
+// source of truth for the header format so every path that emits usage
+// metrics produces an identical value.
+func FormatUsage(usage *tokencount.Usage, model string) string {
 	formatted := "prompt=" + strconv.Itoa(usage.PromptTokens) +
 		",completion=" + strconv.Itoa(usage.CompletionTokens) +
 		",total=" + strconv.Itoa(usage.TotalTokens)

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -40,9 +40,6 @@ const (
 	maxUsageMetricsBodyBytes = int64(10 << 20)
 	// websearchModel is charged per-request in addition to per-token.
 	websearchModel = "websearch"
-	// prompt token detail fields are only exposed in usage metrics for models
-	// that explicitly opt in, to avoid surprising existing consumers.
-	promptTokenDetailsMetricsModel = "kimi-k2-6"
 )
 
 // classifyProxyError maps a transport-level error to a bounded set of reason
@@ -305,7 +302,6 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 			if usage == nil {
 				return
 			}
-			usage.ExposePromptTokenDetails = modelName == promptTokenDetailsMetricsModel
 
 			// For streaming responses, set usage on wrapper for trailer
 			// (non-streaming sets header directly in the buffering block below)
@@ -431,13 +427,10 @@ func formatUsage(usage *tokencount.Usage, model string) string {
 		",completion=" + strconv.Itoa(usage.CompletionTokens) +
 		",total=" + strconv.Itoa(usage.TotalTokens)
 
-	if usage.ExposePromptTokenDetails {
-		cachedPromptTokens, ok := usage.CachedPromptTokens()
-		if ok {
-			uncachedPromptTokens := max(0, usage.PromptTokens-cachedPromptTokens)
-			formatted += ",cached_prompt_tokens=" + strconv.Itoa(cachedPromptTokens) +
-				",uncached_prompt_tokens=" + strconv.Itoa(uncachedPromptTokens)
-		}
+	if cachedPromptTokens, ok := usage.CachedPromptTokens(); ok {
+		uncachedPromptTokens := max(0, usage.PromptTokens-cachedPromptTokens)
+		formatted += ",cached_prompt_tokens=" + strconv.Itoa(cachedPromptTokens) +
+			",uncached_prompt_tokens=" + strconv.Itoa(uncachedPromptTokens)
 	}
 
 	if model != "" {

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -65,7 +65,7 @@ func TestProxyDirector_RewritesHostHeader(t *testing.T) {
 	}
 }
 
-func TestProxyUsageMetrics_NonKimiModelKeepsLegacyUsageFormat(t *testing.T) {
+func TestProxyUsageMetrics_IncludesCachedTokensForAllModels(t *testing.T) {
 	proxy := setupTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -82,7 +82,7 @@ func TestProxyUsageMetrics_NonKimiModelKeepsLegacyUsageFormat(t *testing.T) {
 	proxy.ServeHTTP(wrapper, req.WithContext(ctx))
 
 	got := rec.Header().Get(UsageMetricsResponseHeader)
-	want := "prompt=69,completion=20,total=89,model=test-model"
+	want := "prompt=69,completion=20,total=89,cached_prompt_tokens=64,uncached_prompt_tokens=5,model=test-model"
 	if got != want {
 		t.Fatalf("usage header = %q, want %q", got, want)
 	}

--- a/manager/usage_writer.go
+++ b/manager/usage_writer.go
@@ -50,7 +50,7 @@ func (w *usageMetricsWriter) FormatUsage() string {
 	if w.usage == nil {
 		return ""
 	}
-	return formatUsage(w.usage, w.model)
+	return FormatUsage(w.usage, w.model)
 }
 
 // WriteTrailer writes the usage metrics as an HTTP trailer

--- a/manager/usage_writer_test.go
+++ b/manager/usage_writer_test.go
@@ -67,11 +67,10 @@ func TestUsageMetricsWriter_FormatUsage(t *testing.T) {
 		{
 			name: "appends model after cached prompt token details",
 			usage: &tokencount.Usage{
-				PromptTokens:             69,
-				CompletionTokens:         20,
-				TotalTokens:              89,
-				PromptTokensDetails:      &tokencount.PromptTokensDetails{CachedTokens: 64},
-				ExposePromptTokenDetails: true,
+				PromptTokens:        69,
+				CompletionTokens:    20,
+				TotalTokens:         89,
+				PromptTokensDetails: &tokencount.PromptTokensDetails{CachedTokens: 64},
 			},
 			model:    "kimi-k2-6",
 			expected: "prompt=69,completion=20,total=89,cached_prompt_tokens=64,uncached_prompt_tokens=5,model=kimi-k2-6",
@@ -97,23 +96,22 @@ func TestUsageMetricsWriter_FormatUsage(t *testing.T) {
 		{
 			name: "includes cached prompt token details when present",
 			usage: &tokencount.Usage{
-				PromptTokens:             69,
-				CompletionTokens:         20,
-				TotalTokens:              89,
-				PromptTokensDetails:      &tokencount.PromptTokensDetails{CachedTokens: 64},
-				ExposePromptTokenDetails: true,
-			},
-			expected: "prompt=69,completion=20,total=89,cached_prompt_tokens=64,uncached_prompt_tokens=5",
-		},
-		{
-			name: "keeps legacy format when prompt token details are not exposed",
-			usage: &tokencount.Usage{
 				PromptTokens:        69,
 				CompletionTokens:    20,
 				TotalTokens:         89,
 				PromptTokensDetails: &tokencount.PromptTokensDetails{CachedTokens: 64},
 			},
-			expected: "prompt=69,completion=20,total=89",
+			expected: "prompt=69,completion=20,total=89,cached_prompt_tokens=64,uncached_prompt_tokens=5",
+		},
+		{
+			name: "clamps cached tokens to prompt tokens",
+			usage: &tokencount.Usage{
+				PromptTokens:        69,
+				CompletionTokens:    20,
+				TotalTokens:         89,
+				PromptTokensDetails: &tokencount.PromptTokensDetails{CachedTokens: 100},
+			},
+			expected: "prompt=69,completion=20,total=89,cached_prompt_tokens=69,uncached_prompt_tokens=0",
 		},
 		{
 			name:     "nil usage",

--- a/tokencount/extractor.go
+++ b/tokencount/extractor.go
@@ -21,8 +21,6 @@ type Usage struct {
 	OutputTokens        int                  `json:"output_tokens"`
 	PromptTokensDetails *PromptTokensDetails `json:"prompt_tokens_details,omitempty"`
 	InputTokensDetails  *PromptTokensDetails `json:"input_tokens_details,omitempty"`
-
-	ExposePromptTokenDetails bool `json:"-"`
 }
 
 type PromptTokensDetails struct {

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -592,7 +592,7 @@ func (s *chatStreamer) finalize(
 	}
 
 	if s.usageMetricsRequested && finalUsage != nil {
-		s.w.Header().Set(manager.UsageMetricsResponseHeader, formatUsageHeader(usageFromRaw(finalUsage)))
+		s.w.Header().Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usageFromRaw(finalUsage), modelName))
 	}
 	s.emitBillingEvent(r, em, modelName, finalUsage)
 	return s.writeErr

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -817,7 +817,7 @@ func (s *responsesStreamer) finalize(r *http.Request, em *manager.EnclaveManager
 	})
 
 	if s.usageMetricsRequested && usage != nil {
-		s.w.Header().Set(manager.UsageMetricsResponseHeader, formatUsageHeader(usageFromRaw(usage)))
+		s.w.Header().Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usageFromRaw(usage), modelName))
 	}
 	s.emitBillingEvent(r, em, modelName, usage)
 	return s.writeErr

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -412,9 +412,15 @@ func usageFromRaw(raw any) *tokencount.Usage {
 }
 
 func formatUsageHeader(usage *tokencount.Usage) string {
-	return "prompt=" + strconv.Itoa(usage.PromptTokens) +
+	formatted := "prompt=" + strconv.Itoa(usage.PromptTokens) +
 		",completion=" + strconv.Itoa(usage.CompletionTokens) +
 		",total=" + strconv.Itoa(usage.TotalTokens)
+	if cachedPromptTokens, ok := usage.CachedPromptTokens(); ok {
+		uncachedPromptTokens := max(0, usage.PromptTokens-cachedPromptTokens)
+		formatted += ",cached_prompt_tokens=" + strconv.Itoa(cachedPromptTokens) +
+			",uncached_prompt_tokens=" + strconv.Itoa(uncachedPromptTokens)
+	}
+	return formatted
 }
 
 func chatUsageMap(usage *tokencount.Usage) map[string]any {

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -166,7 +166,7 @@ func Handle(w http.ResponseWriter, r *http.Request, em *manager.EnclaveManager, 
 		if err != nil {
 			return writeUpstreamError(w, err)
 		}
-		applyUsageMetrics(response, usageMetricsRequested)
+		applyUsageMetrics(response, usageMetricsRequested, modelName)
 		emitBillingEvent(em, r, response, modelName, false)
 		return writeJSONResponse(w, response)
 	case "/v1/responses":
@@ -180,7 +180,7 @@ func Handle(w http.ResponseWriter, r *http.Request, em *manager.EnclaveManager, 
 		if err != nil {
 			return writeUpstreamError(w, err)
 		}
-		applyUsageMetrics(response, usageMetricsRequested)
+		applyUsageMetrics(response, usageMetricsRequested, modelName)
 		emitBillingEvent(em, r, response, modelName, false)
 		return writeJSONResponse(w, response)
 	default:
@@ -411,18 +411,6 @@ func usageFromRaw(raw any) *tokencount.Usage {
 	return &usage
 }
 
-func formatUsageHeader(usage *tokencount.Usage) string {
-	formatted := "prompt=" + strconv.Itoa(usage.PromptTokens) +
-		",completion=" + strconv.Itoa(usage.CompletionTokens) +
-		",total=" + strconv.Itoa(usage.TotalTokens)
-	if cachedPromptTokens, ok := usage.CachedPromptTokens(); ok {
-		uncachedPromptTokens := max(0, usage.PromptTokens-cachedPromptTokens)
-		formatted += ",cached_prompt_tokens=" + strconv.Itoa(cachedPromptTokens) +
-			",uncached_prompt_tokens=" + strconv.Itoa(uncachedPromptTokens)
-	}
-	return formatted
-}
-
 func chatUsageMap(usage *tokencount.Usage) map[string]any {
 	return usageMap(usage, "prompt_tokens", "completion_tokens", "prompt_tokens_details")
 }
@@ -443,7 +431,7 @@ func usageMap(usage *tokencount.Usage, inputTokensKey, outputTokensKey, detailsK
 	return usageMap
 }
 
-func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested bool) {
+func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested bool, modelName string) {
 	if response == nil {
 		return
 	}
@@ -457,7 +445,7 @@ func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested boo
 	if usage == nil {
 		return
 	}
-	response.header.Set(manager.UsageMetricsResponseHeader, formatUsageHeader(usage))
+	response.header.Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usage, modelName))
 }
 
 func emitBillingEvent(em *manager.EnclaveManager, r *http.Request, response *upstreamJSONResponse, modelName string, streaming bool) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose `cached_prompt_tokens` and `uncached_prompt_tokens` in usage response headers for all models to make caching visible to clients. Removed the model-specific gate, clamped cached ≤ prompt tokens, and unified header formatting across all response paths via a single `FormatUsage` function.

<sup>Written for commit 55d8b6e3abba54658e9c0af609840f5bb0888508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

