### PR TITLE
Add cached prompt token counter; pre-initialize no-first-token series

### DIFF
--- a/latency.go
+++ b/latency.go
@@ -95,7 +95,20 @@ type latencyWriter struct {
 	aborted   bool // ServeHTTP unwound by panic: the proxy aborted mid-stream
 }
 
+// noFirstTokenReasons enumerates every reason finish can record. Touching
+// all of them when a writer is created births the counter series at zero,
+// so the first failure after a router restart is a visible 0->1 increment
+// instead of a series appearing mid-air, which rate() cannot count.
+var noFirstTokenReasons = [...]string{"canceled", "timeout", "error", "no_output"}
+
+func initNoFirstTokenSeries(model, enclave, pool, class string) {
+	for _, reason := range noFirstTokenReasons {
+		manager.NoFirstTokenTotal.WithLabelValues(model, enclave, pool, class, reason).Add(0)
+	}
+}
+
 func newLatencyWriter(w http.ResponseWriter, arrival time.Time, model, enclave, pool, class string) *latencyWriter {
+	initNoFirstTokenSeries(model, enclave, pool, class)
 	return &latencyWriter{
 		ResponseWriter: w,
 		model:          model,
@@ -122,6 +135,7 @@ const toolRuntimeLabel = "tool-runtime"
 // only the final answer would misread a request the user is actively
 // watching as an SLA violation.
 func newToolLatencyWriter(w http.ResponseWriter, arrival time.Time, model, class string) *latencyWriter {
+	initNoFirstTokenSeries(model, toolRuntimeLabel, toolRuntimeLabel, class)
 	return &latencyWriter{
 		ResponseWriter: w,
 		model:          model,

--- a/latency_test.go
+++ b/latency_test.go
@@ -774,3 +774,13 @@ func TestToolLatencyWriterCountsTokenlessStream(t *testing.T) {
 		t.Fatalf("expected one canceled count under the tool-runtime sentinel, got %v", got)
 	}
 }
+
+func TestNewLatencyWriterInitsNoFirstTokenSeries(t *testing.T) {
+	const model = "no-first-token-init-test"
+	newLatencyWriter(httptest.NewRecorder(), time.Now(), model, "enclave-1", "reserved", "configured")
+	for _, reason := range noFirstTokenReasons {
+		if got := counterState(t, manager.NoFirstTokenTotal.WithLabelValues(model, "enclave-1", "reserved", "configured", reason)); got != 0 {
+			t.Errorf("reason %s: got %v, want series initialized at 0", reason, got)
+		}
+	}
+}

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -289,6 +289,18 @@ var (
 		[]string{"model", "pool", "priority", "stream"},
 	)
 
+	// RequestCachedPromptTokensTotal accumulates the cached share of prompt
+	// tokens from response usage; RequestPromptTokens' _sum minus this is
+	// the recomputed-prefill volume per pool, priority, and stream mode.
+	// Usage without cached-token details counts as fully uncached.
+	RequestCachedPromptTokensTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_request_cached_prompt_tokens_total",
+			Help: "Cached prompt tokens from response usage, by pool, priority, and stream mode",
+		},
+		[]string{"model", "pool", "priority", "stream"},
+	)
+
 	// DispatchSeconds tracks time from request arrival at the router to
 	// backend dispatch: body handling, route-context lookup, rate-limit
 	// checks, and replica selection. This span is otherwise only buried

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -69,6 +69,9 @@ func observeTokenUsage(ctx context.Context, model string, streaming bool, usage 
 		Observe(float64(usage.PromptTokens))
 	RequestCompletionTokens.WithLabelValues(model, labels.pool, labels.priority, stream).
 		Observe(float64(usage.CompletionTokens))
+	cached, _ := usage.CachedPromptTokens()
+	RequestCachedPromptTokensTotal.WithLabelValues(model, labels.pool, labels.priority, stream).
+		Add(float64(cached))
 }
 
 // classifyProxyError maps a transport-level error to a bounded set of reason

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -406,10 +406,23 @@ func tokenHistogramState(t *testing.T, o prometheus.Observer) (count uint64, sum
 	return pb.GetHistogram().GetSampleCount(), pb.GetHistogram().GetSampleSum()
 }
 
+func tokenCounterState(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+	pb := &dto.Metric{}
+	if err := c.Write(pb); err != nil {
+		t.Fatalf("failed to read counter: %v", err)
+	}
+	return pb.GetCounter().GetValue()
+}
+
 func TestObserveTokenUsage(t *testing.T) {
 	const model = "token-usage-test"
 	ctx := WithTokenMetricLabels(context.Background(), "reserved", "configured")
-	observeTokenUsage(ctx, model, true, &tokencount.Usage{PromptTokens: 1200, CompletionTokens: 340})
+	observeTokenUsage(ctx, model, true, &tokencount.Usage{
+		PromptTokens:        1200,
+		CompletionTokens:    340,
+		PromptTokensDetails: &tokencount.PromptTokensDetails{CachedTokens: 900},
+	})
 
 	count, sum := tokenHistogramState(t, RequestPromptTokens.WithLabelValues(model, "reserved", "configured", "streaming"))
 	if count != 1 || sum != 1200 {
@@ -420,11 +433,19 @@ func TestObserveTokenUsage(t *testing.T) {
 		t.Errorf("completion histogram: got count=%d sum=%v, want 1/340", count, sum)
 	}
 
-	// Non-streaming lands on its own series.
+	if got := tokenCounterState(t, RequestCachedPromptTokensTotal.WithLabelValues(model, "reserved", "configured", "streaming")); got != 900 {
+		t.Errorf("cached counter: got %v, want 900", got)
+	}
+
+	// Non-streaming lands on its own series; usage without cached-token
+	// details counts as fully uncached.
 	observeTokenUsage(ctx, model, false, &tokencount.Usage{PromptTokens: 80, CompletionTokens: 20})
 	count, sum = tokenHistogramState(t, RequestPromptTokens.WithLabelValues(model, "reserved", "configured", "non_streaming"))
 	if count != 1 || sum != 80 {
 		t.Errorf("non-streaming prompt histogram: got count=%d sum=%v, want 1/80", count, sum)
+	}
+	if got := tokenCounterState(t, RequestCachedPromptTokensTotal.WithLabelValues(model, "reserved", "configured", "non_streaming")); got != 0 {
+		t.Errorf("non-streaming cached counter: got %v, want 0", got)
 	}
 
 	// A context without labels must not observe anything.


### PR DESCRIPTION
Adds router_request_cached_prompt_tokens_total (by pool, priority, and stream mode) so cached vs recomputed prefill volume can be split per request mode, and pre-initializes no-first-token counter series at dispatch so the first failure after a router restart is a countable increment rather than a series appearing mid-air.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `router_request_cached_prompt_tokens_total` to track cached prompt tokens by pool, priority, and stream. Also initializes no-first-token counter series at zero so the first post-restart failure is a visible increment.

- **New Features**
  - New Prometheus counter `router_request_cached_prompt_tokens_total` with labels `{model, pool, priority, stream}`.
  - Populated in `observeTokenUsage`; if cached-token details are missing, counts as fully uncached (adds 0).

- **Bug Fixes**
  - Pre-initialize `NoFirstTokenTotal` for reasons `canceled`, `timeout`, `error`, `no_output` when a latency writer is created (including tool-runtime).
  - Prevents series appearing mid-air after restarts, so `rate()` captures the first 0→1 increment.

<sup>Written for commit 1a9f4f7ad12d09b61c26d5672ad54951fa44c02a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

