### PR TITLE
Add load cap to cache-aware routing

### DIFF
--- a/cacheroute/cacheroute.go
+++ b/cacheroute/cacheroute.go
@@ -93,6 +93,7 @@ type Settings struct {
 	Retention         time.Duration // how long a replica stays warm for a key
 	MinPromptBytes    int           // eligibility floor on whole-prompt bytes
 	SplitThresholdRPM float64       // per-key rpm per replica of warm set
+	MaxInflightDelta  int           // load cap on warm picks; negative = disabled
 	Secret            string        // routing secret from SetSecret; "" when none installed
 }
 
@@ -104,6 +105,7 @@ func SettingsFrom(c *config.CacheRouteConfig) Settings {
 		Retention:         DefaultRetention,
 		MinPromptBytes:    DefaultMinPromptBytes,
 		SplitThresholdRPM: DefaultSplitThresholdRPM,
+		MaxInflightDelta:  -1,
 		Secret:            currentSecret(),
 	}
 	if c == nil {
@@ -118,6 +120,9 @@ func SettingsFrom(c *config.CacheRouteConfig) Settings {
 	}
 	if c.SplitThresholdRPM > 0 {
 		s.SplitThresholdRPM = c.SplitThresholdRPM
+	}
+	if c.MaxInflightDelta != nil && *c.MaxInflightDelta >= 0 {
+		s.MaxInflightDelta = *c.MaxInflightDelta
 	}
 	return s
 }

--- a/cacheroute/hrw.go
+++ b/cacheroute/hrw.go
@@ -79,3 +79,40 @@ func leastLoaded(ranked []Candidate) Candidate {
 	}
 	return best
 }
+
+// minInFlight returns the smallest in-flight count among candidates.
+func minInFlight(candidates []Candidate) int {
+	m := candidates[0].InFlight
+	for _, c := range candidates[1:] {
+		if c.InFlight < m {
+			m = c.InFlight
+		}
+	}
+	return m
+}
+
+// cappedPick is leastLoaded over the key's warm set (ranked[:r]) subject to
+// the load cap: a warm candidate is eligible only while it is at most delta
+// requests deeper than the least-loaded candidate in the whole ranking.
+// Comparing against the pool minimum rather than an absolute level means a
+// uniformly busy pool keeps its warm picks — the cap only bites when
+// stickiness has made a replica an outlier. When the entire warm set is over
+// the cap the pick falls back to the least-loaded candidate overall (within
+// the cap by definition) and demoted reports the sacrificed warm pick.
+// A negative delta disables the cap.
+func cappedPick(ranked []Candidate, r, delta int) (host string, demoted bool) {
+	if delta < 0 {
+		return leastLoaded(ranked[:r]).Host, false
+	}
+	limit := minInFlight(ranked) + delta
+	best := -1
+	for i, c := range ranked[:r] {
+		if c.InFlight <= limit && (best < 0 || c.InFlight < ranked[best].InFlight) {
+			best = i
+		}
+	}
+	if best >= 0 {
+		return ranked[best].Host, false
+	}
+	return leastLoaded(ranked).Host, true
+}

--- a/cacheroute/load_cap_test.go
+++ b/cacheroute/load_cap_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/tinfoilsh/confidential-model-router/config"
 )
 
