### PR TITLE
cacheroute: per-reuse-class usage token counters

### DIFF
--- a/cacheroute/metrics.go
+++ b/cacheroute/metrics.go
@@ -48,6 +48,26 @@ var (
 		[]string{"model", "outcome"},
 	)
 
+	// UsagePromptTokensTotal and UsageCachedPromptTokensTotal weight
+	// ReuseTotal by engine-reported usage, recorded at response time via
+	// RecordUsage. cached/prompt per outcome is the measured token hit
+	// rate of warm- vs cold-landed traffic — the number that sizes what
+	// enforcement would save.
+	UsagePromptTokensTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_cache_route_usage_prompt_tokens_total",
+			Help: "Engine-reported prompt tokens of keyed requests by prefix-reuse classification (first_seen, repeat_warm, repeat_cold)",
+		},
+		[]string{"model", "outcome"},
+	)
+	UsageCachedPromptTokensTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_cache_route_usage_cached_prompt_tokens_total",
+			Help: "Engine-reported cached prompt tokens of keyed requests by prefix-reuse classification (first_seen, repeat_warm, repeat_cold)",
+		},
+		[]string{"model", "outcome"},
+	)
+
 	// PicksTotal counts the would-be pick per enclave, with the key's
 	// replication factor at pick time. Requests served from outside the
 	// ranked membership (breaker probes) are excluded, so this is also the

