### PR TITLE
Add per-request token count histograms

### DIFF
--- a/main.go
+++ b/main.go
@@ -1046,6 +1046,10 @@ func main() {
 			r = r.WithContext(manager.WithProbeClaim(r.Context(), probeClaim))
 		}
 
+		// Per-request token counts surface only in the proxy's usage
+		// handler; carry the labels resolved here to it.
+		r = r.WithContext(manager.WithTokenMetricLabels(r.Context(), poolLabel, priorityClass(hasConfiguredPriority)))
+
 		if isStreaming && latencyMetricPaths[r.URL.Path] {
 			lw := newLatencyWriter(w, requestStart, modelName, enclave.String(), poolLabel, priorityClass(hasConfiguredPriority))
 			// finish must run via defer: a backend that dies mid-stream

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -266,6 +266,29 @@ var (
 		[]string{"model", "pool", "priority", "stream", "outcome"},
 	)
 
+	// RequestPromptTokens and RequestCompletionTokens record per-request
+	// token counts from response usage. Engine-side token histograms carry
+	// no pool, priority, or stream labels, so they cannot split a model's
+	// traffic by caller class or request mode. Requests whose responses
+	// report no usage are not observed.
+	RequestPromptTokens = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "router_request_prompt_tokens",
+			Help:    "Prompt tokens per request from response usage, by pool, priority, and stream mode",
+			Buckets: []float64{1, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000, 250000},
+		},
+		[]string{"model", "pool", "priority", "stream"},
+	)
+
+	RequestCompletionTokens = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "router_request_completion_tokens",
+			Help:    "Completion tokens per request from response usage, by pool, priority, and stream mode",
+			Buckets: []float64{1, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000},
+		},
+		[]string{"model", "pool", "priority", "stream"},
+	)
+
 	// DispatchSeconds tracks time from request arrival at the router to
 	// backend dispatch: body handling, route-context lookup, rate-limit
 	// checks, and replica selection. This span is otherwise only buried

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -42,6 +42,35 @@ const (
 	websearchModel = "websearch"
 )
 
+// tokenLabelsKey carries the landing pool and priority class from the
+// dispatch site to the proxy's usage handler — the only place per-request
+// token counts are known.
+type tokenLabelsKey struct{}
+
+type tokenLabels struct{ pool, priority string }
+
+// WithTokenMetricLabels attaches the labels used on the per-request token
+// histograms. Requests dispatched without them (tool-loop internals,
+// websocket sessions) are not observed.
+func WithTokenMetricLabels(ctx context.Context, pool, priority string) context.Context {
+	return context.WithValue(ctx, tokenLabelsKey{}, tokenLabels{pool: pool, priority: priority})
+}
+
+func observeTokenUsage(ctx context.Context, model string, streaming bool, usage *tokencount.Usage) {
+	labels, ok := ctx.Value(tokenLabelsKey{}).(tokenLabels)
+	if !ok {
+		return
+	}
+	stream := "non_streaming"
+	if streaming {
+		stream = "streaming"
+	}
+	RequestPromptTokens.WithLabelValues(model, labels.pool, labels.priority, stream).
+		Observe(float64(usage.PromptTokens))
+	RequestCompletionTokens.WithLabelValues(model, labels.pool, labels.priority, stream).
+		Observe(float64(usage.CompletionTokens))
+}
+
 // classifyProxyError maps a transport-level error to a bounded set of reason
 // labels for Prometheus. The raw error message is logged but not exposed as a
 // label to avoid unbounded cardinality.
@@ -309,6 +338,12 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				if wrapper, ok := req.Context().Value(usageWriterKey{}).(*usageMetricsWriter); ok {
 					wrapper.SetUsage(usage)
 				}
+			}
+
+			// The websearch parent call is skipped like its billing event:
+			// the inner responder call re-enters the proxy and records its own.
+			if modelName != websearchModel {
+				observeTokenUsage(req.Context(), modelName, streaming, usage)
 			}
 
 			// Add billing event

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -10,7 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
 	"github.com/tinfoilsh/confidential-model-router/billing"