@@ -108,6 +109,47 @@ func TestDecideDisabledCapKeepsFullRanking(t *testing.T) {
 	d := s.Decide("m", req, pool, cfg)
 	if d == nil || len(d.Order) != 3 {
 		t.Fatalf("expected full order, got %+v", d)
+	}
+}
+
+// TestLoadDemotionCountedAtLandingNotDecision pins where the demotion is
+// metered: a decision alone must not move the counter — the request it
+// routes can still be rejected before dispatch — only the landing may.
+func TestLoadDemotionCountedAtLandingNotDecision(t *testing.T) {
+	s := NewShadow(prometheus.NewRegistry())
+	defer s.Close()
+
+	model := "demote-" + t.Name()
+	key := testKey(42)
+	candidates := hosts("a", "b", "c")
+	// Make the key's whole warm set (r=1: its home) the load outlier.
+	home := rank(key, candidates)[0].Host
+	for i := range candidates {
+		if candidates[i].Host == home {
+			candidates[i].InFlight = 9
+		}
+	}
+	pool := Pool{Size: 3, Candidates: candidates}
+	cfg := Settings{Mode: ModeEnforced, Retention: DefaultRetention, SplitThresholdRPM: DefaultSplitThresholdRPM, MaxInflightDelta: 4}
+	req := &Request{Outcome: OutcomeKeyed, Key: key, PromptBytes: 512}
+
+	counter := LoadDemotionsTotal.WithLabelValues(model)
+	before := testutil.ToFloat64(counter)
+
+	d := s.Decide(model, req, pool, cfg)
+	if d == nil {
+		t.Fatal("expected a decision")
+	}
+	if d.Order[0] == home {
+		t.Fatalf("outlier home must not be the pick: %v", d.Order)
+	}
+	if got := testutil.ToFloat64(counter); got != before {
+		t.Fatalf("demotion counted at decision time: %v -> %v", before, got)
+	}
+
+	s.ObserveLanding(model, req, d, d.Order[0], cfg)
+	if got := testutil.ToFloat64(counter); got != before+1 {
+		t.Fatalf("demotion not counted at landing: %v -> %v", before, got)
 	}
 }
 