--- a/cacheroute/shadow.go
+++ b/cacheroute/shadow.go
@@ -191,22 +191,27 @@ func (s *Shadow) Decide(model string, req *Request, pool Pool, cfg Settings) (d 
 // selector has picked a replica: classify the request against the table,
 // compute the would-be pick, update state, increment metrics. It must never
 // affect the request — panics are recovered into OutcomeError.
-func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost string, cfg Settings) {
-	s.observe(model, req, pool, actualHost, nil, cfg)
+//
+// It returns the reuse classification (ReuseFirstSeen, ReuseRepeatWarm,
+// ReuseRepeatCold), or "" when the request was not keyed or the pool was too
+// small, so the caller can attribute engine-reported usage via RecordUsage.
+func (s *Shadow) Observe(model string, req *Request, pool Pool, actualHost string, cfg Settings) string {
+	return s.observe(model, req, pool, actualHost, nil, cfg)
 }
 
 // ObserveLanding records the landing of a dispatch routed by d, reusing the
 // decision's pool snapshot and ranking so the metrics describe the decision
 // that was actually made.
-func (s *Shadow) ObserveLanding(model string, req *Request, d *Decision, actualHost string, cfg Settings) {
-	s.observe(model, req, d.pool, actualHost, d, cfg)
+func (s *Shadow) ObserveLanding(model string, req *Request, d *Decision, actualHost string, cfg Settings) string {
+	return s.observe(model, req, d.pool, actualHost, d, cfg)
 }
 
-func (s *Shadow) observe(model string, req *Request, pool Pool, actualHost string, d *Decision, cfg Settings) {
+func (s *Shadow) observe(model string, req *Request, pool Pool, actualHost string, d *Decision, cfg Settings) (reuse string) {
 	start := time.Now()
 	defer func() {
 		if r := recover(); r != nil {
 			RequestsTotal.WithLabelValues(model, string(OutcomeError)).Inc()
+			reuse = ""
 		}
 		var elapsed time.Duration
 		if req != nil {
@@ -234,6 +239,7 @@ func (s *Shadow) observe(model string, req *Request, pool Pool, actualHost strin
 	}
 
 	res := s.observeKeyed(model, req.Key, pool.Candidates, actualHost, d, cfg)
+	reuse = res.reuse
 
 	RequestsTotal.WithLabelValues(model, string(OutcomeKeyed)).Inc()
 	ReuseTotal.WithLabelValues(model, res.reuse).Inc()
@@ -266,6 +272,7 @@ func (s *Shadow) observe(model string, req *Request, pool Pool, actualHost strin
 	if res.pick == actualHost {
 		RandomMatchTotal.WithLabelValues(model).Inc()
 	}
+	return
 }
 
 // peekRate reads a key's current request rate without recording an arrival.

--- a/cacheroute/usage.go
+++ b/cacheroute/usage.go
@@ -1,0 +1,31 @@
+package cacheroute
+
+import "context"
+
+// reuseKey carries a request's reuse classification from the routing
+// decision to response-time usage extraction. Only the classification
+// travels — never the routing key or any per-key state.
+type reuseKey struct{}
+
+type reuseValue struct {
+	model string
+	reuse string
+}
+
+// WithReuse returns a context carrying the request's reuse classification
+// for RecordUsage.
+func WithReuse(ctx context.Context, model, reuse string) context.Context {
+	return context.WithValue(ctx, reuseKey{}, reuseValue{model: model, reuse: reuse})
+}
+
+// RecordUsage adds engine-reported token counts to the reuse-classified
+// usage counters. A context without a classification (request not keyed,
+// or the shadow pipeline didn't run) is a no-op.
+func RecordUsage(ctx context.Context, promptTokens, cachedPromptTokens int) {
+	v, ok := ctx.Value(reuseKey{}).(reuseValue)
+	if !ok {
+		return
+	}
+	UsagePromptTokensTotal.WithLabelValues(v.model, v.reuse).Add(float64(promptTokens))
+	UsageCachedPromptTokensTotal.WithLabelValues(v.model, v.reuse).Add(float64(cachedPromptTokens))
+}

--- a/cacheroute/usage_test.go
+++ b/cacheroute/usage_test.go
@@ -1,0 +1,59 @@
+package cacheroute
+
+import (
+	"context"
+	"testing"
+)
+
+func TestObserveReturnsReuseClassification(t *testing.T) {
+	s, _, _ := newTestShadow(t)
+	req := keyedRequest(t, "usage-class", 100)
+	cfg := defaultSettings()
+
+	if got := s.Observe("m", req, pool2(), "enclave-a", cfg); got != ReuseFirstSeen {
+		t.Fatalf("first observation: got %q, want %q", got, ReuseFirstSeen)
+	}
+	if got := s.Observe("m", req, pool2(), "enclave-a", cfg); got != ReuseRepeatWarm {
+		t.Fatalf("repeat on warm host: got %q, want %q", got, ReuseRepeatWarm)
+	}
+	if got := s.Observe("m", req, pool2(), "enclave-b", cfg); got != ReuseRepeatCold {
+		t.Fatalf("repeat on cold host: got %q, want %q", got, ReuseRepeatCold)
+	}
+}
+
+func TestObserveReturnsEmptyWhenNotClassified(t *testing.T) {
+	s, _, _ := newTestShadow(t)
+	req := keyedRequest(t, "usage-small-pool", 100)
+	cfg := defaultSettings()
+
+	small := Pool{Size: 1, Candidates: hosts("enclave-a")}
+	if got := s.Observe("m", req, small, "enclave-a", cfg); got != "" {
+		t.Fatalf("pool too small: got %q, want empty", got)
+	}
+
+	req.Outcome = OutcomeNoSalt
+	if got := s.Observe("m", req, pool2(), "enclave-a", cfg); got != "" {
+		t.Fatalf("non-keyed request: got %q, want empty", got)
+	}
+}
+
+func TestRecordUsage(t *testing.T) {
+	ctx := WithReuse(context.Background(), "usage-test-model", ReuseRepeatCold)
+	RecordUsage(ctx, 1000, 250)
+	RecordUsage(ctx, 500, 0)
+
+	if got := counterValue(t, UsagePromptTokensTotal, "usage-test-model", ReuseRepeatCold); got != 1500 {
+		t.Fatalf("prompt tokens: got %v, want 1500", got)
+	}
+	if got := counterValue(t, UsageCachedPromptTokensTotal, "usage-test-model", ReuseRepeatCold); got != 250 {
+		t.Fatalf("cached tokens: got %v, want 250", got)
+	}
+}
+
+func TestRecordUsageWithoutClassificationIsNoop(t *testing.T) {
+	RecordUsage(context.Background(), 1000, 250)
+
+	if got := counterValue(t, UsagePromptTokensTotal, "usage-noop-model", ReuseFirstSeen); got != 0 {
+		t.Fatalf("prompt tokens without classification: got %v, want 0", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1022,11 +1022,17 @@ func main() {
 
 		// Hand the landing to the cache-route pipeline. Observed at
 		// dispatch so the picked replica counts as warm from prefill
-		// start; cannot affect the request.
+		// start; cannot affect the request. The reuse classification rides
+		// the request context so response-time usage extraction can
+		// attribute engine-reported token counts per class.
+		var cacheRouteReuse string
 		if cacheRouteDecision != nil {
-			cacheRouteShadow.ObserveLanding(modelName, cacheRouteReq, cacheRouteDecision, enclave.String(), cacheRouteSettings)
+			cacheRouteReuse = cacheRouteShadow.ObserveLanding(modelName, cacheRouteReq, cacheRouteDecision, enclave.String(), cacheRouteSettings)
 		} else if cacheRouteReq != nil {
-			cacheRouteShadow.Observe(modelName, cacheRouteReq, model.CacheRoutePoolIn(poolPrimary), enclave.String(), cacheRouteSettings)
+			cacheRouteReuse = cacheRouteShadow.Observe(modelName, cacheRouteReq, model.CacheRoutePoolIn(poolPrimary), enclave.String(), cacheRouteSettings)
+		}
+		if cacheRouteReuse != "" {
+			r = r.WithContext(cacheroute.WithReuse(r.Context(), modelName, cacheRouteReuse))
 		}
 
 		// A claimed recovery probe travels with its request, so the

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -21,6 +21,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/tinfoilsh/confidential-model-router/billing"
+	"github.com/tinfoilsh/confidential-model-router/cacheroute"
 	"github.com/tinfoilsh/confidential-model-router/tokencount"
 	tinfoilClient "github.com/tinfoilsh/tinfoil-go/verifier/client"
 )
@@ -311,6 +312,12 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				}
 			}
 
+			cachedPromptTokens := 0
+			if value, ok := usage.CachedPromptTokens(); ok {
+				cachedPromptTokens = value
+			}
+			cacheroute.RecordUsage(req.Context(), usage.PromptTokens, cachedPromptTokens)
+
 			// Add billing event
 			if billingCollector != nil {
 				if modelName == websearchModel {
@@ -320,10 +327,6 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 					// user's API key and gets billed there directly.
 					emitZeroTokenEvent()
 				} else {
-					cachedPromptTokens := 0
-					if value, ok := usage.CachedPromptTokens(); ok {
-						cachedPromptTokens = value
-					}
 					event := billing.Event{
 						Timestamp:          time.Now(),
 						UserID:             userID,


### PR DESCRIPTION
cacherouting shadow mode classifies keyed requests (first_seen / repeat_warm / repeat_cold) but never sees token counts. This joins them with two aggregate counters so the token hit rate can be measured per reuse class. This will make the shadow mode more useful