### PR TITLE
fix: close completed streaming responses

### DIFF
--- a/tokencount/extractor.go
+++ b/tokencount/extractor.go
@@ -176,29 +176,47 @@ func NewStreamingTokenExtractor(reader io.ReadCloser, writer io.WriteCloser, mod
 // processStream processes the SSE stream, extracting token usage
 func (s *StreamingTokenExtractor) processStream() {
 	defer s.writer.Close()
+	defer s.reader.Close()
 
 	lastLineWasFiltered := false
+	terminalEventPending := false
+	terminalResponseEvent := false
+	eventHasData := false
 
 	for s.scanner.Scan() {
 		line := s.scanner.Text()
 		shouldWrite := true
+		if strings.HasPrefix(line, "event:") {
+			eventType := strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			terminalResponseEvent = isTerminalResponseEvent(eventType)
+		}
 
 		// If the previous line was filtered and this is an empty line, skip it
 		// to avoid consecutive empty lines in the output
 		if lastLineWasFiltered && line == "" {
 			lastLineWasFiltered = false
+			terminalEventPending = false
+			terminalResponseEvent = false
+			eventHasData = false
 			continue
 		}
 
 		lastLineWasFiltered = false
 
 		// Parse SSE data lines
-		if strings.HasPrefix(line, "data: ") {
-			data := strings.TrimPrefix(line, "data: ")
-			if data != "[DONE]" {
+		if strings.HasPrefix(line, "data:") {
+			eventHasData = true
+			data := strings.TrimPrefix(line, "data:")
+			data = strings.TrimPrefix(data, " ")
+			if data == "[DONE]" {
+				terminalEventPending = true
+			} else {
 				// Try to parse the chunk
 				var chunk map[string]interface{}
 				if err := json.Unmarshal([]byte(data), &chunk); err == nil {
+					if eventType, ok := chunk["type"].(string); ok && isTerminalResponseEvent(eventType) {
+						terminalEventPending = true
+					}
 					// Check for usage in the chunk (Chat Completions API)
 					// or nested under "response" (Responses API streaming)
 					usageData, ok := chunk["usage"]
@@ -240,6 +258,9 @@ func (s *StreamingTokenExtractor) processStream() {
 					}
 				}
 			}
+			if terminalResponseEvent {
+				terminalEventPending = true
+			}
 		}
 
 		// Write the line to output if we should
@@ -249,6 +270,15 @@ func (s *StreamingTokenExtractor) processStream() {
 			} else {
 				s.writer.Write([]byte(line + "\n"))
 			}
+		}
+
+		if line == "" {
+			if terminalEventPending && eventHasData {
+				break
+			}
+			terminalEventPending = false
+			terminalResponseEvent = false
+			eventHasData = false
 		}
 	}
 
@@ -266,6 +296,15 @@ func (s *StreamingTokenExtractor) processStream() {
 	}
 
 	s.completed = true
+}
+
+func isTerminalResponseEvent(eventType string) bool {
+	switch eventType {
+	case "response.completed", "response.failed", "response.incomplete":
+		return true
+	default:
+		return false
+	}
 }
 
 // Read implements io.Reader for compatibility

--- a/tokencount/extractor.go
+++ b/tokencount/extractor.go
@@ -148,6 +148,10 @@ func ExtractTokensFromResponseWithHandler(resp *http.Response, model string, usa
 	}, nil, nil
 }
 
+// maxSSELineBytes bounds a single SSE line; mirrors the tool runtime's
+// sseReader limit so large frames survive both parsers.
+const maxSSELineBytes = 1 << 22 // 4 MiB
+
 // StreamingTokenExtractor handles token extraction for streaming responses
 type StreamingTokenExtractor struct {
 	reader               io.ReadCloser
@@ -170,6 +174,10 @@ func NewStreamingTokenExtractor(reader io.ReadCloser, writer io.WriteCloser, mod
 		usage:  &Usage{},
 	}
 	s.scanner = bufio.NewScanner(reader)
+	// Single SSE lines can exceed bufio's 64KiB default (for example a large
+	// tool-call argument blob in one chunk), which would abort the stream
+	// with ErrTooLong and surface as a silent truncation to the client.
+	s.scanner.Buffer(make([]byte, 0, 64*1024), maxSSELineBytes)
 	return s
 }
 
@@ -258,9 +266,6 @@ func (s *StreamingTokenExtractor) processStream() {
 					}
 				}
 			}
-			if terminalResponseEvent {
-				terminalEventPending = true
-			}
 		}
 
 		// Write the line to output if we should
