### PR TITLE
Make enclave metrics poll interval configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -167,6 +167,10 @@ var (
 	// scrapes. Env resolved after parse, like cache-route-secret, so the
 	// secret never reaches flag output.
 	metricsAPIKey = flag.String("metrics-api-key", "", "admin API key sent as a bearer token when polling enclave /metrics (env: METRICS_API_KEY)")
+	// metricsPollInterval sets the enclave /metrics scrape cadence — the
+	// freshness of the queue-depth signal behind overload rejection and
+	// cache-aware routing's overload step-aside.
+	metricsPollInterval = flag.Duration("metrics-poll-interval", getEnvOrDefaultDuration("METRICS_POLL_INTERVAL", time.Second), "enclave /metrics poll interval driving overload detection (env: METRICS_POLL_INTERVAL)")
 )
 
 func jsonError(w http.ResponseWriter, message string, errType string, code int) {
@@ -455,6 +459,7 @@ func main() {
 		}
 		manager.SetMetricsPollAPIKey(strings.TrimSpace(key))
 	}
+	manager.SetMetricsPollInterval(*metricsPollInterval)
 
 	em, err := manager.NewEnclaveManager(configFile, *controlPlaneURL, *usageReporterID, *usageReporterSecret, *usageContextSecret, *initConfigURL, *updateConfigURL, *refreshInterval)
 	if err != nil {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -38,8 +38,8 @@ type Enclave struct {
 	cb        *circuitBreaker
 
 	// inflight counts requests currently proxied through this enclave —
-	// a live load signal, unlike the polled queue depth, which can be up
-	// to sampleStalenessLimit stale when scrapes fail.
+	// a live load signal, unlike the polled queue depth, which can be a
+	// full staleness window old (see stalenessLimit) when scrapes fail.
 	inflight atomic.Int64
 }
 

--- a/manager/metrics.go
+++ b/manager/metrics.go
@@ -21,7 +21,36 @@ import (
 // 1s poll reads fresh data each time. A scrape that outlives the interval
 // blocks the loop and the ticker coalesces missed ticks, so a slow backend
 // is polled at scrape-duration cadence rather than piling up requests.
+// Process-wide override: SetMetricsPollInterval (see pollInterval).
 const defaultMetricsPollInterval = time.Second
+
+// metricsPollIntervalNanos is the process-wide scrape-cadence override in
+// nanoseconds; zero means defaultMetricsPollInterval. Stored atomically so
+// startup wiring can't race a running poller.
+var metricsPollIntervalNanos atomic.Int64
+
+// SetMetricsPollInterval installs the process-wide backend /metrics scrape
+// cadence — the freshness of the queue-depth signal behind overload
+// rejection and cache-aware routing's step-aside. Non-positive restores the
+// 1s default. It applies to pollers (re)started afterwards; every config
+// sync restarts them, so in production only startup wiring calls this. The
+// sample staleness window scales with the interval (see stalenessLimit), so
+// a slow cadence doesn't permanently fail open.
+func SetMetricsPollInterval(d time.Duration) {
+	if d < 0 {
+		d = 0
+	}
+	metricsPollIntervalNanos.Store(int64(d))
+}
+
+// pollInterval resolves the scrape cadence: the installed override when
+// positive, else the 1s default.
+func pollInterval() time.Duration {
+	if d := time.Duration(metricsPollIntervalNanos.Load()); d > 0 {
+		return d
+	}
+	return defaultMetricsPollInterval
+}
 
 // pollAPIKey, when set, is sent as a bearer token on backend /metrics
 // scrapes (enclaves require an admin key). Stored atomically so startup
@@ -113,10 +142,11 @@ func (m *enclaveMetrics) setConfig(cfg *config.OverloadConfig) {
 	// lands (which can take a while if the backend is unreachable). For an
 	// unchanged config the evaluation is a fixed point, so the per-sync
 	// config reinstall does not disturb hysteresis state.
-	if waiting, collected := m.latestSample(); !collected.IsZero() && time.Since(collected) <= sampleStalenessLimit {
+	if waiting, collected := m.latestSample(); !collected.IsZero() && time.Since(collected) <= stalenessLimit() {
 		m.evaluateThresholds(waiting)
 	}
 
+	interval := pollInterval()
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
 	m.wg.Add(1)
@@ -126,8 +156,9 @@ func (m *enclaveMetrics) setConfig(cfg *config.OverloadConfig) {
 		"max_requests_waiting":   trip,
 		"clear_requests_waiting": clear,
 		"retry_after_minutes":    cfg.RetryAfterMinutes,
+		"poll_interval":          interval,
 	}).Info("starting vLLM metrics polling")
-	go m.run(ctx, defaultMetricsPollInterval)
+	go m.run(ctx, interval)
 }
 
 func (m *enclaveMetrics) run(ctx context.Context, interval time.Duration) {
@@ -250,13 +281,27 @@ func (m *enclaveMetrics) latestSample() (float64, time.Time) {
 	return m.latestWaiting, m.latestCollected
 }
 
-// sampleStalenessLimit bounds how long the overload flag keeps driving
-// shouldReject without a fresh sample. It is a fixed window rather than a
-// multiple of the poll interval: at a 1s cadence, deriving it from the
-// interval would fail open after a single slow scrape (the scrape client
-// timeout alone is 5s). 15s means roughly three consecutive timed-out
-// scrapes must elapse before the safety net is dropped.
+// sampleStalenessLimit is the floor on how long the overload flag keeps
+// driving shouldReject without a fresh sample. It is a fixed floor rather
+// than a pure multiple of the poll interval: at the default 1s cadence,
+// deriving it from the interval would fail open after a single slow scrape
+// (the scrape client timeout alone is 5s). 15s means roughly three
+// consecutive timed-out scrapes must elapse before the safety net is
+// dropped.
 const sampleStalenessLimit = 15 * time.Second
+
+// stalenessLimit resolves the freshness window for the current poll cadence:
+// the sampleStalenessLimit floor, or three poll intervals when the
+// configured cadence is slow enough that the floor would expire between
+// scrapes. Without the scaling, any interval above the floor would mark
+// every sample stale before the next scrape lands, silently turning the
+// overload guard off everywhere.
+func stalenessLimit() time.Duration {
+	if scaled := 3 * pollInterval(); scaled > sampleStalenessLimit {
+		return scaled
+	}
+	return sampleStalenessLimit
+}
 
 // evaluateThresholds updates the overload flag from the latest queue depth
 // with hysteresis: trip at the high mark, clear at the lower mark, hold the
@@ -328,7 +373,7 @@ func (m *enclaveMetrics) shouldReject() (bool, time.Duration, float64) {
 	if collected.IsZero() {
 		return false, 0, waiting
 	}
-	if time.Since(collected) > sampleStalenessLimit {
+	if time.Since(collected) > stalenessLimit() {
 		OverloadFailOpenTotal.WithLabelValues(m.model, m.host).Inc()
 		log.WithFields(log.Fields{
 			"model":     m.model,

--- a/manager/metrics_test.go
+++ b/manager/metrics_test.go
@@ -341,6 +341,82 @@ func TestScrape_EndToEndHysteresis(t *testing.T) {
 	}
 }
 
+func TestPollIntervalResolution(t *testing.T) {
+	defer SetMetricsPollInterval(0)
+
+	tests := []struct {
+		name     string
+		interval time.Duration
+		want     time.Duration
+	}{
+		{"unset", 0, time.Second},
+		{"negative resets to default", -time.Second, time.Second},
+		{"sub-second", 250 * time.Millisecond, 250 * time.Millisecond},
+		{"slow", 30 * time.Second, 30 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetMetricsPollInterval(tt.interval)
+			if got := pollInterval(); got != tt.want {
+				t.Fatalf("pollInterval = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStalenessLimitScalesWithPollInterval(t *testing.T) {
+	defer SetMetricsPollInterval(0)
+
+	tests := []struct {
+		name     string
+		interval time.Duration
+		want     time.Duration
+	}{
+		{"default cadence keeps floor", 0, sampleStalenessLimit},
+		{"fast cadence keeps floor", 250 * time.Millisecond, sampleStalenessLimit},
+		{"at floor boundary keeps floor", 5 * time.Second, sampleStalenessLimit},
+		{"slow cadence scales to three intervals", 10 * time.Second, 30 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetMetricsPollInterval(tt.interval)
+			if got := stalenessLimit(); got != tt.want {
+				t.Fatalf("stalenessLimit = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestShouldReject_SlowCadenceSampleStaysFresh pins the interval/staleness
+// coupling: with a poll interval slower than the fixed floor, a sample older
+// than the floor but within three intervals must still drive rejection.
+// Without the scaling, every sample would expire before the next scrape and
+// the overload guard would silently fail open.
+func TestShouldReject_SlowCadenceSampleStaysFresh(t *testing.T) {
+	SetMetricsPollInterval(20 * time.Second)
+	defer SetMetricsPollInterval(0)
+
+	m := newTestMetrics("slow-cadence-host", &config.OverloadConfig{
+		MaxRequestsWaiting: 16,
+	})
+	observe(m, 16)
+	if reject, _, _ := m.shouldReject(); !reject {
+		t.Fatal("expected reject at trip mark")
+	}
+
+	// Older than the 15s floor, within the scaled 60s window: still fresh.
+	m.updateLatest(16, time.Now().Add(-sampleStalenessLimit-time.Second))
+	if reject, _, _ := m.shouldReject(); !reject {
+		t.Fatal("expected reject with sample inside the scaled staleness window")
+	}
+
+	// Beyond the scaled window: fail open.
+	m.updateLatest(16, time.Now().Add(-61*time.Second))
+	if reject, _, _ := m.shouldReject(); reject {
+		t.Fatal("expected allow once the sample outlives the scaled window")
+	}
+}
+
 func TestShouldReject_FailsOpen(t *testing.T) {
 	// No config.
 	m := newTestMetrics("open-nil-host", nil)


### PR DESCRIPTION
## Summary

The backend `/metrics` scrape cadence — the freshness of the queue-depth signal behind overload rejection and cache-aware routing's overload step-aside — was hardcoded at 1s. This makes it configurable process-wide via `-metrics-poll-interval` (env: `METRICS_POLL_INTERVAL`), a Go duration (e.g. `500ms`, `2s`) defaulting to `1s`.

- The interval lives in a package-level atomic with a `SetMetricsPollInterval` setter, following the existing `SetMetricsPollAPIKey` pattern, so startup wiring can't race a running poller. Pollers pick it up when started or restarted by config sync; non-positive values restore the default.
- The sample staleness window now scales with the interval: `max(15s, 3 × interval)`. Without this, any interval above the fixed 15s limit would mark every sample stale before the next scrape lands, silently failing the overload guard open everywhere. Behavior at cadences ≤ 5s is unchanged.
- The "starting vLLM metrics polling" log line gains a `poll_interval` field.

## Test plan

- `TestPollIntervalResolution`: default, negative-reset, sub-second, and slow cadences resolve correctly
- `TestStalenessLimitScalesWithPollInterval`: the 15s floor holds through the 5s boundary, then scales to three intervals
- `TestShouldReject_SlowCadenceSampleStaysFresh`: pins the coupling — with a 20s cadence, a sample older than the 15s floor but inside the scaled window still drives rejection, and one beyond it fails open
- `go test ./...`, `go vet`, `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the backend `/metrics` poll interval configurable to keep overload detection accurate at different cadences while keeping the 1s default.

- **New Features**
  - Adds `-metrics-poll-interval` (env: `METRICS_POLL_INTERVAL`) with Go durations like `500ms` or `2s` (default `1s`).
  - Introduces `manager.SetMetricsPollInterval`; non-positive values reset to default; applied when pollers (re)start.
  - Staleness window scales to `max(15s, 3 × interval)` so slow cadences don’t fail the overload guard open.
  - Logs now include `poll_interval`, and startup wires the interval into the manager.

<sup>Written for commit ea21df3189f6d5b0c54d885cca009917b2face85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