+	"github.com/tinfoilsh/confidential-model-router/tokencount"
 )
 
 func setupTestProxyWithModel(t *testing.T, handler http.Handler, modelName string) *httputil.ReverseProxy {
@@ -386,5 +390,47 @@ func TestSlowHeaderTripper_SlowResponse_RequestNotKilled(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func tokenHistogramState(t *testing.T, o prometheus.Observer) (count uint64, sum float64) {
+	t.Helper()
+	m, ok := o.(prometheus.Metric)
+	if !ok {
+		t.Fatalf("observer is not a metric: %T", o)
+	}
+	pb := &dto.Metric{}
+	if err := m.Write(pb); err != nil {
+		t.Fatalf("failed to read histogram: %v", err)
+	}
+	return pb.GetHistogram().GetSampleCount(), pb.GetHistogram().GetSampleSum()
+}
+
+func TestObserveTokenUsage(t *testing.T) {
+	const model = "token-usage-test"
+	ctx := WithTokenMetricLabels(context.Background(), "reserved", "configured")
+	observeTokenUsage(ctx, model, true, &tokencount.Usage{PromptTokens: 1200, CompletionTokens: 340})
+
+	count, sum := tokenHistogramState(t, RequestPromptTokens.WithLabelValues(model, "reserved", "configured", "streaming"))
+	if count != 1 || sum != 1200 {
+		t.Errorf("prompt histogram: got count=%d sum=%v, want 1/1200", count, sum)
+	}
+	count, sum = tokenHistogramState(t, RequestCompletionTokens.WithLabelValues(model, "reserved", "configured", "streaming"))
+	if count != 1 || sum != 340 {
+		t.Errorf("completion histogram: got count=%d sum=%v, want 1/340", count, sum)
+	}
+
+	// Non-streaming lands on its own series.
+	observeTokenUsage(ctx, model, false, &tokencount.Usage{PromptTokens: 80, CompletionTokens: 20})
+	count, sum = tokenHistogramState(t, RequestPromptTokens.WithLabelValues(model, "reserved", "configured", "non_streaming"))
+	if count != 1 || sum != 80 {
+		t.Errorf("non-streaming prompt histogram: got count=%d sum=%v, want 1/80", count, sum)
+	}
+
+	// A context without labels must not observe anything.
+	observeTokenUsage(context.Background(), model, true, &tokencount.Usage{PromptTokens: 999})
+	count, _ = tokenHistogramState(t, RequestPromptTokens.WithLabelValues(model, "reserved", "configured", "streaming"))
+	if count != 1 {
+		t.Errorf("unlabeled context observed: count=%d, want 1", count)
 	}
 }


### PR DESCRIPTION
Adds `router_request_prompt_tokens` and `router_request_completion_tokens` histograms recording per-request token counts from response usage, labeled by model, pool, priority, and stream mode.

Motivation: understanding a model's input/output token shape split by request mode — e.g. Gemma streaming vs non-streaming prompt/completion sizes. The engine-side histograms (`vllm:request_prompt_tokens_bucket` etc.) carry no stream, pool, or priority labels, so they cannot answer this; they also require hand-pinned instance regexes in dashboards, while these labels come from the router's own registry.

Implementation: the landing pool and priority class are attached to the request context at dispatch and observed in the proxy's existing usage handler, so no additional response parsing is added. Requests whose responses report no usage (and internal tool-loop dispatches, websocket sessions, and the websearch parent call, which is skipped like its billing event) are not observed. Observation-only — no routing, breaker, or proxying behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-request token count histograms in the router to track prompt and completion tokens by model, pool, priority, and streaming mode. This makes it easy to analyze token shapes for streaming vs non‑streaming traffic directly in Prometheus.

- **New Features**
  - Added `router_request_prompt_tokens` and `router_request_completion_tokens` histograms labeled by `model`, `pool`, `priority`, and `stream`.
  - Attached labels at dispatch via `WithTokenMetricLabels` and recorded in the proxy’s usage handler; no extra response parsing.
  - Skips requests without usage and internal calls (tool-loop, websocket, and `websearch` parent); observation only, no routing or proxy behavior changes.

<sup>Written for commit 0505a9949977211a9a687c23151bf2e374317ccb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

