### PR TITLE
feat: add per-replica TTFT metric

### DIFF
--- a/latency.go
+++ b/latency.go
@@ -49,11 +49,11 @@ type latencyWriter struct {
 	last    time.Time
 	nowFunc func() time.Time
 
-	// observeLegacy feeds the dispatch-scoped TTFTSeconds and
-	// InterTokenSeconds metrics. Only the plain proxy path sets it: those
-	// series predate first-token detection, and widening their population
-	// (e.g. with tool-runtime streams) would silently shift dashboards
-	// that still read them.
+	// observeLegacy feeds the dispatch-scoped TTFTSeconds,
+	// ReplicaTTFTSeconds, and InterTokenSeconds metrics. Only the plain proxy
+	// path sets it: those series predate first-token detection, and widening
+	// their population (e.g. with tool-runtime streams) would silently shift
+	// dashboards that still read them.
 	observeLegacy bool
 
 	detector  *sseTokenDetector // non-nil while scanning an SSE body for the first token
@@ -123,7 +123,9 @@ func (lw *latencyWriter) Write(b []byte) (int, error) {
 		now = lw.now()
 		if lw.last.IsZero() {
 			if lw.observeLegacy {
-				manager.TTFTSeconds.WithLabelValues(lw.model, lw.class).Observe(now.Sub(lw.start).Seconds())
+				ttft := now.Sub(lw.start).Seconds()
+				manager.TTFTSeconds.WithLabelValues(lw.model, lw.class).Observe(ttft)
+				manager.ReplicaTTFTSeconds.WithLabelValues(lw.model, lw.enclave, lw.pool, lw.class).Observe(ttft)
 			}
 			if isEventStream(lw.Header().Get("Content-Type")) {
 				lw.detector = &sseTokenDetector{}

--- a/latency_test.go
+++ b/latency_test.go
@@ -49,6 +49,8 @@ func TestLatencyWriterObservesStreaming(t *testing.T) {
 	lw := &latencyWriter{
 		ResponseWriter: httptest.NewRecorder(),
 		model:          model,
+		enclave:        "enclave-1",
+		pool:           "reserved",
 		class:          "configured",
 		arrival:        now,
 		start:          now,
@@ -73,6 +75,10 @@ func TestLatencyWriterObservesStreaming(t *testing.T) {
 	if ttftCount != 1 || ttftSum != 0.5 {
 		t.Fatalf("expected one TTFT observation of 0.5s, got count=%d sum=%v", ttftCount, ttftSum)
 	}
+	replicaTTFTCount, replicaTTFTSum := histogramState(t, manager.ReplicaTTFTSeconds.WithLabelValues(model, "enclave-1", "reserved", "configured"))
+	if replicaTTFTCount != 1 || replicaTTFTSum != 0.5 {
+		t.Fatalf("expected one per-replica TTFT observation of 0.5s, got count=%d sum=%v", replicaTTFTCount, replicaTTFTSum)
+	}
 	itlCount, itlSum := histogramState(t, manager.InterTokenSeconds.WithLabelValues(model, "configured"))
 	if itlCount != 3 || itlSum < 0.0599 || itlSum > 0.0601 {
 		t.Fatalf("expected three 20ms inter-token observations, got count=%d sum=%v", itlCount, itlSum)
@@ -84,6 +90,8 @@ func TestLatencyWriterSkipsErrorResponses(t *testing.T) {
 	lw := &latencyWriter{
 		ResponseWriter: httptest.NewRecorder(),
 		model:          model,
+		enclave:        "enclave-1",
+		pool:           "shared",
 		class:          "none",
 		start:          time.Now(),
 		observeLegacy:  true,
@@ -96,6 +104,9 @@ func TestLatencyWriterSkipsErrorResponses(t *testing.T) {
 
 	if count, _ := histogramState(t, manager.TTFTSeconds.WithLabelValues(model, "none")); count != 0 {
 		t.Fatalf("error response must not observe TTFT, got count=%d", count)
+	}
+	if count, _ := histogramState(t, manager.ReplicaTTFTSeconds.WithLabelValues(model, "enclave-1", "shared", "none")); count != 0 {
+		t.Fatalf("error response must not observe per-replica TTFT, got count=%d", count)
 	}
 }
 
@@ -380,6 +391,9 @@ func TestFirstTokenMeasuresFromArrival(t *testing.T) {
 	}
 	if _, sum := histogramState(t, manager.TTFTSeconds.WithLabelValues(model, "configured")); sum < 0.699 || sum > 0.701 {
 		t.Fatalf("legacy TTFT must measure from dispatch (want 0.7s), got %v", sum)
+	}
+	if _, sum := histogramState(t, manager.ReplicaTTFTSeconds.WithLabelValues(model, "enclave-1", "reserved", "configured")); sum < 0.699 || sum > 0.701 {
+		t.Fatalf("per-replica TTFT must measure from dispatch (want 0.7s), got %v", sum)
 	}
 }
 
@@ -730,6 +744,9 @@ func TestToolLatencyWriterObservesFirstTokenOnly(t *testing.T) {
 
 	if ttftCount, _ := histogramState(t, manager.TTFTSeconds.WithLabelValues(model, "configured")); ttftCount != 0 {
 		t.Fatalf("tool-runtime stream must not feed legacy TTFT, got count=%d", ttftCount)
+	}
+	if ttftCount, _ := histogramState(t, manager.ReplicaTTFTSeconds.WithLabelValues(model, "tool-runtime", "tool-runtime", "configured")); ttftCount != 0 {
+		t.Fatalf("tool-runtime stream must not feed per-replica TTFT, got count=%d", ttftCount)
 	}
 	if itlCount, _ := histogramState(t, manager.InterTokenSeconds.WithLabelValues(model, "configured")); itlCount != 0 {
 		t.Fatalf("tool-runtime stream must not feed legacy inter-token gaps, got count=%d", itlCount)

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -39,6 +39,19 @@ var (
 		[]string{"model", "priority"},
 	)
 
+	// ReplicaTTFTSeconds mirrors TTFTSeconds with the selected enclave and
+	// landing pool attached. It intentionally keeps the same dispatch-scoped
+	// first-response-write semantics so the aggregate and per-replica views
+	// remain directly comparable.
+	ReplicaTTFTSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "router_replica_ttft_seconds",
+			Help:    "Time to first response body byte for streaming requests, by selected enclave and landing pool",
+			Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 7.5, 10, 15, 30, 60},
+		},
+		[]string{"model", "enclave", "pool", "priority"},
+	)
+
 	// FirstTokenSeconds tracks time from request arrival at the router to
 	// the first generated token written to the client. SSE control frames
 	// (response.created, role-only deltas, pings) do not stop the clock;


### PR DESCRIPTION
Adds a per-replica first-response-write latency histogram labeled by enclave and pool.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-replica TTFT metric to track time-to-first-byte by enclave and pool. Uses the same dispatch-scoped semantics as legacy TTFT for easy comparison.

- **New Features**
  - New histogram `router_replica_ttft_seconds` (`manager.ReplicaTTFTSeconds`) labeled by `model`, `enclave`, `pool`, `priority`.
  - Recorded on first response byte in the plain proxy path (`observeLegacy`), matching `TTFTSeconds` semantics.
  - Skips error responses and tool-runtime streams to avoid shifting existing dashboards.
  - Tests added for streaming, error paths, and dispatch-based timing.

<sup>Written for commit d62c3e809fee27f723e93f94c5a166296bedc149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

