### PR TITLE
Measure backend /health response latency

### DIFF
--- a/manager/health.go
+++ b/manager/health.go
@@ -1,0 +1,134 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	tinfoilClient "github.com/tinfoilsh/tinfoil-go/verifier/client"
+)
+
+const (
+	defaultHealthProbeInterval = 5 * time.Second
+	healthProbeTimeout         = 30 * time.Second
+)
+
+// enclaveHealthProber measures whether the backend event loop can answer
+// /health. It is deliberately observational: failures do not affect replica
+// selection or circuit-breaker state.
+type enclaveHealthProber struct {
+	host  string
+	model string
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	client *http.Client
+}
+
+func newEnclaveHealthProber(host, model, tlsKeyFP string) *enclaveHealthProber {
+	return &enclaveHealthProber{
+		host:  host,
+		model: model,
+		client: &http.Client{
+			Timeout: healthProbeTimeout,
+			Transport: &tinfoilClient.TLSBoundRoundTripper{
+				ExpectedPublicKey: tlsKeyFP,
+			},
+		},
+	}
+}
+
+func (p *enclaveHealthProber) start() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.cancel != nil {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p.cancel = cancel
+	p.wg.Add(1)
+	go p.run(ctx)
+}
+
+func (p *enclaveHealthProber) run(ctx context.Context) {
+	defer p.wg.Done()
+
+	p.probe(ctx)
+
+	ticker := time.NewTicker(defaultHealthProbeInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.probe(ctx)
+		}
+	}
+}
+
+func (p *enclaveHealthProber) probe(ctx context.Context) {
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("https://%s/health", p.host),
+		nil,
+	)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"model":   p.model,
+			"enclave": p.host,
+		}).Debugf("health probe request creation failed: %v", err)
+		return
+	}
+
+	start := time.Now()
+	resp, err := p.client.Do(req)
+	elapsed := time.Since(start).Seconds()
+	if err != nil {
+		// Shutdown cancellation is not a backend failure and should not leave
+		// a misleading error observation.
+		if ctx.Err() != nil {
+			return
+		}
+		BackendHealthProbeDurationSeconds.WithLabelValues(p.model, p.host, "error").Observe(elapsed)
+		log.WithFields(log.Fields{
+			"model":   p.model,
+			"enclave": p.host,
+		}).Debugf("health probe failed after %.3fs: %v", elapsed, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	result := "success"
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		result = "error"
+	}
+	BackendHealthProbeDurationSeconds.WithLabelValues(p.model, p.host, result).Observe(elapsed)
+
+	if result == "error" {
+		log.WithFields(log.Fields{
+			"model":   p.model,
+			"enclave": p.host,
+			"status":  resp.StatusCode,
+		}).Debugf("health probe returned an error after %.3fs", elapsed)
+	}
+}
+
+func (p *enclaveHealthProber) shutdown() {
+	p.mu.Lock()
+	cancel := p.cancel
+	p.cancel = nil
+	p.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+		p.wg.Wait()
+	}
+}