--- a/cacheroute/load_cap_test.go
+++ b/cacheroute/load_cap_test.go
@@ -1,0 +1,133 @@
+package cacheroute
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tinfoilsh/confidential-model-router/config"
+)
+
+func loaded(pairs ...any) []Candidate {
+	c := make([]Candidate, 0, len(pairs)/2)
+	for i := 0; i < len(pairs); i += 2 {
+		c = append(c, Candidate{Host: pairs[i].(string), InFlight: pairs[i+1].(int)})
+	}
+	return c
+}
+
+func TestCappedPickDisabledMatchesLeastLoaded(t *testing.T) {
+	ranked := loaded("warm", 9, "b", 3, "c", 0)
+	host, demoted := cappedPick(ranked, 1, -1)
+	if host != "warm" || demoted {
+		t.Fatalf("disabled cap must keep the warm pick: got %s demoted=%v", host, demoted)
+	}
+}
+
+func TestCappedPickUniformLoadKeepsWarm(t *testing.T) {
+	// A uniformly busy pool must keep its warm picks: the cap is relative
+	// to the pool minimum, not an absolute idleness requirement.
+	ranked := loaded("warm", 12, "b", 12, "c", 12)
+	host, demoted := cappedPick(ranked, 1, 0)
+	if host != "warm" || demoted {
+		t.Fatalf("uniform load must keep warm pick even at delta 0: got %s demoted=%v", host, demoted)
+	}
+}
+
+func TestCappedPickDemotesOutlier(t *testing.T) {
+	ranked := loaded("warm", 9, "b", 5, "c", 2)
+	host, demoted := cappedPick(ranked, 1, 4)
+	if host != "c" || !demoted {
+		t.Fatalf("outlier warm home must demote to least-loaded: got %s demoted=%v", host, demoted)
+	}
+	// One request shallower and the warm pick is inside the cap again.
+	ranked[0].InFlight = 6
+	host, demoted = cappedPick(ranked, 1, 4)
+	if host != "warm" || demoted {
+		t.Fatalf("within-cap warm home must win: got %s demoted=%v", host, demoted)
+	}
+}
+
+func TestCappedPickPrefersWithinCapWarmCopy(t *testing.T) {
+	// A split key with one deep and one shallow warm copy serves at the
+	// shallow copy — a warm hit, not a demotion.
+	ranked := loaded("deep", 9, "shallow", 3, "cold", 1)
+	host, demoted := cappedPick(ranked, 2, 4)
+	if host != "shallow" || demoted {
+		t.Fatalf("expected within-cap warm copy, got %s demoted=%v", host, demoted)
+	}
+}
+
+func TestCappedPickTieFavorsWarmer(t *testing.T) {
+	// Ties inside the warm set go to the higher-ranked (warmer) copy,
+	// matching leastLoaded's behavior.
+	ranked := loaded("warmest", 2, "second", 2, "cold", 0)
+	host, demoted := cappedPick(ranked, 2, 4)
+	if host != "warmest" || demoted {
+		t.Fatalf("tie must favor the warmer copy: got %s demoted=%v", host, demoted)
+	}
+}
+
+func TestDecideOrderSinksOverCapHosts(t *testing.T) {
+	s := NewShadow(prometheus.NewRegistry())
+	defer s.Close()
+
+	pool := Pool{Size: 4, Candidates: loaded("a", 0, "b", 9, "c", 1, "d", 8)}
+	cfg := Settings{Mode: ModeEnforced, Retention: DefaultRetention, SplitThresholdRPM: DefaultSplitThresholdRPM, MaxInflightDelta: 4}
+	req := &Request{Outcome: OutcomeKeyed, Key: testKey(7), PromptBytes: 1024}
+
+	d := s.Decide("m", req, pool, cfg)
+	if d == nil {
+		t.Fatal("expected a decision")
+	}
+	if len(d.Order) != 4 {
+		t.Fatalf("order must contain every candidate once: %v", d.Order)
+	}
+	// b (9) and d (8) are over min(0)+4: they must trail a and c regardless
+	// of their warmth rank.
+	overCap := map[string]bool{"b": true, "d": true}
+	if overCap[d.Order[0]] || overCap[d.Order[1]] {
+		t.Fatalf("over-cap host ranked before within-cap hosts: %v", d.Order)
+	}
+	if !overCap[d.Order[2]] || !overCap[d.Order[3]] {
+		t.Fatalf("over-cap hosts must sink to the tail: %v", d.Order)
+	}
+	if slices.Contains(d.Order[1:], d.Order[0]) {
+		t.Fatalf("pick duplicated in order: %v", d.Order)
+	}
+}
+
+func TestDecideDisabledCapKeepsFullRanking(t *testing.T) {
+	s := NewShadow(prometheus.NewRegistry())
+	defer s.Close()
+
+	pool := Pool{Size: 3, Candidates: loaded("a", 0, "b", 9, "c", 1)}
+	cfg := Settings{Mode: ModeEnforced, Retention: DefaultRetention, SplitThresholdRPM: DefaultSplitThresholdRPM, MaxInflightDelta: -1}
+	req := &Request{Outcome: OutcomeKeyed, Key: testKey(7), PromptBytes: 1024}
+
+	d := s.Decide("m", req, pool, cfg)
+	if d == nil || len(d.Order) != 3 {
+		t.Fatalf("expected full order, got %+v", d)
+	}
+}
+
+func TestSettingsFromMaxInflightDelta(t *testing.T) {
+	if got := SettingsFrom(nil).MaxInflightDelta; got != -1 {
+		t.Fatalf("nil config must disable the cap, got %d", got)
+	}
+	if got := SettingsFrom(&config.CacheRouteConfig{Mode: "shadow"}).MaxInflightDelta; got != -1 {
+		t.Fatalf("omitted field must disable the cap, got %d", got)
+	}
+	zero := 0
+	if got := SettingsFrom(&config.CacheRouteConfig{Mode: "shadow", MaxInflightDelta: &zero}).MaxInflightDelta; got != 0 {
+		t.Fatalf("explicit 0 must be the strictest cap, got %d", got)
+	}
+	four := 4
+	if got := SettingsFrom(&config.CacheRouteConfig{Mode: "shadow", MaxInflightDelta: &four}).MaxInflightDelta; got != 4 {
+		t.Fatalf("explicit 4 must carry through, got %d", got)
+	}
+	negative := -3
+	if got := SettingsFrom(&config.CacheRouteConfig{Mode: "shadow", MaxInflightDelta: &negative}).MaxInflightDelta; got != -1 {
+		t.Fatalf("negative must disable the cap, got %d", got)
+	}
+}

