### PR TITLE
feat: measure time to first generated token for streaming requests

### DIFF
--- a/cache_salt.go
+++ b/cache_salt.go
@@ -64,14 +64,17 @@ func applyCacheSalt(body map[string]any, path, apiKey string, enabled bool) (cac
 
 // saltProxiedBody applies cache-salt handling to a request that the router
 // otherwise forwards verbatim (the subdomain routing path, which never
-// parses the body). It rewrites r.Body in place and returns the derivation
-// mode. The body must be one JSON object so router-owned cache fields can
-// never bypass stripping on a malformed request.
-func saltProxiedBody(r *http.Request, apiKey string, enabled bool) (cachesalt.Mode, error) {
+// parses the body elsewhere). It rewrites r.Body in place and returns the
+// derivation mode plus whether the body requests a streaming response — the
+// one routing signal this path needs from the body, surfaced here so the
+// caller doesn't have to parse it a second time. The body must be one JSON
+// object so router-owned cache fields can never bypass stripping on a
+// malformed request.
+func saltProxiedBody(r *http.Request, apiKey string, enabled bool) (cachesalt.Mode, bool, error) {
 	bodyBytes, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
-		return cachesalt.ModeNone, err
+		return cachesalt.ModeNone, false, err
 	}
 
 	// UseNumber keeps numbers as their exact text across the re-marshal;
@@ -84,25 +87,26 @@ func saltProxiedBody(r *http.Request, apiKey string, enabled bool) (cachesalt.Mo
 	var body map[string]any
 	if err := dec.Decode(&body); err != nil || !decodeConsumedAll(dec) || body == nil {
 		if err != nil {
-			return cachesalt.ModeNone, err
+			return cachesalt.ModeNone, false, err
 		}
-		return cachesalt.ModeNone, errors.New("request body must be one JSON object")
+		return cachesalt.ModeNone, false, errors.New("request body must be one JSON object")
 	}
+	streaming, _ := body["stream"].(bool)
 
 	mode, changed := applyCacheSalt(body, r.URL.Path, apiKey, enabled)
 	if !changed {
 		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-		return mode, nil
+		return mode, streaming, nil
 	}
 
 	newBytes, err := json.Marshal(body)
 	if err != nil {
-		return cachesalt.ModeNone, err
+		return cachesalt.ModeNone, false, err
 	}
 	r.Body = io.NopCloser(bytes.NewReader(newBytes))
 	r.ContentLength = int64(len(newBytes))
 	r.Header.Set("Content-Length", fmt.Sprintf("%d", len(newBytes)))
-	return mode, nil
+	return mode, streaming, nil
 }
 
 // recordCacheSaltInjection counts a performed injection. A skipped one

--- a/cache_salt_test.go
+++ b/cache_salt_test.go
@@ -215,7 +215,7 @@ func TestSaltProxiedBody(t *testing.T) {
 	t.Run("injects and strips on the salted body", func(t *testing.T) {
 		req := httptest.NewRequest("POST", "/v1/chat/completions",
 			strings.NewReader(`{"model":"m","cache_salt":"client-chosen","user_cache_secret":"s1"}`))
-		mode, err := saltProxiedBody(req, "tenant-a", true)
+		mode, _, err := saltProxiedBody(req, "tenant-a", true)
 		if err != nil {
 			t.Fatalf("saltProxiedBody: %v", err)
 		}
@@ -235,7 +235,7 @@ func TestSaltProxiedBody(t *testing.T) {
 	t.Run("strips client salt even when disabled", func(t *testing.T) {
 		req := httptest.NewRequest("POST", "/v1/chat/completions",
 			strings.NewReader(`{"model":"m","cache_salt":"client-chosen"}`))
-		mode, err := saltProxiedBody(req, "tenant-a", false)
+		mode, _, err := saltProxiedBody(req, "tenant-a", false)
 		if err != nil {
 			t.Fatalf("saltProxiedBody: %v", err)
 		}
@@ -249,7 +249,7 @@ func TestSaltProxiedBody(t *testing.T) {
 
 	t.Run("injects tenant salt with no secret", func(t *testing.T) {
 		req := httptest.NewRequest("POST", "/v1/responses", strings.NewReader(`{"model":"m"}`))
-		mode, err := saltProxiedBody(req, "tenant-a", true)
+		mode, _, err := saltProxiedBody(req, "tenant-a", true)
 		if err != nil {
 			t.Fatalf("saltProxiedBody: %v", err)
 		}
@@ -265,7 +265,7 @@ func TestSaltProxiedBody(t *testing.T) {
 		const raw = `{"model":"m","messages":[]}`
 		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(raw))
 		// Disabled + no salt fields: nothing to do, must not re-marshal.
-		if _, err := saltProxiedBody(req, "tenant-a", false); err != nil {
+		if _, _, err := saltProxiedBody(req, "tenant-a", false); err != nil {
 			t.Fatalf("saltProxiedBody: %v", err)
 		}
 		out, _ := io.ReadAll(req.Body)
@@ -279,7 +279,7 @@ func TestSaltProxiedBody(t *testing.T) {
 		// would silently turn it into ...992.
 		req := httptest.NewRequest("POST", "/v1/chat/completions",
 			strings.NewReader(`{"model":"m","seed":9007199254740993}`))
-		if _, err := saltProxiedBody(req, "tenant-a", true); err != nil {
+		if _, _, err := saltProxiedBody(req, "tenant-a", true); err != nil {
 			t.Fatalf("saltProxiedBody: %v", err)
 		}
 		raw, _ := io.ReadAll(req.Body)
@@ -291,7 +291,7 @@ func TestSaltProxiedBody(t *testing.T) {
 	t.Run("rejects a non-JSON body", func(t *testing.T) {
 		const raw = `not json`
 		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(raw))
-		if _, err := saltProxiedBody(req, "tenant-a", true); err == nil {
+		if _, _, err := saltProxiedBody(req, "tenant-a", true); err == nil {
 			t.Fatal("expected malformed subdomain body to be rejected")
 		}
 	})
@@ -310,7 +310,7 @@ func TestSaltProxiedBody(t *testing.T) {
 			`{"model":"m"} x`,
 		} {
 			req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(raw))
-			if _, err := saltProxiedBody(req, "tenant-a", true); err == nil {
+			if _, _, err := saltProxiedBody(req, "tenant-a", true); err == nil {
 				t.Errorf("expected trailing-data body %q to be rejected", raw)
 			}
 		}
@@ -321,7 +321,7 @@ func TestSaltProxiedBody(t *testing.T) {
 		// must not regress ordinary clients that end the body with a newline.
 		req := httptest.NewRequest("POST", "/v1/chat/completions",
 			strings.NewReader("{\"model\":\"m\"}\n\t "))
-		mode, err := saltProxiedBody(req, "tenant-a", true)
+		mode, _, err := saltProxiedBody(req, "tenant-a", true)
 		if err != nil {
 			t.Fatalf("saltProxiedBody: %v", err)
 		}
@@ -330,6 +330,25 @@ func TestSaltProxiedBody(t *testing.T) {
 		}
 		if got := decodeBody(t, req); got["cache_salt"] != tenantSalt {
 			t.Errorf("cache_salt = %v, want %q", got["cache_salt"], tenantSalt)
+		}
+	})
+
+	t.Run("reports the stream flag for SLA gating", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/v1/chat/completions",
+			strings.NewReader(`{"model":"m","stream":true}`))
+		_, streaming, err := saltProxiedBody(req, "tenant-a", true)
+		if err != nil {
+			t.Fatalf("saltProxiedBody: %v", err)
+		}
+		if !streaming {
+			t.Error("stream:true was not reported")
+		}
+
+		// A non-boolean stream value must read as non-streaming, not error.
+		req = httptest.NewRequest("POST", "/v1/chat/completions",
+			strings.NewReader(`{"model":"m","stream":"yes"}`))
+		if _, streaming, err = saltProxiedBody(req, "tenant-a", true); err != nil || streaming {
+			t.Errorf("non-boolean stream: streaming=%v err=%v, want false, nil", streaming, err)
 		}
 	})
 }
@@ -341,7 +360,7 @@ func TestCacheSaltMetricSkippedInjection(t *testing.T) {
 
 	// Skipped: empty identity on an allowlisted, enabled path.
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{"model":"m"}`))
-	mode, err := saltProxiedBody(req, "", true)
+	mode, _, err := saltProxiedBody(req, "", true)
 	if err != nil {
 		t.Fatalf("saltProxiedBody: %v", err)
 	}

--- a/latency.go
+++ b/latency.go
@@ -84,8 +84,10 @@ func (lw *latencyWriter) WriteHeader(code int) {
 
 func (lw *latencyWriter) Write(b []byte) (int, error) {
 	// status 0 means an implicit 200 from a Write without WriteHeader
-	if lw.status < 300 {
-		now := lw.now()
+	observe := lw.status < 300
+	var now time.Time
+	if observe {
+		now = lw.now()
 		if lw.last.IsZero() {
 			manager.TTFTSeconds.WithLabelValues(lw.model, lw.class).Observe(now.Sub(lw.start).Seconds())
 			if isEventStream(lw.Header().Get("Content-Type")) {
@@ -95,18 +97,30 @@ func (lw *latencyWriter) Write(b []byte) (int, error) {
 			manager.InterTokenSeconds.WithLabelValues(lw.model, lw.class).Observe(now.Sub(lw.last).Seconds())
 		}
 		lw.last = now
-		if !lw.tokenSeen {
-			if lw.detector == nil {
-				// The backend answered the streaming request with a plain
-				// 2xx body: the whole payload is the generation, so its
-				// first byte is the first token.
-				lw.observeFirstToken(now)
-			} else if lw.detector.feed(b) {
+	}
+
+	n, err := lw.ResponseWriter.Write(b)
+
+	// First-token detection runs after the delegated write and only on
+	// success: a chunk the connection refused was never sent to the client,
+	// and recording it would both fake a served token and let finish() skip
+	// the request's no-token count. err == nil is the strongest delivery
+	// signal this layer has (and implies n == len(b) per the io.Writer
+	// contract). On failure the proxy aborts the stream, so the unfed
+	// detector state is never consulted again.
+	if observe && err == nil && !lw.tokenSeen {
+		if lw.detector == nil {
+			// The backend answered the streaming request with a plain 2xx
+			// body: the whole payload is the generation, so its first
+			// non-empty write is the first token.
+			if n > 0 {
 				lw.observeFirstToken(now)
 			}
+		} else if lw.detector.feed(b) {
+			lw.observeFirstToken(now)
 		}
 	}
-	return lw.ResponseWriter.Write(b)
+	return n, err
 }
 
 // isEventStream reports whether a Content-Type header declares an SSE body.

--- a/latency.go
+++ b/latency.go
@@ -2,8 +2,13 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/tinfoilsh/confidential-model-router/manager"
@@ -24,26 +29,38 @@ func priorityClass(hasConfiguredPriority bool) string {
 	return "none"
 }
 
-// latencyWriter wraps http.ResponseWriter to observe time-to-first-byte and
-// inter-chunk gaps on streaming responses. Only 2xx responses are observed,
-// so proxy error bodies don't register as fast first tokens. It deliberately
-// does not implement io.ReaderFrom: a delegating ReadFrom would bypass Write
-// and drop the per-chunk timing.
+// latencyWriter wraps http.ResponseWriter to observe streaming latency:
+// legacy time-to-first-byte, inter-chunk gaps, and — via an incremental SSE
+// scan of the bytes actually sent to the client — time to the first
+// generated token, measured from request arrival at the router. Only 2xx
+// responses are observed, so proxy error bodies don't register as fast first
+// tokens. It deliberately does not implement io.ReaderFrom: a delegating
+// ReadFrom would bypass Write and drop the per-chunk timing.
 type latencyWriter struct {
 	http.ResponseWriter
 	model   string
+	enclave string
+	pool    string
 	class   string
+	arrival time.Time // request arrival at the router: first-token zero point
+	start   time.Time // dispatch to the backend: legacy first-byte zero point
 	status  int
-	start   time.Time
 	last    time.Time
 	nowFunc func() time.Time
+
+	detector  *sseTokenDetector // non-nil while scanning an SSE body for the first token
+	tokenSeen bool
+	aborted   bool // ServeHTTP unwound by panic: the proxy aborted mid-stream
 }
 
-func newLatencyWriter(w http.ResponseWriter, model, class string) *latencyWriter {
+func newLatencyWriter(w http.ResponseWriter, arrival time.Time, model, enclave, pool, class string) *latencyWriter {
 	return &latencyWriter{
 		ResponseWriter: w,
 		model:          model,
+		enclave:        enclave,
+		pool:           pool,
 		class:          class,
+		arrival:        arrival,
 		start:          time.Now(),
 	}
 }
@@ -70,12 +87,60 @@ func (lw *latencyWriter) Write(b []byte) (int, error) {
 		now := lw.now()
 		if lw.last.IsZero() {
 			manager.TTFTSeconds.WithLabelValues(lw.model, lw.class).Observe(now.Sub(lw.start).Seconds())
+			if strings.Contains(lw.Header().Get("Content-Type"), "text/event-stream") {
+				lw.detector = &sseTokenDetector{}
+			}
 		} else {
 			manager.InterTokenSeconds.WithLabelValues(lw.model, lw.class).Observe(now.Sub(lw.last).Seconds())
 		}
 		lw.last = now
+		if !lw.tokenSeen {
+			if lw.detector == nil {
+				// The backend answered the streaming request with a plain
+				// 2xx body: the whole payload is the generation, so its
+				// first byte is the first token.
+				lw.observeFirstToken(now)
+			} else if lw.detector.feed(b) {
+				lw.observeFirstToken(now)
+			}
+		}
 	}
 	return lw.ResponseWriter.Write(b)
+}
+
+func (lw *latencyWriter) observeFirstToken(now time.Time) {
+	lw.tokenSeen = true
+	lw.detector = nil
+	manager.FirstTokenSeconds.WithLabelValues(lw.model, lw.enclave, lw.pool, lw.class).
+		Observe(now.Sub(lw.arrival).Seconds())
+}
+
+// finish counts a request that ended before any generated token was sent.
+// It must run deferred, not inline after ServeHTTP: a backend that dies
+// mid-stream unwinds the handler with http.ErrAbortHandler, and that
+// request must still be counted.
+func (lw *latencyWriter) finish(ctx context.Context) {
+	if lw.tokenSeen {
+		return
+	}
+	var reason string
+	switch {
+	// A client disconnect both cancels the request context and aborts the
+	// proxy copy; classify on the context first so client-fault outcomes
+	// aren't misfiled as backend errors. (The proxy's courtesy 502 after a
+	// cancellation is likewise outranked here.)
+	case errors.Is(ctx.Err(), context.Canceled):
+		reason = "canceled"
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		reason = "timeout"
+	case lw.status >= 300,
+		lw.aborted,
+		lw.detector != nil && lw.detector.sawError:
+		reason = "error"
+	default:
+		reason = "no_output"
+	}
+	manager.NoFirstTokenTotal.WithLabelValues(lw.model, lw.enclave, lw.pool, lw.class, reason).Inc()
 }
 
 // Flush implements http.Flusher
@@ -104,4 +169,192 @@ func (lw *latencyWriter) Push(target string, opts *http.PushOptions) error {
 // Unwrap returns the underlying ResponseWriter (for http.ResponseController)
 func (lw *latencyWriter) Unwrap() http.ResponseWriter {
 	return lw.ResponseWriter
+}
+
+// maxSSEBufferBytes bounds the memory spent buffering one SSE line or one
+// event's joined data while scanning for the first token. Token-bearing
+// delta chunks are tiny; the only frames that plausibly exceed this are
+// control frames that echo the request, like the Responses API's
+// response.created — exactly the events detection must ignore. An overflow
+// therefore skips the event rather than classifying a truncated frame: at
+// worst a pathologically large token event defers detection to the next
+// delta, whereas classifying truncated JSON could resurrect the
+// first-byte-as-first-token bug this scan exists to fix.
+const maxSSEBufferBytes = 64 << 10
+
+// sseTokenDetector incrementally scans an SSE stream, as written to the
+// client, for the first event carrying generated output. It understands
+// Chat Completions and legacy Completions chunks (choices) and Responses
+// API events (typed payloads); everything else — response.created,
+// role-only deltas, usage-only chunks, pings, [DONE] — is control traffic.
+// State is O(1): at most one partial line and one event's data are
+// buffered, both capped at maxSSEBufferBytes.
+type sseTokenDetector struct {
+	line      []byte // partial line carried across Write boundaries
+	data      []byte // joined data: field values of the current event
+	hasData   bool
+	skipLine  bool // current line overflowed; discard bytes to next newline
+	skipEvent bool // current event overflowed; never classify it
+	sawError  bool // stream carried an error event before any token
+}
+
+// feed scans the next chunk of the stream and reports whether it completed
+// an event carrying generated output.
+func (d *sseTokenDetector) feed(p []byte) bool {
+	token := false
+	for len(p) > 0 {
+		nl := bytes.IndexByte(p, '\n')
+		if nl < 0 {
+			d.bufferPartial(p)
+			break
+		}
+		segment := p[:nl]
+		p = p[nl+1:]
+		if d.skipLine {
+			// Tail of an overflowed line: drop it, event stays poisoned.
+			d.skipLine = false
+			continue
+		}
+		line := segment
+		if len(d.line) > 0 {
+			line = append(d.line, segment...)
+			d.line = nil
+		}
+		if len(line) > maxSSEBufferBytes {
+			d.skipEvent = true
+			continue
+		}
+		if d.processLine(line) {
+			token = true
+		}
+	}
+	return token
+}
+
+func (d *sseTokenDetector) bufferPartial(p []byte) {
+	if d.skipLine {
+		return
+	}
+	if len(d.line)+len(p) > maxSSEBufferBytes {
+		d.line = nil
+		d.skipLine = true
+		d.skipEvent = true
+		return
+	}
+	d.line = append(d.line, p...)
+}
+
+// processLine handles one complete SSE line and reports whether it closed
+// an event carrying generated output.
+func (d *sseTokenDetector) processLine(line []byte) bool {
+	line = bytes.TrimSuffix(line, []byte("\r"))
+	if len(line) == 0 {
+		// Blank line: event boundary, classify what accumulated.
+		token := !d.skipEvent && d.hasData && d.classifyEvent(d.data)
+		d.data = nil
+		d.hasData = false
+		d.skipEvent = false
+		return token
+	}
+	value, ok := bytes.CutPrefix(line, []byte("data:"))
+	if !ok {
+		// event:/id:/retry: fields and comment keep-alives carry no
+		// output. The Responses API repeats the event type inside the data
+		// payload, so data alone suffices to classify.
+		return false
+	}
+	if d.skipEvent {
+		return false
+	}
+	value = bytes.TrimPrefix(value, []byte(" "))
+	if len(d.data)+len(value) >= maxSSEBufferBytes {
+		d.data = nil
+		d.hasData = false
+		d.skipEvent = true
+		return false
+	}
+	if d.hasData {
+		// Per the SSE spec, multiple data lines in one event join with \n.
+		d.data = append(d.data, '\n')
+	}
+	d.data = append(d.data, value...)
+	d.hasData = true
+	return false
+}
+
+// streamChunk is the union of the SSE payload shapes the router classifies:
+// Chat/legacy Completions chunks carry choices; Responses API events carry
+// a type plus event-specific fields.
+type streamChunk struct {
+	Type    string          `json:"type"`
+	Delta   json.RawMessage `json:"delta"`
+	Text    string          `json:"text"`
+	Error   json.RawMessage `json:"error"`
+	Choices []struct {
+		Text  string `json:"text"`
+		Delta struct {
+			Content          string          `json:"content"`
+			ReasoningContent string          `json:"reasoning_content"`
+			Reasoning        string          `json:"reasoning"`
+			Refusal          string          `json:"refusal"`
+			ToolCalls        json.RawMessage `json:"tool_calls"`
+			FunctionCall     json.RawMessage `json:"function_call"`
+		} `json:"delta"`
+	} `json:"choices"`
+}
+
+// classifyEvent reports whether one complete SSE event carries generated
+// output, recording error events on the way.
+func (d *sseTokenDetector) classifyEvent(data []byte) bool {
+	if len(data) == 0 || data[0] != '{' {
+		// [DONE] or any other non-object payload is control traffic.
+		return false
+	}
+	var chunk streamChunk
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		return false
+	}
+	if jsonPresent(chunk.Error) {
+		// In-band engine error on a 200 stream (e.g. vLLM aborts).
+		d.sawError = true
+		return false
+	}
+	if chunk.Type != "" { // Responses API event
+		switch {
+		case chunk.Type == "error" || chunk.Type == "response.failed":
+			d.sawError = true
+		case strings.HasSuffix(chunk.Type, ".delta"):
+			// Text, reasoning, refusal, tool-argument, and audio deltas
+			// all carry the payload as a JSON string in the delta field.
+			var delta string
+			if json.Unmarshal(chunk.Delta, &delta) == nil && delta != "" {
+				return true
+			}
+		case chunk.Type == "response.output_text.done":
+			// Safety net for streams that finalize text without deltas.
+			return chunk.Text != ""
+		}
+		return false
+	}
+	for _, choice := range chunk.Choices {
+		if choice.Text != "" || choice.Delta.Content != "" ||
+			choice.Delta.ReasoningContent != "" || choice.Delta.Reasoning != "" ||
+			choice.Delta.Refusal != "" {
+			return true
+		}
+		if nonEmptyJSONArray(choice.Delta.ToolCalls) || jsonPresent(choice.Delta.FunctionCall) {
+			return true
+		}
+	}
+	return false
+}
+
+// jsonPresent reports whether a raw JSON field was present and non-null.
+func jsonPresent(raw json.RawMessage) bool {
+	return len(raw) > 0 && !bytes.Equal(raw, []byte("null"))
+}
+
+func nonEmptyJSONArray(raw json.RawMessage) bool {
+	var arr []json.RawMessage
+	return len(raw) > 0 && json.Unmarshal(raw, &arr) == nil && len(arr) > 0
 }

--- a/latency.go
+++ b/latency.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"mime"
 	"net"
 	"net/http"
 	"strings"
@@ -87,7 +88,7 @@ func (lw *latencyWriter) Write(b []byte) (int, error) {
 		now := lw.now()
 		if lw.last.IsZero() {
 			manager.TTFTSeconds.WithLabelValues(lw.model, lw.class).Observe(now.Sub(lw.start).Seconds())
-			if strings.Contains(lw.Header().Get("Content-Type"), "text/event-stream") {
+			if isEventStream(lw.Header().Get("Content-Type")) {
 				lw.detector = &sseTokenDetector{}
 			}
 		} else {
@@ -106,6 +107,20 @@ func (lw *latencyWriter) Write(b []byte) (int, error) {
 		}
 	}
 	return lw.ResponseWriter.Write(b)
+}
+
+// isEventStream reports whether a Content-Type header declares an SSE body.
+// Media types are case-insensitive (RFC 9110 §8.3.1) and a substring match
+// would also hit unrelated types that merely embed this one, so parse
+// properly: misreading the type silently reverts first-token detection to
+// first-byte semantics. A malformed optional parameter doesn't obscure the
+// type itself, so it doesn't disqualify the stream.
+func isEventStream(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil && !errors.Is(err, mime.ErrInvalidMediaParameter) {
+		return false
+	}
+	return mediaType == "text/event-stream"
 }
 
 func (lw *latencyWriter) observeFirstToken(now time.Time) {

--- a/latency.go
+++ b/latency.go
@@ -49,6 +49,13 @@ type latencyWriter struct {
 	last    time.Time
 	nowFunc func() time.Time
 
+	// observeLegacy feeds the dispatch-scoped TTFTSeconds and
+	// InterTokenSeconds metrics. Only the plain proxy path sets it: those
+	// series predate first-token detection, and widening their population
+	// (e.g. with tool-runtime streams) would silently shift dashboards
+	// that still read them.
+	observeLegacy bool
+
 	detector  *sseTokenDetector // non-nil while scanning an SSE body for the first token
 	tokenSeen bool
 	aborted   bool // ServeHTTP unwound by panic: the proxy aborted mid-stream
@@ -60,6 +67,32 @@ func newLatencyWriter(w http.ResponseWriter, arrival time.Time, model, enclave, 
 		model:          model,
 		enclave:        enclave,
 		pool:           pool,
+		class:          class,
+		arrival:        arrival,
+		start:          time.Now(),
+		observeLegacy:  true,
+	}
+}
+
+// toolRuntimeLabel marks first-token series for requests served by the
+// router's tool loop rather than one proxied replica. The loop may dispatch
+// to several replicas and pools before the first client-visible token, so
+// no single enclave or pool value would be truthful — and the sentinel keeps
+// tool traffic separable from per-replica latencies on dashboards.
+const toolRuntimeLabel = "tool-runtime"
+
+// newToolLatencyWriter observes first-token latency for SSE streams the
+// tool runtime writes to the client. The first client-visible output on
+// this path may be inline tool-progress content rather than model text;
+// both are generated stream output the caller is waiting on, and counting
+// only the final answer would misread a request the user is actively
+// watching as an SLA violation.
+func newToolLatencyWriter(w http.ResponseWriter, arrival time.Time, model, class string) *latencyWriter {
+	return &latencyWriter{
+		ResponseWriter: w,
+		model:          model,
+		enclave:        toolRuntimeLabel,
+		pool:           toolRuntimeLabel,
 		class:          class,
 		arrival:        arrival,
 		start:          time.Now(),
@@ -89,11 +122,13 @@ func (lw *latencyWriter) Write(b []byte) (int, error) {
 	if observe {
 		now = lw.now()
 		if lw.last.IsZero() {
-			manager.TTFTSeconds.WithLabelValues(lw.model, lw.class).Observe(now.Sub(lw.start).Seconds())
+			if lw.observeLegacy {
+				manager.TTFTSeconds.WithLabelValues(lw.model, lw.class).Observe(now.Sub(lw.start).Seconds())
+			}
 			if isEventStream(lw.Header().Get("Content-Type")) {
 				lw.detector = &sseTokenDetector{}
 			}
-		} else {
+		} else if lw.observeLegacy {
 			manager.InterTokenSeconds.WithLabelValues(lw.model, lw.class).Observe(now.Sub(lw.last).Seconds())
 		}
 		lw.last = now

--- a/latency_test.go
+++ b/latency_test.go
@@ -52,6 +52,7 @@ func TestLatencyWriterObservesStreaming(t *testing.T) {
 		class:          "configured",
 		arrival:        now,
 		start:          now,
+		observeLegacy:  true,
 		nowFunc:        func() time.Time { return now },
 	}
 
@@ -85,6 +86,7 @@ func TestLatencyWriterSkipsErrorResponses(t *testing.T) {
 		model:          model,
 		class:          "none",
 		start:          time.Now(),
+		observeLegacy:  true,
 	}
 
 	lw.WriteHeader(502)
@@ -104,6 +106,7 @@ func TestLatencyWriterInformationalThenError(t *testing.T) {
 		model:          model,
 		class:          "none",
 		start:          time.Now(),
+		observeLegacy:  true,
 	}
 
 	lw.WriteHeader(100)
@@ -124,6 +127,7 @@ func TestLatencyWriterInformationalThenSuccess(t *testing.T) {
 		class:          "none",
 		arrival:        time.Now(),
 		start:          time.Now(),
+		observeLegacy:  true,
 	}
 
 	lw.WriteHeader(100)
@@ -144,6 +148,7 @@ func TestLatencyWriterImplicit200(t *testing.T) {
 		class:          "none",
 		arrival:        time.Now(),
 		start:          time.Now(),
+		observeLegacy:  true,
 	}
 
 	// Write without WriteHeader is an implicit 200 and must be observed
@@ -187,6 +192,7 @@ func newSSELatencyWriter(model string, now *time.Time) *latencyWriter {
 		class:          "configured",
 		arrival:        *now,
 		start:          *now,
+		observeLegacy:  true,
 		nowFunc:        func() time.Time { return *now },
 	}
 }
@@ -361,6 +367,7 @@ func TestFirstTokenMeasuresFromArrival(t *testing.T) {
 		class:          "configured",
 		arrival:        t0,
 		start:          now,
+		observeLegacy:  true,
 		nowFunc:        func() time.Time { return now },
 	}
 
@@ -392,6 +399,7 @@ func TestFirstTokenNonSSEBody(t *testing.T) {
 		class:          "configured",
 		arrival:        t0,
 		start:          t0,
+		observeLegacy:  true,
 		nowFunc:        func() time.Time { return now },
 	}
 
@@ -591,6 +599,7 @@ func TestFirstTokenContentTypeParsing(t *testing.T) {
 				class:          "configured",
 				arrival:        t0,
 				start:          t0,
+				observeLegacy:  true,
 				nowFunc:        func() time.Time { return now },
 			}
 
@@ -635,6 +644,7 @@ func TestFirstTokenNotRecordedOnFailedWrite(t *testing.T) {
 		class:          "configured",
 		arrival:        t0,
 		start:          t0,
+		observeLegacy:  true,
 		nowFunc:        func() time.Time { return now },
 	}
 
@@ -674,6 +684,7 @@ func TestFirstTokenIgnoresEmptyWrite(t *testing.T) {
 		class:          "configured",
 		arrival:        t0,
 		start:          t0,
+		observeLegacy:  true,
 		nowFunc:        func() time.Time { return now },
 	}
 
@@ -688,5 +699,61 @@ func TestFirstTokenIgnoresEmptyWrite(t *testing.T) {
 	count, sum := firstTokenState(t, model)
 	if count != 1 || sum < 1.999 || sum > 2.001 {
 		t.Fatalf("expected first token at the first non-empty write (2.0s), got count=%d sum=%v", count, sum)
+	}
+}
+
+func TestToolLatencyWriterObservesFirstTokenOnly(t *testing.T) {
+	// Tool-runtime streams must feed the first-token metrics under the
+	// tool-runtime sentinel labels while leaving the dispatch-scoped legacy
+	// TTFT / inter-token series untouched, so those keep their original
+	// plain-proxy population.
+	const model = "ft-tool-runtime"
+	t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	now := t0
+	rec := httptest.NewRecorder()
+	lw := newToolLatencyWriter(rec, t0, model, "configured")
+	lw.nowFunc = func() time.Time { return now }
+
+	// The tool streamers set the SSE content type themselves before the
+	// first write; mirror that order here.
+	rec.Header().Set("Content-Type", "text/event-stream")
+	lw.WriteHeader(200)
+	now = t0.Add(time.Second)
+	writeChunk(t, lw, "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}]}\n\n")
+	now = t0.Add(3 * time.Second)
+	writeChunk(t, lw, "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"<tinfoil-event>{\\\"status\\\":\\\"in_progress\\\"}</tinfoil-event>\"}}]}\n\n")
+
+	count, sum := histogramState(t, manager.FirstTokenSeconds.WithLabelValues(model, "tool-runtime", "tool-runtime", "configured"))
+	if count != 1 || sum < 2.999 || sum > 3.001 {
+		t.Fatalf("expected one first-token observation of 3.0s under the tool-runtime sentinel, got count=%d sum=%v", count, sum)
+	}
+
+	if ttftCount, _ := histogramState(t, manager.TTFTSeconds.WithLabelValues(model, "configured")); ttftCount != 0 {
+		t.Fatalf("tool-runtime stream must not feed legacy TTFT, got count=%d", ttftCount)
+	}
+	if itlCount, _ := histogramState(t, manager.InterTokenSeconds.WithLabelValues(model, "configured")); itlCount != 0 {
+		t.Fatalf("tool-runtime stream must not feed legacy inter-token gaps, got count=%d", itlCount)
+	}
+}
+
+func TestToolLatencyWriterCountsTokenlessStream(t *testing.T) {
+	const model = "ft-tool-canceled"
+	t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	now := t0
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "text/event-stream")
+	lw := newToolLatencyWriter(rec, t0, model, "none")
+	lw.nowFunc = func() time.Time { return now }
+
+	lw.WriteHeader(200)
+	writeChunk(t, lw, "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}]}\n\n")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	lw.finish(ctx)
+
+	got := counterState(t, manager.NoFirstTokenTotal.WithLabelValues(model, "tool-runtime", "tool-runtime", "none", "canceled"))
+	if got != 1 {
+		t.Fatalf("expected one canceled count under the tool-runtime sentinel, got %v", got)
 	}
 }

--- a/latency_test.go
+++ b/latency_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -605,5 +606,87 @@ func TestFirstTokenContentTypeParsing(t *testing.T) {
 				t.Fatalf("%q: non-SSE body must count its first byte as the first token, got count=%d", tc.contentType, count)
 			}
 		})
+	}
+}
+
+// failingResponseWriter refuses all writes, like a connection whose client
+// has gone away.
+type failingResponseWriter struct{ header http.Header }
+
+func newFailingResponseWriter() *failingResponseWriter {
+	return &failingResponseWriter{header: make(http.Header)}
+}
+
+func (f *failingResponseWriter) Header() http.Header       { return f.header }
+func (f *failingResponseWriter) Write([]byte) (int, error) { return 0, errors.New("connection reset") }
+func (f *failingResponseWriter) WriteHeader(int)           {}
+
+func TestFirstTokenNotRecordedOnFailedWrite(t *testing.T) {
+	const model = "ft-failed-write"
+	t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	now := t0
+	fw := newFailingResponseWriter()
+	fw.Header().Set("Content-Type", "text/event-stream")
+	lw := &latencyWriter{
+		ResponseWriter: fw,
+		model:          model,
+		enclave:        "enclave-1",
+		pool:           "reserved",
+		class:          "configured",
+		arrival:        t0,
+		start:          t0,
+		nowFunc:        func() time.Time { return now },
+	}
+
+	lw.WriteHeader(200)
+	now = t0.Add(time.Second)
+	// The write carrying the token fails: the client never received it.
+	if _, err := lw.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n")); err == nil {
+		t.Fatal("expected the underlying write to fail")
+	}
+	if count, _ := firstTokenState(t, model); count != 0 {
+		t.Fatalf("token on a failed write must not be recorded, got count=%d", count)
+	}
+
+	// The disconnect that failed the write also cancels the request
+	// context; the request must land in the canceled bucket instead.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	lw.finish(ctx)
+	if got := noFirstTokenCount(t, model, "canceled"); got != 1 {
+		t.Fatalf("expected one canceled count, got %v", got)
+	}
+}
+
+func TestFirstTokenIgnoresEmptyWrite(t *testing.T) {
+	// A zero-length write on a plain body delivers nothing and must not
+	// stop the clock; the first non-empty write is the first token.
+	const model = "ft-empty-write"
+	t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	now := t0
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "application/json")
+	lw := &latencyWriter{
+		ResponseWriter: rec,
+		model:          model,
+		enclave:        "enclave-1",
+		pool:           "reserved",
+		class:          "configured",
+		arrival:        t0,
+		start:          t0,
+		nowFunc:        func() time.Time { return now },
+	}
+
+	lw.WriteHeader(200)
+	now = t0.Add(time.Second)
+	writeChunk(t, lw, "")
+	if count, _ := firstTokenState(t, model); count != 0 {
+		t.Fatal("zero-length write counted as first token")
+	}
+	now = t0.Add(2 * time.Second)
+	writeChunk(t, lw, `{"choices":[{"message":{"content":"Hello"}}]}`)
+	count, sum := firstTokenState(t, model)
+	if count != 1 || sum < 1.999 || sum > 2.001 {
+		t.Fatalf("expected first token at the first non-empty write (2.0s), got count=%d sum=%v", count, sum)
 	}
 }

--- a/latency_test.go
+++ b/latency_test.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/tinfoilsh/confidential-model-router/manager"
+	"github.com/tinfoilsh/confidential-model-router/tokencount"
 )
 
 // sinkResponseWriter accepts any write sequence. httptest.ResponseRecorder
@@ -44,6 +49,7 @@ func TestLatencyWriterObservesStreaming(t *testing.T) {
 		ResponseWriter: httptest.NewRecorder(),
 		model:          model,
 		class:          "configured",
+		arrival:        now,
 		start:          now,
 		nowFunc:        func() time.Time { return now },
 	}
@@ -115,6 +121,7 @@ func TestLatencyWriterInformationalThenSuccess(t *testing.T) {
 		ResponseWriter: newSinkResponseWriter(),
 		model:          model,
 		class:          "none",
+		arrival:        time.Now(),
 		start:          time.Now(),
 	}
 
@@ -134,6 +141,7 @@ func TestLatencyWriterImplicit200(t *testing.T) {
 		ResponseWriter: httptest.NewRecorder(),
 		model:          model,
 		class:          "none",
+		arrival:        time.Now(),
 		start:          time.Now(),
 	}
 
@@ -148,9 +156,404 @@ func TestLatencyWriterImplicit200(t *testing.T) {
 
 func TestLatencyWriterForwardsFlush(t *testing.T) {
 	rec := httptest.NewRecorder()
-	lw := newLatencyWriter(rec, "latency-test-flush", "none")
+	lw := newLatencyWriter(rec, time.Now(), "latency-test-flush", "enclave-1", "none", "none")
 	lw.Flush()
 	if !rec.Flushed {
 		t.Fatal("Flush was not forwarded to the underlying writer")
+	}
+}
+
+func counterState(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+	pb := &dto.Metric{}
+	if err := c.Write(pb); err != nil {
+		t.Fatalf("failed to read counter: %v", err)
+	}
+	return pb.GetCounter().GetValue()
+}
+
+// newSSELatencyWriter builds a writer over a recorder that already carries
+// the SSE content type, with time controlled through *now. Labels are fixed
+// so tests only vary the model name.
+func newSSELatencyWriter(model string, now *time.Time) *latencyWriter {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	return &latencyWriter{
+		ResponseWriter: rec,
+		model:          model,
+		enclave:        "enclave-1",
+		pool:           "reserved",
+		class:          "configured",
+		arrival:        *now,
+		start:          *now,
+		nowFunc:        func() time.Time { return *now },
+	}
+}
+
+func writeChunk(t *testing.T, lw *latencyWriter, s string) {
+	t.Helper()
+	if _, err := lw.Write([]byte(s)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func firstTokenState(t *testing.T, model string) (uint64, float64) {
+	t.Helper()
+	return histogramState(t, manager.FirstTokenSeconds.WithLabelValues(model, "enclave-1", "reserved", "configured"))
+}
+
+func noFirstTokenCount(t *testing.T, model, reason string) float64 {
+	t.Helper()
+	return counterState(t, manager.NoFirstTokenTotal.WithLabelValues(model, "enclave-1", "reserved", "configured", reason))
+}
+
+func TestFirstTokenIgnoresChatControlEvents(t *testing.T) {
+	const model = "ft-chat-control"
+	t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	now := t0
+	lw := newSSELatencyWriter(model, &now)
+
+	lw.WriteHeader(200)
+	now = t0.Add(200 * time.Millisecond)
+	writeChunk(t, lw, "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}]}\n\n")
+	now = t0.Add(400 * time.Millisecond)
+	writeChunk(t, lw, ": ping\n\n")
+	now = t0.Add(900 * time.Millisecond)
+	writeChunk(t, lw, "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\n")
+
+	count, sum := firstTokenState(t, model)
+	if count != 1 || sum < 0.899 || sum > 0.901 {
+		t.Fatalf("expected one first-token observation of 0.9s, got count=%d sum=%v", count, sum)
+	}
+
+	// A stream that produced a token must not be counted as token-less.
+	lw.finish(context.Background())
+	if got := noFirstTokenCount(t, model, "no_output"); got != 0 {
+		t.Fatalf("stream with a token counted as no_output: %v", got)
+	}
+}
+
+func TestFirstTokenIgnoresResponsesControlEvents(t *testing.T) {
+	const model = "ft-responses-control"
+	t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	now := t0
+	lw := newSSELatencyWriter(model, &now)
+
+	lw.WriteHeader(200)
+	now = t0.Add(100 * time.Millisecond)
+	writeChunk(t, lw, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"status\":\"in_progress\",\"instructions\":\"be helpful\"}}\n\n")
+	now = t0.Add(150 * time.Millisecond)
+	writeChunk(t, lw, "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_1\"}}\n\n")
+	now = t0.Add(2 * time.Second)
+	writeChunk(t, lw, "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"content\":[]}}\n\n")
+	writeChunk(t, lw, "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"part\":{\"type\":\"output_text\",\"text\":\"\"}}\n\n")
+	now = t0.Add(2500 * time.Millisecond)
+	writeChunk(t, lw, "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"He\"}\n\n")
+
+	count, sum := firstTokenState(t, model)
+	if count != 1 || sum < 2.499 || sum > 2.501 {
+		t.Fatalf("expected one first-token observation of 2.5s, got count=%d sum=%v", count, sum)
+	}
+}
+
+func TestFirstTokenGeneratedShapes(t *testing.T) {
+	// Every event shape that carries generated output must stop the clock.
+	for name, chunk := range map[string]string{
+		"completions text":   "data: {\"choices\":[{\"index\":0,\"text\":\"Hi\"}]}\n\n",
+		"reasoning content":  "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"Th\"}}]}\n\n",
+		"tool calls":         "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}}]}}]}\n\n",
+		"refusal":            "data: {\"choices\":[{\"delta\":{\"refusal\":\"I\"}}]}\n\n",
+		"responses fn args":  "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"lo\"}\n\n",
+		"second choice only": "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\"}},{\"index\":1,\"delta\":{\"content\":\"x\"}}]}\n\n",
+	} {
+		model := "ft-shape-" + strings.ReplaceAll(name, " ", "-")
+		t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+		now := t0
+		lw := newSSELatencyWriter(model, &now)
+		lw.WriteHeader(200)
+		now = t0.Add(time.Second)
+		writeChunk(t, lw, chunk)
+		if count, _ := firstTokenState(t, model); count != 1 {
+			t.Errorf("%s: expected a first-token observation, got count=%d", name, count)
+		}
+	}
+}
+
+func TestFirstTokenSplitAcrossWrites(t *testing.T) {
+	const model = "ft-split"
+	t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	now := t0
+	lw := newSSELatencyWriter(model, &now)
+
+	lw.WriteHeader(200)
+	const event = "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"
+	now = t0.Add(time.Second)
+	writeChunk(t, lw, event[:20])
+	now = t0.Add(3 * time.Second)
+	writeChunk(t, lw, event[20:])
+
+	count, sum := firstTokenState(t, model)
+	if count != 1 || sum < 2.999 || sum > 3.001 {
+		t.Fatalf("split event must observe at completion time, got count=%d sum=%v", count, sum)
+	}
+}
+
+func TestFirstTokenSSESpecEdgeCases(t *testing.T) {
+	// CRLF endings, no space after the colon, and multi-line data joined
+	// per the SSE spec must all classify correctly.
+	d := &sseTokenDetector{}
+	if d.feed([]byte("data:{\"choices\":[{\"delta\":{\"content\":\"\"}}]}\r\n\r\n")) {
+		t.Fatal("empty CRLF delta classified as a token")
+	}
+	if !d.feed([]byte("data:{\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\r\n\r\n")) {
+		t.Fatal("CRLF token event missed")
+	}
+	d = &sseTokenDetector{}
+	if !d.feed([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}]\ndata: }\n\n")) {
+		t.Fatal("multi-line data event missed")
+	}
+}
+
+func TestFirstTokenSkipsOversizedControlFrame(t *testing.T) {
+	const model = "ft-oversize"
+	t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	now := t0
+	lw := newSSELatencyWriter(model, &now)
+	lw.WriteHeader(200)
+
+	// A response.created echoing a huge prompt, exceeding the scan buffer,
+	// delivered across several writes. It must neither classify nor wedge
+	// the detector.
+	huge := "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"instructions\":\"" +
+		strings.Repeat("a", maxSSEBufferBytes+1024) + "\"}}\n\n"
+	now = t0.Add(time.Second)
+	for len(huge) > 0 {
+		n := min(len(huge), 32<<10)
+		writeChunk(t, lw, huge[:n])
+		huge = huge[n:]
+	}
+	if count, _ := firstTokenState(t, model); count != 0 {
+		t.Fatal("oversized control frame classified as a token")
+	}
+
+	now = t0.Add(4 * time.Second)
+	writeChunk(t, lw, "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"He\"}\n\n")
+	count, sum := firstTokenState(t, model)
+	if count != 1 || sum < 3.999 || sum > 4.001 {
+		t.Fatalf("detector did not recover after oversized frame, got count=%d sum=%v", count, sum)
+	}
+}
+
+func TestFirstTokenMeasuresFromArrival(t *testing.T) {
+	// Routing and parsing time before dispatch counts toward first-token
+	// latency (arrival zero point) but not toward the legacy dispatch TTFT.
+	const model = "ft-arrival"
+	t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	now := t0.Add(300 * time.Millisecond) // dispatch 300ms after arrival
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "text/event-stream")
+	lw := &latencyWriter{
+		ResponseWriter: rec,
+		model:          model,
+		enclave:        "enclave-1",
+		pool:           "reserved",
+		class:          "configured",
+		arrival:        t0,
+		start:          now,
+		nowFunc:        func() time.Time { return now },
+	}
+
+	lw.WriteHeader(200)
+	now = t0.Add(time.Second)
+	writeChunk(t, lw, "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n")
+
+	if _, sum := firstTokenState(t, model); sum < 0.999 || sum > 1.001 {
+		t.Fatalf("first token must measure from arrival (want 1.0s), got %v", sum)
+	}
+	if _, sum := histogramState(t, manager.TTFTSeconds.WithLabelValues(model, "configured")); sum < 0.699 || sum > 0.701 {
+		t.Fatalf("legacy TTFT must measure from dispatch (want 0.7s), got %v", sum)
+	}
+}
+
+func TestFirstTokenNonSSEBody(t *testing.T) {
+	// A backend that answers a streaming request with a plain JSON body
+	// delivers the whole generation at once: first byte is first token.
+	const model = "ft-nonsse"
+	t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	now := t0
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "application/json")
+	lw := &latencyWriter{
+		ResponseWriter: rec,
+		model:          model,
+		enclave:        "enclave-1",
+		pool:           "reserved",
+		class:          "configured",
+		arrival:        t0,
+		start:          t0,
+		nowFunc:        func() time.Time { return now },
+	}
+
+	lw.WriteHeader(200)
+	now = t0.Add(1200 * time.Millisecond)
+	writeChunk(t, lw, `{"choices":[{"message":{"content":"Hello"}}]}`)
+
+	count, sum := firstTokenState(t, model)
+	if count != 1 || sum < 1.199 || sum > 1.201 {
+		t.Fatalf("expected one first-token observation of 1.2s, got count=%d sum=%v", count, sum)
+	}
+}
+
+func TestNoFirstTokenReasons(t *testing.T) {
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	expiredCtx, cancelExpired := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancelExpired()
+
+	for _, tc := range []struct {
+		name   string
+		reason string
+		ctx    context.Context
+		drive  func(t *testing.T, lw *latencyWriter)
+	}{
+		{
+			name:   "client canceled before token",
+			reason: "canceled",
+			ctx:    canceledCtx,
+			drive: func(t *testing.T, lw *latencyWriter) {
+				lw.WriteHeader(200)
+				writeChunk(t, lw, "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}]}\n\n")
+			},
+		},
+		{
+			name:   "request deadline expired",
+			reason: "timeout",
+			ctx:    expiredCtx,
+			drive: func(t *testing.T, lw *latencyWriter) {
+				lw.WriteHeader(200)
+			},
+		},
+		{
+			name:   "backend HTTP error",
+			reason: "error",
+			ctx:    context.Background(),
+			drive: func(t *testing.T, lw *latencyWriter) {
+				lw.WriteHeader(502)
+				writeChunk(t, lw, `{"error":{"message":"bad gateway"}}`)
+			},
+		},
+		{
+			name:   "in-stream error event",
+			reason: "error",
+			ctx:    context.Background(),
+			drive: func(t *testing.T, lw *latencyWriter) {
+				lw.WriteHeader(200)
+				writeChunk(t, lw, "data: {\"error\":{\"message\":\"engine overloaded\",\"code\":503}}\n\n")
+				writeChunk(t, lw, "data: [DONE]\n\n")
+			},
+		},
+		{
+			name:   "proxy aborted mid-stream",
+			reason: "error",
+			ctx:    context.Background(),
+			drive: func(t *testing.T, lw *latencyWriter) {
+				lw.WriteHeader(200)
+				writeChunk(t, lw, "event: response.created\ndata: {\"type\":\"response.created\"}\n\n")
+				lw.aborted = true
+			},
+		},
+		{
+			name:   "stream ended with no output",
+			reason: "no_output",
+			ctx:    context.Background(),
+			drive: func(t *testing.T, lw *latencyWriter) {
+				lw.WriteHeader(200)
+				writeChunk(t, lw, "data: {\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"total_tokens\":10}}\n\n")
+				writeChunk(t, lw, "data: [DONE]\n\n")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			model := "ft-" + strings.ReplaceAll(tc.name, " ", "-")
+			t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+			now := t0
+			lw := newSSELatencyWriter(model, &now)
+			tc.drive(t, lw)
+			lw.finish(tc.ctx)
+
+			if got := noFirstTokenCount(t, model, tc.reason); got != 1 {
+				t.Fatalf("expected one %q count, got %v", tc.reason, got)
+			}
+			if count, _ := firstTokenState(t, model); count != 0 {
+				t.Fatalf("token-less stream must not observe first-token latency, got count=%d", count)
+			}
+		})
+	}
+}
+
+// TestFirstTokenThroughStreamingExtractor pins the integration with the
+// tokencount extractor, which sits between the backend and the latency
+// writer in the real proxy chain and re-chunks the SSE stream one line per
+// write (with usage-only chunks filtered out). Detection must fire on the
+// token event under that chunking, not on the control frames around it.
+func TestFirstTokenThroughStreamingExtractor(t *testing.T) {
+	const model = "ft-extractor"
+	backendSSE := "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}]}\n\n" +
+		": keep-alive\n\n" +
+		"data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\n" +
+		"data: {\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":1,\"total_tokens\":4}}\n\n" +
+		"data: [DONE]\n\n"
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(backendSSE)),
+	}
+	newBody, _, err := tokencount.ExtractTokensFromResponseWithHandler(resp, model, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer newBody.Close()
+
+	t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	now := t0
+	lw := newSSELatencyWriter(model, &now)
+	lw.WriteHeader(200)
+
+	// Copy the extractor's output the way the reverse proxy does — one
+	// Write per Read — advancing the clock 10ms per chunk.
+	var tokenLineAt time.Time
+	buf := make([]byte, 32<<10)
+	for {
+		n, readErr := newBody.Read(buf)
+		if n > 0 {
+			now = now.Add(10 * time.Millisecond)
+			if bytes.Contains(buf[:n], []byte("Hello")) {
+				tokenLineAt = now
+			}
+			writeChunk(t, lw, string(buf[:n]))
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+	}
+	if tokenLineAt.IsZero() {
+		t.Fatal("token line never reached the writer")
+	}
+
+	// The event terminator may land in the write after the token line, so
+	// allow detection there, but never on an earlier (control) write and
+	// never later.
+	count, sum := firstTokenState(t, model)
+	if count != 1 {
+		t.Fatalf("expected one first-token observation, got %d", count)
+	}
+	earliest := tokenLineAt.Sub(t0).Seconds()
+	latest := tokenLineAt.Add(10 * time.Millisecond).Sub(t0).Seconds()
+	if sum < earliest-0.0001 || sum > latest+0.0001 {
+		t.Fatalf("first token observed at %vs, want within [%v, %v]", sum, earliest, latest)
 	}
 }

--- a/latency_test.go
+++ b/latency_test.go
@@ -557,3 +557,53 @@ func TestFirstTokenThroughStreamingExtractor(t *testing.T) {
 		t.Fatalf("first token observed at %vs, want within [%v, %v]", sum, earliest, latest)
 	}
 }
+
+func TestFirstTokenContentTypeParsing(t *testing.T) {
+	// Media types are case-insensitive (RFC 9110 §8.3.1): every spelling of
+	// text/event-stream must engage SSE token detection, so a control frame
+	// is not counted as a token, while a type that merely embeds the string
+	// must take the non-SSE path, where the first byte is the first token.
+	const controlFrame = "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}]}\n\n"
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		sse         bool
+	}{
+		{"canonical-with-params", "text/event-stream; charset=utf-8", true},
+		{"mixed-case", "Text/Event-Stream", true},
+		{"upper-case-with-params", "TEXT/EVENT-STREAM;CHARSET=UTF-8", true},
+		{"malformed-parameter", "text/event-stream; charset", true},
+		{"embeds-the-substring", "text/event-stream-json", false},
+		{"plain-json", "application/json", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			model := "ft-ctype-" + tc.name
+			t0 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+			now := t0
+			rec := httptest.NewRecorder()
+			rec.Header().Set("Content-Type", tc.contentType)
+			lw := &latencyWriter{
+				ResponseWriter: rec,
+				model:          model,
+				enclave:        "enclave-1",
+				pool:           "reserved",
+				class:          "configured",
+				arrival:        t0,
+				start:          t0,
+				nowFunc:        func() time.Time { return now },
+			}
+
+			lw.WriteHeader(200)
+			now = t0.Add(time.Second)
+			writeChunk(t, lw, controlFrame)
+
+			count, _ := firstTokenState(t, model)
+			if tc.sse && count != 0 {
+				t.Fatalf("%q: control frame counted as first token, detector not engaged", tc.contentType)
+			}
+			if !tc.sse && count != 1 {
+				t.Fatalf("%q: non-SSE body must count its first byte as the first token, got count=%d", tc.contentType, count)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -476,6 +476,12 @@ func main() {
 	cacheRouteShadow := em.CacheRouteShadow()
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Timestamp arrival before any parsing or routing: the first-token
+		// SLA is measured from the edge of the router, so time spent on
+		// body handling, route-context lookups, and replica selection is
+		// part of what it reports.
+		requestStart := time.Now()
+
 		if !limitRequestBody(w, r) {
 			return
 		}
@@ -869,7 +875,7 @@ func main() {
 				jsonError(w, manager.ErrMsgModelNotFound, manager.ErrTypeInvalidRequest, http.StatusNotFound)
 				return
 			}
-			mode, err := saltProxiedBody(r, apiKey, *cacheSaltEnabled)
+			mode, streamRequested, err := saltProxiedBody(r, apiKey, *cacheSaltEnabled)
 			if err != nil {
 				var tooLarge *http.MaxBytesError
 				if errors.As(err, &tooLarge) {
@@ -879,6 +885,9 @@ func main() {
 				jsonError(w, fmt.Sprintf("Invalid request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 				return
 			}
+			// Subdomain-routed streams must feed the same SLA metrics as
+			// path-routed ones; this is the only place their body is parsed.
+			isStreaming = streamRequested
 			recordCacheSaltInjection(modelName, mode)
 		}
 
@@ -944,21 +953,23 @@ func main() {
 		}
 
 		// Meter landing pools on reserved models; poolSpill is only
-		// non-nil for reserved callers.
+		// non-nil for reserved callers. Models without reservations have
+		// no pool concept and carry "none" on the SLA metrics.
+		poolLabel := "none"
 		if poolPrimary != nil && !overloaded {
-			pool := "shared"
+			poolLabel = "shared"
 			if poolSpill != nil {
 				if poolPrimary[enclave.String()] {
-					pool = "reserved"
+					poolLabel = "reserved"
 				} else {
-					pool = "spilled"
+					poolLabel = "spilled"
 					log.WithFields(log.Fields{
 						"model":   modelName,
 						"enclave": enclave.String(),
 					}).Debug("reserved pool exhausted; spilling to shared pool")
 				}
 			}
-			manager.ReservedPoolServesTotal.WithLabelValues(modelName, pool).Inc()
+			manager.ReservedPoolServesTotal.WithLabelValues(modelName, poolLabel).Inc()
 		}
 
 		if overloaded {
@@ -1008,11 +1019,22 @@ func main() {
 			r = r.WithContext(manager.WithProbeClaim(r.Context(), probeClaim))
 		}
 
-		rw := http.ResponseWriter(w)
 		if isStreaming && latencyMetricPaths[r.URL.Path] {
-			rw = newLatencyWriter(w, modelName, priorityClass(hasConfiguredPriority))
+			lw := newLatencyWriter(w, requestStart, modelName, enclave.String(), poolLabel, priorityClass(hasConfiguredPriority))
+			// finish must run via defer: a backend that dies mid-stream
+			// unwinds ServeHTTP with http.ErrAbortHandler, and that request
+			// must still be counted as failed-before-first-token. served
+			// distinguishes that unwind from a normal return.
+			served := false
+			defer func() {
+				lw.aborted = !served
+				lw.finish(r.Context())
+			}()
+			enclave.ServeHTTP(lw, r)
+			served = true
+			return
 		}
-		enclave.ServeHTTP(rw, r)
+		enclave.ServeHTTP(w, r)
 	})
 
 	// Setup graceful shutdown

--- a/main.go
+++ b/main.go
@@ -831,13 +831,30 @@ func main() {
 				r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 				if len(activeProfiles) > 0 || hasAutoContinueTools {
-					if err := toolruntime.Handle(w, r, em, activeProfiles, body, modelName, routerOpts); err != nil {
+					// Streaming tool requests feed the same first-token SLA
+					// metrics as plain proxied streams. The loop may dispatch
+					// to several replicas and pools before the first
+					// client-visible token, so enclave and pool carry the
+					// tool-runtime sentinel; the deferred finish still counts
+					// requests that end token-less, including a panic unwind.
+					tw := http.ResponseWriter(w)
+					toolServed := false
+					if isStreaming && latencyMetricPaths[r.URL.Path] {
+						lw := newToolLatencyWriter(w, requestStart, modelName, priorityClass(hasConfiguredPriority))
+						tw = lw
+						defer func() {
+							lw.aborted = !toolServed
+							lw.finish(r.Context())
+						}()
+					}
+					if err := toolruntime.Handle(tw, r, em, activeProfiles, body, modelName, routerOpts); err != nil {
 						log.WithError(err).WithFields(log.Fields{
 							"model": modelName,
 							"path":  r.URL.Path,
 						}).Error("tool runtime failed")
-						jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusBadGateway)
+						jsonError(tw, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusBadGateway)
 					}
+					toolServed = true
 					return
 				}
 

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -25,15 +25,46 @@ var (
 		[]string{"model"},
 	)
 
-	// TTFTSeconds tracks time to first response body byte for streaming
-	// requests, split by caller priority class for SLA tracking
+	// TTFTSeconds tracks time from backend dispatch to the first response
+	// body byte, split by caller priority class. The first byte is usually
+	// an SSE control frame (e.g. response.created), not a generated token,
+	// so this understates real first-token latency — dashboards should use
+	// FirstTokenSeconds; this series is kept for continuity.
 	TTFTSeconds = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "router_ttft_seconds",
-			Help:    "Time to first response body byte for streaming requests",
+			Help:    "Time to first response body byte for streaming requests (first byte, not first token; see router_first_token_seconds)",
 			Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 7.5, 10, 15, 30, 60},
 		},
 		[]string{"model", "priority"},
+	)
+
+	// FirstTokenSeconds tracks time from request arrival at the router to
+	// the first generated token written to the client. SSE control frames
+	// (response.created, role-only deltas, pings) do not stop the clock;
+	// only an event carrying generated output does. Requests that end
+	// before producing one are counted in NoFirstTokenTotal instead, so
+	// this histogram only ever contains real token latencies.
+	FirstTokenSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "router_first_token_seconds",
+			Help:    "Time from request arrival at the router to the first generated (non-control) streamed token sent to the client",
+			Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 7.5, 10, 15, 30, 60, 120},
+		},
+		[]string{"model", "enclave", "pool", "priority"},
+	)
+
+	// NoFirstTokenTotal counts streaming requests that ended before a first
+	// generated token was sent. Reasons: canceled (client disconnected),
+	// timeout (request deadline expired), error (HTTP error response,
+	// in-stream error event, or mid-stream abort), no_output (stream
+	// finished cleanly without generated output).
+	NoFirstTokenTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_no_first_token_total",
+			Help: "Streaming requests that ended before the first generated token was sent, by reason",
+		},
+		[]string{"model", "enclave", "pool", "priority", "reason"},
 	)
 
 	// InterTokenSeconds tracks gaps between streamed response chunks,

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -44,7 +44,10 @@ var (
 	// (response.created, role-only deltas, pings) do not stop the clock;
 	// only an event carrying generated output does. Requests that end
 	// before producing one are counted in NoFirstTokenTotal instead, so
-	// this histogram only ever contains real token latencies.
+	// this histogram only ever contains real token latencies. Requests
+	// served by the router's tool loop carry the "tool-runtime" sentinel
+	// in enclave and pool: the loop may touch several replicas before the
+	// first client-visible token, so no single value would be truthful.
 	FirstTokenSeconds = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "router_first_token_seconds",


### PR DESCRIPTION
This adds a `router_first_token_seconds` histogram measuring streaming latency from request arrival at the router to the first SSE event carrying generated output, labeled by model, enclave, and reserved/spillover pool — unlike `router_ttft_seconds`, which stops at the first body byte and is usually satisfied by a control frame like `response.created` long before any token exists. The latency writer now scans the outgoing stream incrementally (O(1) buffering, oversized control frames skipped rather than classified) and recognizes generated output across Chat Completions, legacy Completions, and Responses API event shapes; requests that end before producing a token are excluded from the histogram and counted separately in `router_no_first_token_total` by reason (`canceled`, `timeout`, `error`, `no_output`), so the histogram only ever contains real token latencies. Subdomain-routed streaming requests, previously invisible to latency metrics, now feed the same instrumentation, and the legacy first-byte metric is left unchanged so existing dashboards keep working until they migrate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds precise first-token latency for streaming responses, measured from request arrival to the first generated token. Subdomain- and tool-runtime streams are included; legacy first-byte metrics remain for continuity.

- **New Features**
  - Added Prometheus `router_first_token_seconds` labeled by model, enclave, pool, and priority.
  - Incremental SSE scan detects the first generated output and ignores control frames; supports Chat Completions, legacy Completions, and Responses API.
  - Streams that end before a token are excluded and counted in `router_no_first_token_total` by reason (`canceled`, `timeout`, `error`, `no_output`).
  - First-token clocks from request arrival; `router_ttft_seconds` and inter-chunk gap metrics are unchanged.
  - Subdomain routing surfaces `stream` via `saltProxiedBody`, so these requests feed the same metrics; SLA metrics include pool (`reserved`, `spilled`, `shared`, `none`).
  - Tool-runtime streams now feed first-token metrics with `enclave`/`pool` set to `tool-runtime`; legacy `router_ttft_seconds`/inter-chunk metrics are not observed on this path.

- **Bug Fixes**
  - Parse `Content-Type` with `mime.ParseMediaType` to detect SSE case-insensitively and avoid substring false-positives.
  - Only record a first token after the underlying write succeeds; zero-length writes on non-SSE bodies are ignored. Failed token writes are now counted in `router_no_first_token_total` under `canceled`/`error` as appropriate.

<sup>Written for commit 1dceedd98e56cdbc820abdcb6a92ad6581143381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

