### PR TITLE
Publish reserved pool size per model

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -71,7 +71,7 @@ type Model struct {
 // counting them would silently shrink an org's effective pool (or leave it
 // empty, routing all its traffic to spill). The caller must hold m.mu or
 // have exclusive access (addModel, before publish).
-func (m *Model) applyReservations(reservations []config.ReservationConfig, hostnames []string) {
+func (m *Model) applyReservations(name string, reservations []config.ReservationConfig, hostnames []string) {
 	m.Reservations = reservations
 
 	known := make(map[string]bool, len(hostnames))
@@ -106,6 +106,7 @@ func (m *Model) applyReservations(reservations []config.ReservationConfig, hostn
 			}
 		}
 	}
+	ReservedPoolSize.WithLabelValues(name).Set(float64(len(reserved)))
 	if len(byOrg) == 0 {
 		m.reservedByOrg = nil
 		m.sharedHosts = nil
@@ -917,7 +918,7 @@ func (em *EnclaveManager) addModel(modelName string, modelConfig config.Model) {
 		CacheRoute:        modelConfig.CacheRoute,
 		expectedHosts:     len(modelConfig.Hostnames),
 	}
-	model.applyReservations(modelConfig.Reservations, modelConfig.Hostnames)
+	model.applyReservations(modelName, modelConfig.Reservations, modelConfig.Hostnames)
 	em.models.Store(modelName, model)
 	cacheroute.SetMode(modelName, modelConfig.CacheRoute)
 	cacheroute.SetPoolInfo(modelName, modelConfig.Hostnames)
@@ -1000,7 +1001,7 @@ func (em *EnclaveManager) sync() error {
 				log.Warnf("model %s no longer in config", modelName)
 				model.mu.Lock()
 				model.expectedHosts = 0
-				model.applyReservations(nil, nil)
+				model.applyReservations(modelName, nil, nil)
 				for _, enclave := range model.Enclaves {
 					enclave.shutdown()
 				}
@@ -1027,7 +1028,7 @@ func (em *EnclaveManager) sync() error {
 			model.Overload = configModel.Overload
 			model.RateLimit = configModel.RateLimit
 			model.CacheRoute = configModel.CacheRoute
-			model.applyReservations(configModel.Reservations, configModel.Hostnames)
+			model.applyReservations(modelName, configModel.Reservations, configModel.Hostnames)
 			for _, enclave := range model.Enclaves {
 				enclave.updateOverloadConfig(model.Overload)
 			}

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -177,6 +177,18 @@ var (
 		[]string{"model", "pool"},
 	)
 
+	// ReservedPoolSize publishes each model's effective reserved-host count
+	// from config, so dashboards don't have to mirror the reservation by
+	// hand. Counts only reserved hosts that exist in the configured
+	// hostnames, matching what routing actually uses.
+	ReservedPoolSize = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "router_reserved_pool_size",
+			Help: "Configured reserved enclaves per model (0 when the model has no reservations)",
+		},
+		[]string{"model"},
+	)
+
 	// CacheSaltInjectionsTotal tracks requests injected with a derived cache_salt
 	CacheSaltInjectionsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/manager/reservations_test.go
+++ b/manager/reservations_test.go
@@ -3,6 +3,9 @@ package manager
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
 	"github.com/tinfoilsh/confidential-model-router/config"
 )
 
@@ -10,7 +13,7 @@ import (
 // for org-reserved. a and b form the shared pool.
 func newReservedTestModel() *Model {
 	m := newTestModel("a", "b", "c")
-	m.applyReservations(
+	m.applyReservations("reservation-test-model",
 		[]config.ReservationConfig{{OrgIDs: []string{"org-reserved"}, Enclaves: []string{"c"}}},
 		[]string{"a", "b", "c"},
 	)
@@ -55,7 +58,7 @@ func TestReservationPools(t *testing.T) {
 // Reservations with no orgs or no enclaves are dropped.
 func TestReservationPoolsIgnoreDegenerateEntries(t *testing.T) {
 	m := newTestModel("a", "b")
-	m.applyReservations(
+	m.applyReservations("reservation-test-model",
 		[]config.ReservationConfig{
 			{OrgIDs: nil, Enclaves: []string{"a"}},
 			{OrgIDs: []string{""}, Enclaves: []string{"a"}},
@@ -73,7 +76,7 @@ func TestReservationPoolsIgnoreDegenerateEntries(t *testing.T) {
 // pinned to an empty pool.
 func TestReservationPoolsDropUnknownHosts(t *testing.T) {
 	m := newTestModel("a", "b")
-	m.applyReservations(
+	m.applyReservations("reservation-test-model",
 		[]config.ReservationConfig{
 			{OrgIDs: []string{"org-x"}, Enclaves: []string{"b", "typo-host"}},
 			{OrgIDs: []string{"org-y"}, Enclaves: []string{"stale-host"}},
@@ -100,7 +103,7 @@ func TestReservationPoolsDropUnknownHosts(t *testing.T) {
 // One reservation entry can dedicate a pool to several orgs.
 func TestReservationPoolsMultiOrg(t *testing.T) {
 	m := newTestModel("a", "b", "c")
-	m.applyReservations(
+	m.applyReservations("reservation-test-model",
 		[]config.ReservationConfig{{OrgIDs: []string{"org-reserved", "org-partner"}, Enclaves: []string{"b", "c"}}},
 		[]string{"a", "b", "c"},
 	)
@@ -295,5 +298,30 @@ func TestCacheRoutePoolIn(t *testing.T) {
 	// nil filter preserves the unrestricted behavior.
 	if pool := m.CacheRoutePoolIn(nil); pool.Size != 3 {
 		t.Fatalf("unrestricted pool = %+v, want size 3", pool)
+	}
+}
+
+func gaugeState(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	pb := &dto.Metric{}
+	if err := g.Write(pb); err != nil {
+		t.Fatalf("failed to read gauge: %v", err)
+	}
+	return pb.GetGauge().GetValue()
+}
+
+func TestApplyReservationsPublishesPoolSize(t *testing.T) {
+	const model = "pool-size-test-model"
+	m := newTestModel("a", "b", "c")
+	m.applyReservations(model,
+		[]config.ReservationConfig{{OrgIDs: []string{"org-reserved"}, Enclaves: []string{"b", "c", "ghost"}}},
+		[]string{"a", "b", "c"},
+	)
+	if got := gaugeState(t, ReservedPoolSize.WithLabelValues(model)); got != 2 {
+		t.Errorf("reserved pool size = %v, want 2 (unknown host must not count)", got)
+	}
+	m.applyReservations(model, nil, nil)
+	if got := gaugeState(t, ReservedPoolSize.WithLabelValues(model)); got != 0 {
+		t.Errorf("cleared pool size = %v, want 0", got)
 	}
 }


### PR DESCRIPTION
Adds a router_reserved_pool_size gauge set on every config apply with the effective reserved-host count per model (unknown hosts excluded, zero when a model has no reservations), so dashboards can read pool strength directly instead of mirroring the reservation with hand-maintained instance regexes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes each model’s effective reserved-host count via a new `prometheus` gauge, so dashboards can read pool strength directly. This removes the need to mirror reservation configs with instance regexes.

- **New Features**
  - Adds `router_reserved_pool_size` (`prometheus` GaugeVec) labeled by `model`, updated on every config apply.
  - Counts only reserved hosts that exist in the model’s `hostnames`; unknown hosts are ignored; reports 0 when there are no reservations.

- **Refactors**
  - `applyReservations` now receives the model name to set the gauge.

<sup>Written for commit 904dd10ef667b0c772377838552e724670c0834a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