--- a/cacheroute/metrics.go
+++ b/cacheroute/metrics.go
@@ -71,6 +71,19 @@ var (
 		[]string{"model"},
 	)
 
+	// LoadDemotionsTotal counts keyed requests whose whole warm set was
+	// over the load cap (max_inflight_delta), so the pick fell back to the
+	// least-loaded replica — a cache win given up to preserve balance. Fed
+	// by enforced decisions and shadow simulations alike; per-key demotion
+	// rate is the tuning signal for the cap.
+	LoadDemotionsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_cache_route_load_demotions_total",
+			Help: "Keyed requests routed to the least-loaded replica instead of a warm one because the warm set exceeded the load cap",
+		},
+		[]string{"model"},
+	)
+
 	// RepeatIntervalSeconds measures time between sightings of a key.
 	// Buckets straddle every plausible retention window.
 	RepeatIntervalSeconds = promauto.NewHistogramVec(

--- a/cacheroute/metrics.go
+++ b/cacheroute/metrics.go
@@ -73,9 +73,11 @@ var (
 
 	// LoadDemotionsTotal counts keyed requests whose whole warm set was
 	// over the load cap (max_inflight_delta), so the pick fell back to the
-	// least-loaded replica — a cache win given up to preserve balance. Fed
-	// by enforced decisions and shadow simulations alike; per-key demotion
-	// rate is the tuning signal for the cap.
+	// least-loaded replica — a cache win given up to preserve balance.
+	// Recorded at landing for enforced decisions and shadow simulations
+	// alike (never for requests rejected before dispatch), so its rate is
+	// directly comparable to the other cache-route series; the demotion
+	// share of keyed traffic is the tuning signal for the cap.
 	LoadDemotionsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_cache_route_load_demotions_total",

--- a/cacheroute/metrics_test.go
+++ b/cacheroute/metrics_test.go
@@ -35,6 +35,7 @@ func TestMetricContract(t *testing.T) {
 	// values.
 	KeyEvictionsTotal.WithLabelValues(model, "ttl")
 	RandomMatchTotal.WithLabelValues(model)
+	LoadDemotionsTotal.WithLabelValues(model)
 
 	want := map[string][]string{
 		"router_cache_route_requests_total":           {"model", "outcome"},
@@ -42,6 +43,7 @@ func TestMetricContract(t *testing.T) {
 		"router_cache_route_reuse_prompt_bytes_total": {"model", "outcome"},
 		"router_cache_route_picks_total":              {"model", "enclave", "r"},
 		"router_cache_route_random_match_total":       {"model"},
+		"router_cache_route_load_demotions_total":     {"model"},
 		"router_cache_route_repeat_interval_seconds":  {"model"},
 		"router_cache_route_key_rpm":                  {"model"},
 		"router_cache_route_key_evictions_total":      {"model", "reason"},

--- a/cacheroute/shadow.go
+++ b/cacheroute/shadow.go
@@ -148,6 +148,7 @@ type Decision struct {
 	pool    Pool
 	home    string
 	r       int
+	demoted bool // the load cap displaced the warm pick
 	elapsed time.Duration
 }
 
@@ -170,10 +171,11 @@ func (s *Shadow) Decide(model string, req *Request, pool Pool, cfg Settings) (d 
 	}
 	ranked := rank(req.Key, pool.Candidates)
 	r := replicationFactor(s.peekRate(model, req.Key), cfg.SplitThresholdRPM, len(ranked))
+	// The demotion is metered at landing (see observe), not here: a request
+	// this decision routes can still be rejected before dispatch, and a
+	// demotion count without a landing would diverge from every other
+	// cache-route series exactly during the overload windows it is read in.
 	pick, demoted := cappedPick(ranked, r, cfg.MaxInflightDelta)
-	if demoted {
-		LoadDemotionsTotal.WithLabelValues(model).Inc()
-	}
 	// Over-cap hosts sink below every within-cap one so overload spill from
 	// the pick falls through to the key's next warm *eligible* copy instead
 	// of re-concentrating on an already-deep replica.
@@ -203,6 +205,7 @@ func (s *Shadow) Decide(model string, req *Request, pool Pool, cfg Settings) (d 
 		pool:    pool,
 		home:    ranked[0].Host,
 		r:       r,
+		demoted: demoted,
 		elapsed: time.Since(start),
 	}
 }
@@ -262,9 +265,9 @@ func (s *Shadow) observe(model string, req *Request, pool Pool, actualHost strin
 		RepeatIntervalSeconds.WithLabelValues(model).Observe(res.interval.Seconds())
 	}
 	KeyRPM.WithLabelValues(model).Observe(res.rpm)
-	// Enforced decisions count their demotions in Decide; this covers the
-	// shadow simulation, so the would-be demotion rate is visible before a
-	// pool is ever enforced.
+	// Counted here for enforced decisions and shadow simulations alike, so
+	// both modes meter demotions over the same population as every other
+	// series: requests that landed.
 	if res.demoted {
 		LoadDemotionsTotal.WithLabelValues(model).Inc()
 	}
@@ -375,6 +378,7 @@ func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, act
 	home := ""
 	if d != nil {
 		home, res.r = d.home, d.r
+		res.demoted = d.demoted
 	} else {
 		ranked := rank(key, candidates)
 		res.r = replicationFactor(res.rpm, cfg.SplitThresholdRPM, len(ranked))

--- a/cacheroute/shadow.go
+++ b/cacheroute/shadow.go
@@ -170,12 +170,32 @@ func (s *Shadow) Decide(model string, req *Request, pool Pool, cfg Settings) (d 
 	}
 	ranked := rank(req.Key, pool.Candidates)
 	r := replicationFactor(s.peekRate(model, req.Key), cfg.SplitThresholdRPM, len(ranked))
-	pick := leastLoaded(ranked[:r]).Host
+	pick, demoted := cappedPick(ranked, r, cfg.MaxInflightDelta)
+	if demoted {
+		LoadDemotionsTotal.WithLabelValues(model).Inc()
+	}
+	// Over-cap hosts sink below every within-cap one so overload spill from
+	// the pick falls through to the key's next warm *eligible* copy instead
+	// of re-concentrating on an already-deep replica.
 	order := make([]string, 0, len(ranked))
 	order = append(order, pick)
-	for _, c := range ranked {
-		if c.Host != pick {
-			order = append(order, c.Host)
+	if delta := cfg.MaxInflightDelta; delta >= 0 {
+		limit := minInFlight(ranked) + delta
+		for _, c := range ranked {
+			if c.Host != pick && c.InFlight <= limit {
+				order = append(order, c.Host)
+			}
+		}
+		for _, c := range ranked {
+			if c.Host != pick && c.InFlight > limit {
+				order = append(order, c.Host)
+			}
+		}
+	} else {
+		for _, c := range ranked {
+			if c.Host != pick {
+				order = append(order, c.Host)
+			}
 		}
 	}
 	return &Decision{
@@ -242,6 +262,12 @@ func (s *Shadow) observe(model string, req *Request, pool Pool, actualHost strin
 		RepeatIntervalSeconds.WithLabelValues(model).Observe(res.interval.Seconds())
 	}
 	KeyRPM.WithLabelValues(model).Observe(res.rpm)
+	// Enforced decisions count their demotions in Decide; this covers the
+	// shadow simulation, so the would-be demotion rate is visible before a
+	// pool is ever enforced.
+	if res.demoted {
+		LoadDemotionsTotal.WithLabelValues(model).Inc()
+	}
 
 	// A breaker probe serves from outside the ranked membership (health
 	// beats cache), so the dispatch was not a random draw from the
@@ -296,7 +322,8 @@ type keyedResult struct {
 	repeat   bool // the key was already in the table
 	interval time.Duration
 	rpm      float64
-	pick     string // least-loaded of the top-R ranking; unset when a Decision was supplied
+	pick     string // capped least-loaded of the top-R ranking; unset when a Decision was supplied
+	demoted  bool   // the load cap displaced the warm pick; unset when a Decision was supplied
 	r        int
 }
 
@@ -351,7 +378,10 @@ func (s *Shadow) observeKeyed(model string, key Key, candidates []Candidate, act
 	} else {
 		ranked := rank(key, candidates)
 		res.r = replicationFactor(res.rpm, cfg.SplitThresholdRPM, len(ranked))
-		res.pick = leastLoaded(ranked[:res.r]).Host
+		// The cap applies to the shadow pick too, so the simulated
+		// placement distribution (PicksTotal) shows what enforcement
+		// would actually do under the same settings.
+		res.pick, res.demoted = cappedPick(ranked, res.r, cfg.MaxInflightDelta)
 		home = ranked[0].Host
 	}
 	s.shiftCountLocked(model, e.home, e.r, home, res.r)

--- a/cacheroute/shadow.go
+++ b/cacheroute/shadow.go
@@ -140,9 +140,12 @@ func (s *Shadow) Close() {
 // ranking and one pool snapshot per request, so the recorded replication
 // factor is the one that actually shaped routing.
 type Decision struct {
-	// Order is the host preference: the pick (least-loaded of the key's
-	// top-R replicas) first, then the rest of the ranking, so an
-	// unacceptable pick spills to the next-warmest host.
+	// Order is the host preference. First the pick: the least-loaded of
+	// the key's top-R replicas within the load cap, or — when the whole
+	// warm set is over the cap — the least-loaded candidate overall. Then
+	// the rest of the ranking, within-cap hosts before over-cap ones, so
+	// an unacceptable pick spills to the next-warmest host that the cap
+	// still allows.
 	Order []string
 
 	pool    Pool

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,12 @@ type CacheRouteConfig struct {
 	RetentionWindowMinutes int     `yaml:"retention_window_minutes,omitempty"`
 	MinPromptBytes         int     `yaml:"min_prompt_bytes,omitempty"`
 	SplitThresholdRPM      float64 `yaml:"split_threshold_rpm,omitempty"`
+	// MaxInflightDelta caps how much deeper in-flight a warm pick may be
+	// than the pool's least-loaded replica before the pick falls back to
+	// least-loaded routing. 0 is the strictest cap (warm only on a tie);
+	// omitted or negative disables the cap. A pointer so 0 and omitted
+	// stay distinguishable.
+	MaxInflightDelta *int `yaml:"max_inflight_delta,omitempty"`
 }
 
 // ReservationConfig dedicates a subset of a model's enclaves to the listed


### PR DESCRIPTION
Adds an optional per-model `cache_route.max_inflight_delta`: a warm pick is honored only while its live in-flight count is within the delta of the pool's least-loaded replica, otherwise selection falls back to least-loaded and the sacrificed hit is counted in a new `router_cache_route_load_demotions_total` metric. Because the cap is relative to the pool minimum, uniformly busy pools keep their warm picks — it only overrides stickiness when a replica becomes a load outlier, which bounds the imbalance cache-aware routing can create regardless of key distribution. The cap also applies to shadow-mode simulated picks, so the capped placement distribution is observable before enforcing a pool. Omitted or negative disables the cap; behavior is unchanged for existing configs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a load cap to cache-aware routing to prevent warm picks from overloading a single replica. A warm pick is used only if its in-flight count is within `max_inflight_delta` of the pool’s least‑loaded replica; otherwise we fall back to least‑loaded and count a demotion at landing via `router_cache_route_load_demotions_total`.

- **New Features**
  - Per-model `cache_route.max_inflight_delta` config (0 = strictest; omitted/negative = disabled).
  - Cap applies in enforced and shadow mode; shadow uses capped simulated picks so placement can be validated first.
  - Over-cap hosts are pushed after within-cap hosts in the fallback order to spread spillover.
  - Metric `router_cache_route_load_demotions_total` (by model), counted at landing for sacrificed warm hits in both enforced and shadow paths.

- **Migration**
  - No change by default.
  - To enable, set `cache_route.max_inflight_delta` to a non-negative integer and monitor `router_cache_route_load_demotions_total`.

<sup>Written for commit a5606ce01de5c58ff5cc59ff7762bd487a96411b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