--- a/manager/health_test.go
+++ b/manager/health_test.go
@@ -1,0 +1,72 @@
+package manager
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func healthProbeCount(t *testing.T, model, host, result string) uint64 {
+	t.Helper()
+	observer := BackendHealthProbeDurationSeconds.WithLabelValues(model, host, result)
+	metric, ok := observer.(prometheus.Metric)
+	if !ok {
+		t.Fatal("health probe histogram does not implement prometheus.Metric")
+	}
+	var value dto.Metric
+	if err := metric.Write(&value); err != nil {
+		t.Fatalf("write health probe metric: %v", err)
+	}
+	return value.GetHistogram().GetSampleCount()
+}
+
+func TestHealthProbeRecordsLatencyByResult(t *testing.T) {
+	status := http.StatusNoContent
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/health" {
+			t.Errorf("path = %s, want /health", r.URL.Path)
+		}
+		w.WriteHeader(status)
+	}))
+	defer ts.Close()
+
+	host := strings.TrimPrefix(ts.URL, "https://")
+	model := "health-probe-test-model"
+	prober := newEnclaveHealthProber(host, model, "unused-in-test")
+	prober.client = ts.Client()
+
+	successBefore := healthProbeCount(t, model, host, "success")
+	prober.probe(context.Background())
+	if got := healthProbeCount(t, model, host, "success") - successBefore; got != 1 {
+		t.Fatalf("success observations = %d, want 1", got)
+	}
+
+	status = http.StatusServiceUnavailable
+	errorBefore := healthProbeCount(t, model, host, "error")
+	prober.probe(context.Background())
+	if got := healthProbeCount(t, model, host, "error") - errorBefore; got != 1 {
+		t.Fatalf("error observations = %d, want 1", got)
+	}
+}
+
+func TestHealthProbeDoesNotRecordShutdownCancellation(t *testing.T) {
+	host := "shutdown-cancellation.invalid"
+	model := "health-probe-cancellation-test-model"
+	prober := newEnclaveHealthProber(host, model, "unused-in-test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	before := healthProbeCount(t, model, host, "error")
+	prober.probe(ctx)
+	if got := healthProbeCount(t, model, host, "error") - before; got != 0 {
+		t.Fatalf("error observations = %d, want 0 for shutdown cancellation", got)
+	}
+}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -35,6 +35,7 @@ type Enclave struct {
 	predicate attestation.PredicateType
 	proxy     *httputil.ReverseProxy
 	metrics   *enclaveMetrics
+	health    *enclaveHealthProber
 	cb        *circuitBreaker
 
 	// inflight counts requests currently proxied through this enclave —
@@ -330,7 +331,10 @@ func (em *EnclaveManager) addEnclave(
 	}
 
 	cb := newCircuitBreaker()
-	model.Enclaves[host] = &Enclave{
+	if current := model.Enclaves[host]; current != nil && current.health != nil {
+		current.health.shutdown()
+	}
+	enclave := &Enclave{
 		host:      host,
 		modelName: modelName,
 		predicate: verification.Measurement.Type,
@@ -338,9 +342,12 @@ func (em *EnclaveManager) addEnclave(
 		hpkeKey:   verification.HPKEPublicKey,
 		proxy:     newProxy(host, verification.TLSPublicKeyFP, modelName, em.billingCollector, cb),
 		metrics:   newEnclaveMetrics(host, modelName),
+		health:    newEnclaveHealthProber(host, modelName, verification.TLSPublicKeyFP),
 		cb:        cb,
 	}
-	model.Enclaves[host].updateOverloadConfig(model.Overload)
+	model.Enclaves[host] = enclave
+	enclave.updateOverloadConfig(model.Overload)
+	enclave.health.start()
 	CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cbClosed))
 	return nil
 }
@@ -1109,6 +1116,9 @@ func (e *Enclave) shutdown() {
 	}
 	if e.metrics != nil {
 		e.metrics.shutdown()
+	}
+	if e.health != nil {
+		e.health.shutdown()
 	}
 	if e.cb != nil {
 		e.cb.Retire()

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -112,6 +112,17 @@ var (
 		[]string{"model", "enclave"},
 	)
 
+	// BackendHealthProbeDurationSeconds tracks active /health checks against
+	// every attested backend, independently of overload metrics polling.
+	BackendHealthProbeDurationSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "router_backend_health_probe_duration_seconds",
+			Help:    "Time for an attested backend enclave's /health endpoint to respond, by result",
+			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+		},
+		[]string{"model", "enclave", "result"},
+	)
+
 	// OverloadEventsTotal tracks the total number of times a backend entered overload state
 	OverloadEventsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
## Summary

- probe every attested model replica's `/health` endpoint every 5 seconds
- export `router_backend_health_probe_duration_seconds{model,enclave,result}` with buckets through 60 seconds
- keep the signal observational: probe failures do not affect routing or circuit-breaker state

This gives us a direct way to compare replica event-loop responsiveness before and after [confidential-gemma4-31b#40](https://github.com/tinfoilsh/confidential-gemma4-31b/pull/40).

```promql
histogram_quantile(0.95, sum by (le, enclave) (rate(router_backend_health_probe_duration_seconds_bucket[5m])))
```

## Test

- `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds periodic /health latency probes for each attested backend and exposes a Prometheus histogram to track responsiveness. Probes run every 5s and do not affect routing or circuit-breaker state.

- **New Features**
  - Export `router_backend_health_probe_duration_seconds{model,enclave,result}` with buckets up to 60s.
  - Start a per-enclave prober on add, and cleanly shut it down on removal.
  - Use a TLS-bound HTTP client with a 30s timeout; ignore shutdown-cancellation in metrics.

<sup>Written for commit 14752db20637531f9e1749f26f7d3c6be2bdc4f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

