### PR TITLE
Fix stall on enclave network fetch

### DIFF
--- a/manager/addenclave_test.go
+++ b/manager/addenclave_test.go
@@ -1,0 +1,71 @@
+package manager
+
+import (
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blackholeListener returns the address of a TCP listener that accepts
+// connections at the kernel level but never completes a TLS handshake —
+// standing in for a host whose inbound packets are being dropped.
+func blackholeListener(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	return ln.Addr().String()
+}
+
+func shortVerifyTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	old := enclaveVerifyTimeout
+	enclaveVerifyTimeout = d
+	t.Cleanup(func() { enclaveVerifyTimeout = old })
+}
+
+// Regression test to avoid  model-wide routing freeze: while addEnclave is
+// blocked on network I/O to an unresponsive host, the model lock must remain
+// available to request routing.
+func TestAddEnclaveNetworkIODoesNotHoldModelLock(t *testing.T) {
+	shortVerifyTimeout(t, 2*time.Second)
+	addr := blackholeListener(t)
+
+	model := &Model{Enclaves: map[string]*Enclave{}}
+	em := &EnclaveManager{models: &sync.Map{}}
+	em.models.Store("test-model", model)
+
+	done := make(chan error, 1)
+	go func() { done <- em.addEnclave("test-model", addr, nil) }()
+
+	// Let addEnclave reach its network call, then verify the write lock —
+	// the strictest form of "routing can proceed" — is acquirable.
+	time.Sleep(100 * time.Millisecond)
+	locked := make(chan struct{})
+	go func() {
+		model.mu.Lock()
+		if len(model.Enclaves) != 0 {
+			t.Error("enclave inserted before verification completed")
+		}
+		model.mu.Unlock()
+		close(locked)
+	}()
+	select {
+	case <-locked:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("model lock held while addEnclave was blocked on network I/O")
+	}
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "attestation") {
+			t.Fatalf("expected attestation fetch error, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("addEnclave did not return after verify timeout")
+	}
+}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -230,10 +230,10 @@ func (em *EnclaveManager) GetRateLimitConfig(modelName string) *config.RateLimit
 	return model.RateLimit
 }
 
-// Bound network steps of enclave verification.
-const enclaveVerifyTimeout = 10 * time.Second
+// Bound network steps of enclave verification. Var for tests
+var enclaveVerifyTimeout = 10 * time.Second
 
-// attestation.TLSPublicKey, but dial & handshake are bounded w/ a timeout
+// attestation.TLSPublicKey, but dial & handshake are bounded w/ a timeout.
 func tlsPublicKeyFP(host string) (string, error) {
 	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: enclaveVerifyTimeout}, "tcp", host+":443", &tls.Config{})
 	if err != nil {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -2,10 +2,12 @@ package manager
 
 import (
 	"context"
+	"crypto/tls"
 	_ "embed"
 	"encoding/json"
 	"fmt"
 	"math/rand/v2"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -228,6 +230,19 @@ func (em *EnclaveManager) GetRateLimitConfig(modelName string) *config.RateLimit
 	return model.RateLimit
 }
 
+// Bound network steps of enclave verification.
+const enclaveVerifyTimeout = 10 * time.Second
+
+// attestation.TLSPublicKey, but dial & handshake are bounded w/ a timeout
+func tlsPublicKeyFP(host string) (string, error) {
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: enclaveVerifyTimeout}, "tcp", host+":443", &tls.Config{})
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	return attestation.ConnectionCertFP(conn.ConnectionState())
+}
+
 // attestationFetch retrieves the attestation document from a given enclave hostname.
 // This is a local implementation that disables HTTP connection pooling to prevent
 // certificate validation errors when multiple hostnames (e.g., router.inf4.tinfoil.sh
@@ -240,6 +255,7 @@ func attestationFetch(host string) (*attestation.Document, error) {
 	u.Path = "/.well-known/tinfoil-attestation"
 
 	httpClient := &http.Client{
+		Timeout: enclaveVerifyTimeout,
 		Transport: &http.Transport{
 			DisableKeepAlives: true, // Prevents connection reuse across different hostnames
 		},
@@ -268,14 +284,18 @@ func (em *EnclaveManager) addEnclave(
 		return fmt.Errorf("model %s not found", modelName)
 	}
 
-	model.mu.Lock()
-	defer model.mu.Unlock()
-
 	// If the enclave already exists and the TLS key fingerprint is the same, do nothing
+	// Take read lock only for this short check, don't hold it during network I/O below
+	model.mu.RLock()
 	currentEnclave, exists := model.Enclaves[host]
+	var currentFP string
 	if exists {
-		realTLSKeyFP, err := attestation.TLSPublicKey(host, false)
-		if err == nil && currentEnclave.tlsKeyFP == realTLSKeyFP {
+		currentFP = currentEnclave.tlsKeyFP
+	}
+	model.mu.RUnlock()
+	if exists {
+		realTLSKeyFP, err := tlsPublicKeyFP(host)
+		if err == nil && currentFP == realTLSKeyFP {
 			log.Debugf("enclave %s already exists and TLS key fingerprint is the same, skipping", host)
 			return nil
 		}
@@ -295,6 +315,9 @@ func (em *EnclaveManager) addEnclave(
 			return fmt.Errorf("failed to verify hardware measurements: %v", err)
 		}
 	}
+
+	model.mu.Lock()
+	defer model.mu.Unlock()
 
 	// Validate that the enclave's attested measurement matches the model's source measurement
 	// SECURITY: This check is critical - it ensures the enclave runs the expected code


### PR DESCRIPTION
We were holding the model lock for the whole enclave network fetch - attest, fingerprint, etc. with no timeout. This meant that if an enclave decided to be slow to respond it could shut down any routing. Added a timeout & also stopped holding the lock during the network call
also a teensie tiny regression test