@@ -273,7 +278,7 @@ func (s *StreamingTokenExtractor) processStream() {
 		}
 
 		if line == "" {
-			if terminalEventPending && eventHasData {
+			if (terminalEventPending || terminalResponseEvent) && eventHasData {
 				break
 			}
 			terminalEventPending = false
@@ -300,7 +305,7 @@ func (s *StreamingTokenExtractor) processStream() {
 
 func isTerminalResponseEvent(eventType string) bool {
 	switch eventType {
-	case "response.completed", "response.failed", "response.incomplete":
+	case "response.completed", "response.failed", "response.incomplete", "error":
 		return true
 	default:
 		return false
@@ -311,9 +316,4 @@ func isTerminalResponseEvent(eventType string) bool {
 func (s *StreamingTokenExtractor) Read(p []byte) (n int, err error) {
 	// This is mainly for compatibility - actual processing happens in processStream
 	return s.buffer.Read(p)
-}
-
-// Close implements io.Closer
-func (s *StreamingTokenExtractor) Close() error {
-	return s.reader.Close()
 }

--- a/tokencount/extractor_streaming_test.go
+++ b/tokencount/extractor_streaming_test.go
@@ -161,12 +161,14 @@ data: [DONE]
 
 func TestExtractTokensFromResponseWithHandler_Parameters(t *testing.T) {
 	// Test that the function properly accepts and uses the clientRequestedUsage parameter
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Header: http.Header{
-			"Content-Type": []string{"text/event-stream"},
-		},
-		Body: io.NopCloser(strings.NewReader("data: test\n")),
+	makeResponse := func() *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			Body: io.NopCloser(strings.NewReader("data: test\n")),
+		}
 	}
 
 	usageHandler := func(usage *Usage) {
@@ -174,7 +176,7 @@ func TestExtractTokensFromResponseWithHandler_Parameters(t *testing.T) {
 	}
 
 	// Call with clientRequestedUsage = true
-	body, usage, err := ExtractTokensFromResponseWithHandler(resp, "test-model", usageHandler, true)
+	body, usage, err := ExtractTokensFromResponseWithHandler(makeResponse(), "test-model", usageHandler, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -186,7 +188,7 @@ func TestExtractTokensFromResponseWithHandler_Parameters(t *testing.T) {
 	}
 
 	// Test backward compatibility
-	body2, usage2, err2 := ExtractTokensFromResponse(resp, "test-model")
+	body2, usage2, err2 := ExtractTokensFromResponse(makeResponse(), "test-model")
 	if err2 != nil {
 		t.Errorf("Unexpected error in backward compatible function: %v", err2)
 	}
@@ -456,6 +458,97 @@ func TestResponseCompletedEventEndsOpenUpstreamStream(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("stream remained open after the response completed event")
+	}
+}
+
+func TestTerminalEventLineAfterDataLineEndsOpenUpstreamStream(t *testing.T) {
+	upstreamReader, upstreamWriter := io.Pipe()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Body: upstreamReader,
+	}
+	body, _, err := ExtractTokensFromResponse(resp, "test-model")
+	if err != nil {
+		t.Fatalf("ExtractTokensFromResponse() error = %v", err)
+	}
+	defer body.Close()
+	defer upstreamWriter.Close()
+
+	input := "data: {\"response\":{\"status\":\"completed\"}}\nevent: response.completed\n\n"
+	go func() {
+		_, _ = io.WriteString(upstreamWriter, input)
+	}()
+
+	readDone := make(chan []byte, 1)
+	go func() {
+		output, _ := io.ReadAll(body)
+		readDone <- output
+	}()
+
+	select {
+	case output := <-readDone:
+		if string(output) != input {
+			t.Fatalf("Expected:\n%q\nGot:\n%q", input, output)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stream remained open when the event line followed the data line")
+	}
+}
+
+func TestResponsesErrorEventEndsOpenUpstreamStream(t *testing.T) {
+	upstreamReader, upstreamWriter := io.Pipe()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Body: upstreamReader,
+	}
+	body, _, err := ExtractTokensFromResponse(resp, "test-model")
+	if err != nil {
+		t.Fatalf("ExtractTokensFromResponse() error = %v", err)
+	}
+	defer body.Close()
+	defer upstreamWriter.Close()
+
+	input := "event: error\ndata: {\"type\":\"error\",\"message\":\"upstream failure\"}\n\n"
+	go func() {
+		_, _ = io.WriteString(upstreamWriter, input)
+	}()
+
+	readDone := make(chan []byte, 1)
+	go func() {
+		output, _ := io.ReadAll(body)
+		readDone <- output
+	}()
+
+	select {
+	case output := <-readDone:
+		if string(output) != input {
+			t.Fatalf("Expected:\n%q\nGot:\n%q", input, output)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stream remained open after the error event")
+	}
+}
+
+func TestLargeSSELineSurvivesScannerBuffer(t *testing.T) {
+	largeContent := strings.Repeat("a", 128*1024)
+	input := "data: {\"choices\":[{\"delta\":{\"content\":\"" + largeContent + "\"}}]}\n\ndata: [DONE]\n\n"
+	inputReader := io.NopCloser(strings.NewReader(input))
+	pr, pw := io.Pipe()
+	extractor := NewStreamingTokenExtractor(inputReader, pw, "test-model")
+
+	go extractor.processStream()
+	output, err := io.ReadAll(pr)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(output) != input {
+		t.Fatalf("large SSE line was truncated: got %d bytes, want %d", len(output), len(input))
 	}
 }
 

--- a/tokencount/extractor_streaming_test.go
+++ b/tokencount/extractor_streaming_test.go
@@ -385,6 +385,96 @@ func TestFilteredChunkMustNotLeaveEmptySSEEvent(t *testing.T) {
 	}
 }
 
+func TestDoneEventEndsOpenUpstreamStream(t *testing.T) {
+	upstreamReader, upstreamWriter := io.Pipe()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Body: upstreamReader,
+	}
+	body, _, err := ExtractTokensFromResponse(resp, "test-model")
+	if err != nil {
+		t.Fatalf("ExtractTokensFromResponse() error = %v", err)
+	}
+	defer body.Close()
+	defer upstreamWriter.Close()
+
+	go func() {
+		_, _ = io.WriteString(upstreamWriter, "data: {\"choices\":[{\"delta\":{\"content\":\"complete\"}}]}\n\ndata:[DONE]\n\n")
+	}()
+
+	readDone := make(chan []byte, 1)
+	go func() {
+		output, _ := io.ReadAll(body)
+		readDone <- output
+	}()
+
+	select {
+	case output := <-readDone:
+		expected := "data: {\"choices\":[{\"delta\":{\"content\":\"complete\"}}]}\n\ndata:[DONE]\n\n"
+		if string(output) != expected {
+			t.Fatalf("Expected:\n%q\nGot:\n%q", expected, output)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stream remained open after the done event")
+	}
+}
+
+func TestResponseCompletedEventEndsOpenUpstreamStream(t *testing.T) {
+	upstreamReader, upstreamWriter := io.Pipe()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Body: upstreamReader,
+	}
+	body, _, err := ExtractTokensFromResponse(resp, "test-model")
+	if err != nil {
+		t.Fatalf("ExtractTokensFromResponse() error = %v", err)
+	}
+	defer body.Close()
+	defer upstreamWriter.Close()
+
+	input := "data: {\"response\":{\"status\":\"completed\"},\"type\":\"response.completed\"}\n\n"
+	go func() {
+		_, _ = io.WriteString(upstreamWriter, input)
+	}()
+
+	readDone := make(chan []byte, 1)
+	go func() {
+		output, _ := io.ReadAll(body)
+		readDone <- output
+	}()
+
+	select {
+	case output := <-readDone:
+		if string(output) != input {
+			t.Fatalf("Expected:\n%q\nGot:\n%q", input, output)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stream remained open after the response completed event")
+	}
+}
+
+func TestResponseTerminalEventWithoutDataDoesNotEndStream(t *testing.T) {
+	input := "event: response.completed\n\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"later\"}\n\ndata: [DONE]\n\n"
+	inputReader := io.NopCloser(strings.NewReader(input))
+	pr, pw := io.Pipe()
+	extractor := NewStreamingTokenExtractor(inputReader, pw, "test-model")
+
+	go extractor.processStream()
+	output, err := io.ReadAll(pr)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(output) != input {
+		t.Fatalf("Expected:\n%q\nGot:\n%q", input, output)
+	}
+}
+
 func TestEdgeCases(t *testing.T) {
 	tests := []struct {
 		name                 string


### PR DESCRIPTION
## Summary
- end proxied SSE responses after a fully framed Chat Completions or Responses API terminal event
- close the upstream response body so completed streams cannot remain active indefinitely
- preserve multi-turn tool runtime behavior and cover open upstream and malformed framing cases

## Testing
- `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop leaving SSE streams open by closing the proxied response once a terminal event is fully framed. Detection is more robust now (including error events) and large SSE lines no longer get truncated.

- **Bug Fixes**
  - Detect terminal end via [DONE], event: response.* or error, or JSON type: response.* or error.
  - End only after a full event with data; also handle when the event line follows the data line.
  - Close the upstream response body when the terminal frame completes to avoid hanging streams.
  - Increase the SSE scanner buffer to 4 MiB to preserve large frames.
  - Added tests for error events, large SSE lines, and ending open upstream streams.

<sup>Written for commit 411acaaadf8f9b88a7c72654bb319bc6a5e0c4a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

