### PR TITLE
feat: report request costs and count input tokens

### DIFF
--- a/cache_salt.go
+++ b/cache_salt.go
@@ -62,14 +62,12 @@ func applyCacheSalt(body map[string]any, path, apiKey string, enabled bool) (cac
 	return mode, true
 }
 
-// saltProxiedBody applies cache-salt handling to a request that the router
-// otherwise forwards verbatim (the subdomain routing path, which never
-// parses the body elsewhere). It rewrites r.Body in place and returns the
-// derivation mode plus whether the body requests a streaming response — the
-// one routing signal this path needs from the body, surfaced here so the
-// caller doesn't have to parse it a second time. The body must be one JSON
-// object so router-owned cache fields can never bypass stripping on a
-// malformed request.
+// saltProxiedBody applies cache-salt and streaming-usage handling to a request
+// that the router otherwise forwards verbatim (the subdomain routing path,
+// which never parses the body elsewhere). It rewrites r.Body in place and
+// returns the derivation mode plus whether the body requests a streaming
+// response. The body must be one JSON object so router-owned fields can never
+// bypass rewriting on a malformed request.
 func saltProxiedBody(r *http.Request, apiKey string, enabled bool) (cachesalt.Mode, bool, error) {
 	bodyBytes, err := io.ReadAll(r.Body)
 	r.Body.Close()
@@ -94,6 +92,10 @@ func saltProxiedBody(r *http.Request, apiKey string, enabled bool) (cachesalt.Mo
 	streaming, _ := body["stream"].(bool)
 
 	mode, changed := applyCacheSalt(body, r.URL.Path, apiKey, enabled)
+	if streaming {
+		ensureStreamingUsageOptions(body, r.Header)
+		changed = true
+	}
 	if !changed {
 		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		return mode, streaming, nil

--- a/cache_salt_test.go
+++ b/cache_salt_test.go
@@ -343,6 +343,11 @@ func TestSaltProxiedBody(t *testing.T) {
 		if !streaming {
 			t.Error("stream:true was not reported")
 		}
+		body := decodeBody(t, req)
+		streamOptions, ok := body["stream_options"].(map[string]any)
+		if !ok || streamOptions["include_usage"] != true || streamOptions["continuous_usage_stats"] != true {
+			t.Fatalf("streaming usage options were not injected: %#v", body)
+		}
 
 		// A non-boolean stream value must read as non-streaming, not error.
 		req = httptest.NewRequest("POST", "/v1/chat/completions",

--- a/input_tokens.go
+++ b/input_tokens.go
@@ -30,6 +30,7 @@ func handleInputTokens(
 	w http.ResponseWriter,
 	r *http.Request,
 	apiKey string,
+	routedModel string,
 	resolveModel inputTokenModelResolver,
 	dispatch inputTokenDispatch,
 ) {
@@ -56,7 +57,7 @@ func handleInputTokens(
 		return
 	}
 
-	modelName, err := inputTokensModel(body, resolveModel)
+	modelName, err := inputTokensModel(body, routedModel, resolveModel)
 	if err != nil {
 		jsonError(w, err.Error(), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 		return
@@ -118,7 +119,10 @@ func handleInputTokens(
 	})
 }
 
-func inputTokensModel(body map[string]any, resolveModel inputTokenModelResolver) (string, error) {
+func inputTokensModel(body map[string]any, routedModel string, resolveModel inputTokenModelResolver) (string, error) {
+	if routedModel != "" {
+		return routedModel, nil
+	}
 	modelValue, ok := body["model"]
 	if !ok {
 		return "", fmt.Errorf("Missing required parameter: 'model'.")
@@ -174,6 +178,9 @@ func responsesTokenizeBody(body map[string]any, modelName string) (map[string]an
 func responsesMessages(body map[string]any) ([]any, error) {
 	messages := make([]any, 0)
 	if instructions, ok := body["instructions"]; ok {
+		if instructions == nil {
+			instructions = ""
+		}
 		text, ok := instructions.(string)
 		if !ok {
 			return nil, fmt.Errorf("Invalid parameter: 'instructions' must be a string.")
@@ -276,6 +283,12 @@ func responsesContent(content any) (any, error) {
 				image["detail"] = detail
 			}
 			converted = append(converted, map[string]any{"type": "image_url", "image_url": image})
+		case "refusal":
+			refusal, ok := part["refusal"].(string)
+			if !ok {
+				return nil, fmt.Errorf("Responses refusal content requires string 'refusal'.")
+			}
+			converted = append(converted, map[string]any{"type": "text", "text": refusal})
 		default:
 			return nil, fmt.Errorf("Unsupported Responses content part type %q.", partType)
 		}
@@ -330,10 +343,14 @@ func responsesFunctionCallOutput(item map[string]any) (map[string]any, error) {
 	if !ok {
 		return nil, fmt.Errorf("Responses function_call_output items require 'output'.")
 	}
+	converted, err := responsesContent(output)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid function_call_output output: %w", err)
+	}
 	return map[string]any{
 		"role":         "tool",
 		"tool_call_id": callID,
-		"content":      output,
+		"content":      converted,
 	}, nil
 }
 

--- a/input_tokens.go
+++ b/input_tokens.go
@@ -1,0 +1,390 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/tinfoilsh/confidential-model-router/manager"
+)
+
+const (
+	chatInputTokensPath      = "/v1/chat/completions/input_tokens"
+	responsesInputTokensPath = "/v1/responses/input_tokens"
+	tokenizePath             = "/tokenize"
+	inputTokensAuthErrorType = "authentication_error"
+	maxInputTokensErrorBytes = 1 << 20
+)
+
+type inputTokenDispatch func(context.Context, string, string, []byte, http.Header) (*http.Response, error)
+
+type inputTokenModelResolver func(map[string]any) (string, error)
+
+func isInputTokensPath(path string) bool {
+	return path == chatInputTokensPath || path == responsesInputTokensPath
+}
+
+func handleInputTokens(
+	w http.ResponseWriter,
+	r *http.Request,
+	apiKey string,
+	resolveModel inputTokenModelResolver,
+	dispatch inputTokenDispatch,
+) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		jsonError(w, "Method not allowed.", manager.ErrTypeInvalidRequest, http.StatusMethodNotAllowed)
+		return
+	}
+	if apiKey == "" {
+		jsonError(w, "Missing bearer API key.", inputTokensAuthErrorType, http.StatusUnauthorized)
+		return
+	}
+
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeRequestBodyError(w, err)
+		return
+	}
+	defer r.Body.Close()
+
+	var body map[string]any
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		jsonError(w, fmt.Sprintf("Invalid request body: %v.", err), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+		return
+	}
+
+	modelName, err := inputTokensModel(body, resolveModel)
+	if err != nil {
+		jsonError(w, err.Error(), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+		return
+	}
+
+	var tokenizeBody map[string]any
+	switch r.URL.Path {
+	case chatInputTokensPath:
+		tokenizeBody, err = chatTokenizeBody(body, modelName)
+	case responsesInputTokensPath:
+		tokenizeBody, err = responsesTokenizeBody(body, modelName)
+	default:
+		err = fmt.Errorf("unsupported input-token route: %s", r.URL.Path)
+	}
+	if err != nil {
+		jsonError(w, err.Error(), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+		return
+	}
+
+	tokenizeBytes, err := json.Marshal(tokenizeBody)
+	if err != nil {
+		jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusInternalServerError)
+		return
+	}
+	headers := make(http.Header)
+	headers.Set("Authorization", "Bearer "+apiKey)
+	headers.Set("Content-Type", "application/json")
+	resp, err := dispatch(r.Context(), modelName, tokenizePath, tokenizeBytes, headers)
+	if err != nil {
+		jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		forwardInputTokensError(w, resp)
+		return
+	}
+
+	var tokenized struct {
+		Count *int `json:"count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenized); err != nil {
+		jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusBadGateway)
+		return
+	}
+	if tokenized.Count == nil || *tokenized.Count < 0 {
+		jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusBadGateway)
+		return
+	}
+
+	object := "chat.completion.input_tokens"
+	if r.URL.Path == responsesInputTokensPath {
+		object = "response.input_tokens"
+	}
+	sendJSON(w, map[string]any{
+		"object":       object,
+		"input_tokens": *tokenized.Count,
+	})
+}
+
+func inputTokensModel(body map[string]any, resolveModel inputTokenModelResolver) (string, error) {
+	modelValue, ok := body["model"]
+	if !ok {
+		return "", fmt.Errorf("Missing required parameter: 'model'.")
+	}
+	modelName, ok := modelValue.(string)
+	if !ok || modelName == "" {
+		return "", fmt.Errorf("Invalid parameter: 'model' must be a non-empty string.")
+	}
+	if modelName != "auto" {
+		return modelName, nil
+	}
+	if resolveModel == nil {
+		return "", fmt.Errorf("Model 'auto' is not available for this request.")
+	}
+	return resolveModel(body)
+}
+
+func chatTokenizeBody(body map[string]any, modelName string) (map[string]any, error) {
+	messages, ok := body["messages"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("Missing or invalid required parameter: 'messages'.")
+	}
+
+	tokenizeBody := map[string]any{
+		"model":    modelName,
+		"messages": messages,
+	}
+	if tools, ok := body["tools"]; ok {
+		tokenizeBody["tools"] = tools
+	}
+	return tokenizeBody, nil
+}
+
+func responsesTokenizeBody(body map[string]any, modelName string) (map[string]any, error) {
+	messages, err := responsesMessages(body)
+	if err != nil {
+		return nil, err
+	}
+	tokenizeBody := map[string]any{
+		"model":    modelName,
+		"messages": messages,
+	}
+	if tools, ok := body["tools"]; ok {
+		converted, err := responsesTools(tools)
+		if err != nil {
+			return nil, err
+		}
+		tokenizeBody["tools"] = converted
+	}
+	return tokenizeBody, nil
+}
+
+func responsesMessages(body map[string]any) ([]any, error) {
+	messages := make([]any, 0)
+	if instructions, ok := body["instructions"]; ok {
+		text, ok := instructions.(string)
+		if !ok {
+			return nil, fmt.Errorf("Invalid parameter: 'instructions' must be a string.")
+		}
+		if text != "" {
+			messages = append(messages, map[string]any{"role": "system", "content": text})
+		}
+	}
+
+	input, ok := body["input"]
+	if !ok {
+		return nil, fmt.Errorf("Missing required parameter: 'input'.")
+	}
+	if text, ok := input.(string); ok {
+		return append(messages, map[string]any{"role": "user", "content": text}), nil
+	}
+	items, ok := input.([]any)
+	if !ok {
+		return nil, fmt.Errorf("Invalid parameter: 'input' must be a string or array.")
+	}
+
+	for _, rawItem := range items {
+		item, ok := rawItem.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("Invalid item in 'input': expected an object.")
+		}
+		itemType, _ := item["type"].(string)
+		switch itemType {
+		case "", "message":
+			message, err := responsesMessage(item)
+			if err != nil {
+				return nil, err
+			}
+			messages = append(messages, message)
+		case "function_call":
+			message, err := responsesFunctionCall(item)
+			if err != nil {
+				return nil, err
+			}
+			messages = appendFunctionCall(messages, message)
+		case "function_call_output":
+			message, err := responsesFunctionCallOutput(item)
+			if err != nil {
+				return nil, err
+			}
+			messages = append(messages, message)
+		default:
+			return nil, fmt.Errorf("Unsupported Responses input item type %q.", itemType)
+		}
+	}
+	return messages, nil
+}
+
+func responsesMessage(item map[string]any) (map[string]any, error) {
+	role, ok := item["role"].(string)
+	if !ok || role == "" {
+		return nil, fmt.Errorf("Responses message items require a non-empty 'role'.")
+	}
+	content, ok := item["content"]
+	if !ok {
+		return nil, fmt.Errorf("Responses message items require 'content'.")
+	}
+	converted, err := responsesContent(content)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"role": role, "content": converted}, nil
+}
+
+func responsesContent(content any) (any, error) {
+	if text, ok := content.(string); ok {
+		return text, nil
+	}
+	parts, ok := content.([]any)
+	if !ok {
+		return nil, fmt.Errorf("Responses message 'content' must be a string or array.")
+	}
+
+	converted := make([]any, 0, len(parts))
+	for _, rawPart := range parts {
+		part, ok := rawPart.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("Invalid Responses content part: expected an object.")
+		}
+		partType, _ := part["type"].(string)
+		switch partType {
+		case "input_text", "output_text":
+			text, ok := part["text"].(string)
+			if !ok {
+				return nil, fmt.Errorf("Responses %s content requires string 'text'.", partType)
+			}
+			converted = append(converted, map[string]any{"type": "text", "text": text})
+		case "input_image":
+			imageURL, ok := part["image_url"].(string)
+			if !ok || imageURL == "" {
+				return nil, fmt.Errorf("Responses input_image content requires string 'image_url'.")
+			}
+			image := map[string]any{"url": imageURL}
+			if detail, ok := part["detail"].(string); ok && detail != "" {
+				image["detail"] = detail
+			}
+			converted = append(converted, map[string]any{"type": "image_url", "image_url": image})
+		default:
+			return nil, fmt.Errorf("Unsupported Responses content part type %q.", partType)
+		}
+	}
+	return converted, nil
+}
+
+func responsesFunctionCall(item map[string]any) (map[string]any, error) {
+	callID, callIDOK := item["call_id"].(string)
+	name, nameOK := item["name"].(string)
+	arguments, argumentsOK := item["arguments"].(string)
+	if !callIDOK || callID == "" || !nameOK || name == "" || !argumentsOK {
+		return nil, fmt.Errorf("Responses function_call items require string 'call_id', 'name', and 'arguments'.")
+	}
+	return map[string]any{
+		"role":    "assistant",
+		"content": nil,
+		"tool_calls": []any{map[string]any{
+			"id":   callID,
+			"type": "function",
+			"function": map[string]any{
+				"name":      name,
+				"arguments": arguments,
+			},
+		}},
+	}, nil
+}
+
+func appendFunctionCall(messages []any, message map[string]any) []any {
+	if len(messages) == 0 {
+		return append(messages, message)
+	}
+	previous, ok := messages[len(messages)-1].(map[string]any)
+	if !ok || previous["role"] != "assistant" || previous["content"] != nil {
+		return append(messages, message)
+	}
+	previousCalls, previousOK := previous["tool_calls"].([]any)
+	newCalls, newOK := message["tool_calls"].([]any)
+	if !previousOK || !newOK {
+		return append(messages, message)
+	}
+	previous["tool_calls"] = append(previousCalls, newCalls...)
+	return messages
+}
+
+func responsesFunctionCallOutput(item map[string]any) (map[string]any, error) {
+	callID, ok := item["call_id"].(string)
+	if !ok || callID == "" {
+		return nil, fmt.Errorf("Responses function_call_output items require string 'call_id'.")
+	}
+	output, ok := item["output"]
+	if !ok {
+		return nil, fmt.Errorf("Responses function_call_output items require 'output'.")
+	}
+	return map[string]any{
+		"role":         "tool",
+		"tool_call_id": callID,
+		"content":      output,
+	}, nil
+}
+
+func responsesTools(tools any) ([]any, error) {
+	items, ok := tools.([]any)
+	if !ok {
+		return nil, fmt.Errorf("Invalid parameter: 'tools' must be an array.")
+	}
+	converted := make([]any, 0, len(items))
+	for _, rawTool := range items {
+		tool, ok := rawTool.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("Invalid tool: expected an object.")
+		}
+		toolType, _ := tool["type"].(string)
+		if toolType != "function" {
+			return nil, fmt.Errorf("Unsupported Responses tool type %q.", toolType)
+		}
+		name, ok := tool["name"].(string)
+		if !ok || name == "" {
+			return nil, fmt.Errorf("Responses function tools require a non-empty string 'name'.")
+		}
+		function := map[string]any{"name": name}
+		for _, key := range []string{"description", "parameters", "strict"} {
+			if value, ok := tool[key]; ok {
+				function[key] = value
+			}
+		}
+		converted = append(converted, map[string]any{
+			"type":     "function",
+			"function": function,
+		})
+	}
+	return converted, nil
+}
+
+func forwardInputTokensError(w http.ResponseWriter, resp *http.Response) {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxInputTokensErrorBytes+1))
+	if err != nil {
+		jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusBadGateway)
+		return
+	}
+	if len(body) > maxInputTokensErrorBytes {
+		jsonError(w, manager.ErrMsgServerError, manager.ErrTypeServer, http.StatusBadGateway)
+		return
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(resp.StatusCode)
+	w.Write(body)
+}

--- a/input_tokens.go
+++ b/input_tokens.go
@@ -18,6 +18,22 @@ const (
 	maxInputTokensErrorBytes = 1 << 20
 )
 
+var tokenizeChatFields = []string{
+	"add_generation_prompt",
+	"continue_final_message",
+	"add_special_tokens",
+	"chat_template",
+	"chat_template_kwargs",
+	"mm_processor_kwargs",
+	"media_io_kwargs",
+}
+
+var unsupportedResponsesCountFields = []string{
+	"conversation",
+	"previous_response_id",
+	"previous_input_messages",
+}
+
 type inputTokenDispatch func(context.Context, string, string, []byte, http.Header) (*http.Response, error)
 
 type inputTokenModelResolver func(map[string]any) (string, error)
@@ -153,10 +169,16 @@ func chatTokenizeBody(body map[string]any, modelName string) (map[string]any, er
 	if tools, ok := body["tools"]; ok {
 		tokenizeBody["tools"] = tools
 	}
+	copyTokenizeChatFields(tokenizeBody, body)
 	return tokenizeBody, nil
 }
 
 func responsesTokenizeBody(body map[string]any, modelName string) (map[string]any, error) {
+	for _, field := range unsupportedResponsesCountFields {
+		if value, ok := body[field]; ok && value != nil {
+			return nil, fmt.Errorf("Input-token counting does not support Responses parameter %q.", field)
+		}
+	}
 	messages, err := responsesMessages(body)
 	if err != nil {
 		return nil, err
@@ -165,14 +187,68 @@ func responsesTokenizeBody(body map[string]any, modelName string) (map[string]an
 		"model":    modelName,
 		"messages": messages,
 	}
-	if tools, ok := body["tools"]; ok {
+	toolChoice, _ := body["tool_choice"].(string)
+	if tools, ok := body["tools"]; ok && toolChoice != "none" {
 		converted, err := responsesTools(tools)
 		if err != nil {
 			return nil, err
 		}
 		tokenizeBody["tools"] = converted
 	}
+	copyTokenizeChatFields(tokenizeBody, body)
+	if reasoning, ok := body["reasoning"].(map[string]any); ok {
+		if effort, ok := reasoning["effort"].(string); ok && effort != "" {
+			kwargs, _ := tokenizeBody["chat_template_kwargs"].(map[string]any)
+			if kwargs == nil {
+				kwargs = make(map[string]any)
+			} else {
+				kwargs = cloneMap(kwargs)
+			}
+			kwargs["reasoning_effort"] = effort
+			if _, configured := kwargs["enable_thinking"]; !configured {
+				kwargs["enable_thinking"] = effort != "none"
+			}
+			tokenizeBody["chat_template_kwargs"] = kwargs
+		}
+	}
+	if responsesContinuesFinalMessage(body["input"]) {
+		tokenizeBody["add_generation_prompt"] = false
+		tokenizeBody["continue_final_message"] = true
+	}
 	return tokenizeBody, nil
+}
+
+func copyTokenizeChatFields(target, source map[string]any) {
+	for _, field := range tokenizeChatFields {
+		if value, ok := source[field]; ok {
+			target[field] = value
+		}
+	}
+}
+
+func cloneMap(source map[string]any) map[string]any {
+	cloned := make(map[string]any, len(source))
+	for key, value := range source {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func responsesContinuesFinalMessage(input any) bool {
+	items, ok := input.([]any)
+	if !ok || len(items) == 0 {
+		return false
+	}
+	last, ok := items[len(items)-1].(map[string]any)
+	if !ok {
+		return false
+	}
+	itemType, _ := last["type"].(string)
+	if itemType != "" && itemType != "message" && itemType != "reasoning" {
+		return false
+	}
+	status, _ := last["status"].(string)
+	return status == "in_progress" || status == "incomplete"
 }
 
 func responsesMessages(body map[string]any) ([]any, error) {

--- a/input_tokens_test.go
+++ b/input_tokens_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestHandleInputTokensChatRequest(t *testing.T) {
+	var dispatchedModel string
+	var dispatchedPath string
+	var dispatchedBody map[string]any
+	var dispatchedAuthorization string
+	dispatch := func(_ context.Context, modelName, path string, body []byte, headers http.Header) (*http.Response, error) {
+		dispatchedModel = modelName
+		dispatchedPath = path
+		dispatchedAuthorization = headers.Get("Authorization")
+		if err := json.Unmarshal(body, &dispatchedBody); err != nil {
+			t.Fatal(err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"count":37,"tokens":[1,2,3]}`)),
+		}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, chatInputTokensPath, strings.NewReader(`{
+		"model":"gpt-oss-120b",
+		"messages":[{"role":"user","content":"hello"}],
+		"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}],
+		"max_completion_tokens":100
+	}`))
+	rec := httptest.NewRecorder()
+	handleInputTokens(rec, req, "secret-key", nil, dispatch)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if dispatchedModel != "gpt-oss-120b" || dispatchedPath != tokenizePath {
+		t.Fatalf("unexpected dispatch target: model=%q path=%q", dispatchedModel, dispatchedPath)
+	}
+	if dispatchedAuthorization != "Bearer secret-key" {
+		t.Fatalf("unexpected authorization header %q", dispatchedAuthorization)
+	}
+	if _, ok := dispatchedBody["max_completion_tokens"]; ok {
+		t.Fatal("max_completion_tokens must not be sent to /tokenize")
+	}
+	if _, ok := dispatchedBody["messages"].([]any); !ok {
+		t.Fatalf("expected messages in tokenize body: %#v", dispatchedBody)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response["object"] != "chat.completion.input_tokens" || response["input_tokens"] != float64(37) {
+		t.Fatalf("unexpected response: %#v", response)
+	}
+}
+
+func TestHandleInputTokensResponsesRequest(t *testing.T) {
+	var dispatchedBody map[string]any
+	dispatch := func(_ context.Context, _, _ string, body []byte, _ http.Header) (*http.Response, error) {
+		if err := json.Unmarshal(body, &dispatchedBody); err != nil {
+			t.Fatal(err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"count":91}`)),
+		}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, responsesInputTokensPath, strings.NewReader(`{
+		"model":"gpt-oss-120b",
+		"instructions":"Be concise.",
+		"input":[{
+			"role":"user",
+			"content":[
+				{"type":"input_text","text":"Describe this."},
+				{"type":"input_image","image_url":"https://example.com/image.png","detail":"low"}
+			]
+		}],
+		"tools":[{
+			"type":"function",
+			"name":"lookup",
+			"description":"Look something up",
+			"parameters":{"type":"object"},
+			"strict":true
+		}]
+	}`))
+	rec := httptest.NewRecorder()
+	handleInputTokens(rec, req, "secret-key", nil, dispatch)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	expectedMessages := []any{
+		map[string]any{"role": "system", "content": "Be concise."},
+		map[string]any{
+			"role": "user",
+			"content": []any{
+				map[string]any{"type": "text", "text": "Describe this."},
+				map[string]any{
+					"type": "image_url",
+					"image_url": map[string]any{
+						"url":    "https://example.com/image.png",
+						"detail": "low",
+					},
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(dispatchedBody["messages"], expectedMessages) {
+		t.Fatalf("unexpected converted messages:\nwant: %#v\n got: %#v", expectedMessages, dispatchedBody["messages"])
+	}
+	expectedTools := []any{map[string]any{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "lookup",
+			"description": "Look something up",
+			"parameters":  map[string]any{"type": "object"},
+			"strict":      true,
+		},
+	}}
+	if !reflect.DeepEqual(dispatchedBody["tools"], expectedTools) {
+		t.Fatalf("unexpected converted tools:\nwant: %#v\n got: %#v", expectedTools, dispatchedBody["tools"])
+	}
+	if !strings.Contains(rec.Body.String(), `"object":"response.input_tokens"`) {
+		t.Fatalf("unexpected response: %s", rec.Body.String())
+	}
+}
+
+func TestResponsesMessagesConvertsFunctionCalls(t *testing.T) {
+	messages, err := responsesMessages(map[string]any{
+		"input": []any{
+			map[string]any{"type": "function_call", "call_id": "call_1", "name": "first", "arguments": `{}`},
+			map[string]any{"type": "function_call", "call_id": "call_2", "name": "second", "arguments": `{"id":1}`},
+			map[string]any{"type": "function_call_output", "call_id": "call_1", "output": "done"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected grouped assistant calls and one tool result, got %#v", messages)
+	}
+	assistant := messages[0].(map[string]any)
+	if calls := assistant["tool_calls"].([]any); len(calls) != 2 {
+		t.Fatalf("expected two grouped tool calls, got %#v", calls)
+	}
+	tool := messages[1].(map[string]any)
+	if tool["role"] != "tool" || tool["tool_call_id"] != "call_1" || tool["content"] != "done" {
+		t.Fatalf("unexpected tool output message: %#v", tool)
+	}
+}
+
+func TestHandleInputTokensRequiresBearerKey(t *testing.T) {
+	dispatched := false
+	dispatch := func(context.Context, string, string, []byte, http.Header) (*http.Response, error) {
+		dispatched = true
+		return nil, nil
+	}
+	req := httptest.NewRequest(http.MethodPost, responsesInputTokensPath, strings.NewReader(`{"model":"gpt-oss-120b","input":"hello"}`))
+	rec := httptest.NewRecorder()
+
+	handleInputTokens(rec, req, "", nil, dispatch)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+	if dispatched {
+		t.Fatal("unauthenticated request was dispatched")
+	}
+}
+
+func TestHandleInputTokensForwardsTokenizeError(t *testing.T) {
+	dispatch := func(context.Context, string, string, []byte, http.Header) (*http.Response, error) {
+		header := make(http.Header)
+		header.Set("Content-Type", "application/json")
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"invalid messages"}}`)),
+		}, nil
+	}
+	req := httptest.NewRequest(http.MethodPost, chatInputTokensPath, strings.NewReader(`{"model":"gpt-oss-120b","messages":[]}`))
+	rec := httptest.NewRecorder()
+
+	handleInputTokens(rec, req, "secret-key", nil, dispatch)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", rec.Code)
+	}
+	if rec.Body.String() != `{"error":{"message":"invalid messages"}}` {
+		t.Fatalf("unexpected forwarded body: %s", rec.Body.String())
+	}
+}

--- a/input_tokens_test.go
+++ b/input_tokens_test.go
@@ -34,6 +34,7 @@ func TestHandleInputTokensChatRequest(t *testing.T) {
 		"model":"gpt-oss-120b",
 		"messages":[{"role":"user","content":"hello"}],
 		"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}],
+		"chat_template_kwargs":{"enable_thinking":false},
 		"max_completion_tokens":100
 	}`))
 	rec := httptest.NewRecorder()
@@ -53,6 +54,9 @@ func TestHandleInputTokensChatRequest(t *testing.T) {
 	}
 	if _, ok := dispatchedBody["messages"].([]any); !ok {
 		t.Fatalf("expected messages in tokenize body: %#v", dispatchedBody)
+	}
+	if !reflect.DeepEqual(dispatchedBody["chat_template_kwargs"], map[string]any{"enable_thinking": false}) {
+		t.Fatalf("expected chat template kwargs in tokenize body: %#v", dispatchedBody)
 	}
 
 	var response map[string]any
@@ -80,6 +84,7 @@ func TestHandleInputTokensResponsesRequest(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, responsesInputTokensPath, strings.NewReader(`{
 		"model":"gpt-oss-120b",
 		"instructions":"Be concise.",
+		"reasoning":{"effort":"high"},
 		"input":[{
 			"role":"user",
 			"content":[
@@ -131,6 +136,10 @@ func TestHandleInputTokensResponsesRequest(t *testing.T) {
 	}}
 	if !reflect.DeepEqual(dispatchedBody["tools"], expectedTools) {
 		t.Fatalf("unexpected converted tools:\nwant: %#v\n got: %#v", expectedTools, dispatchedBody["tools"])
+	}
+	expectedTemplateKwargs := map[string]any{"reasoning_effort": "high", "enable_thinking": true}
+	if !reflect.DeepEqual(dispatchedBody["chat_template_kwargs"], expectedTemplateKwargs) {
+		t.Fatalf("unexpected chat template kwargs:\nwant: %#v\n got: %#v", expectedTemplateKwargs, dispatchedBody["chat_template_kwargs"])
 	}
 	if !strings.Contains(rec.Body.String(), `"object":"response.input_tokens"`) {
 		t.Fatalf("unexpected response: %s", rec.Body.String())
@@ -184,6 +193,44 @@ func TestResponsesMessagesAcceptsNullInstructionsAndRefusal(t *testing.T) {
 	want := map[string]any{"type": "text", "text": "I cannot help with that."}
 	if !reflect.DeepEqual(content[0], want) {
 		t.Fatalf("unexpected refusal conversion: %#v", content[0])
+	}
+}
+
+func TestResponsesTokenizeBodyHonorsToolChoiceAndContinuation(t *testing.T) {
+	body := map[string]any{
+		"input": []any{map[string]any{
+			"type":    "message",
+			"role":    "assistant",
+			"status":  "incomplete",
+			"content": "partial",
+		}},
+		"tools": []any{map[string]any{
+			"type":       "function",
+			"name":       "lookup",
+			"parameters": map[string]any{"type": "object"},
+		}},
+		"tool_choice": "none",
+	}
+
+	tokenizeBody, err := responsesTokenizeBody(body, "gpt-oss-120b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := tokenizeBody["tools"]; ok {
+		t.Fatal("tool_choice=none must omit tools from the rendered prompt")
+	}
+	if tokenizeBody["add_generation_prompt"] != false || tokenizeBody["continue_final_message"] != true {
+		t.Fatalf("expected partial assistant continuation options, got %#v", tokenizeBody)
+	}
+}
+
+func TestResponsesTokenizeBodyRejectsStatefulInputs(t *testing.T) {
+	_, err := responsesTokenizeBody(map[string]any{
+		"input":                "continue",
+		"previous_response_id": "resp_123",
+	}, "gpt-oss-120b")
+	if err == nil || !strings.Contains(err.Error(), "previous_response_id") {
+		t.Fatalf("expected unsupported stateful input error, got %v", err)
 	}
 }
 

--- a/input_tokens_test.go
+++ b/input_tokens_test.go
@@ -37,7 +37,7 @@ func TestHandleInputTokensChatRequest(t *testing.T) {
 		"max_completion_tokens":100
 	}`))
 	rec := httptest.NewRecorder()
-	handleInputTokens(rec, req, "secret-key", nil, dispatch)
+	handleInputTokens(rec, req, "secret-key", "", nil, dispatch)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -96,7 +96,7 @@ func TestHandleInputTokensResponsesRequest(t *testing.T) {
 		}]
 	}`))
 	rec := httptest.NewRecorder()
-	handleInputTokens(rec, req, "secret-key", nil, dispatch)
+	handleInputTokens(rec, req, "secret-key", "", nil, dispatch)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -161,6 +161,32 @@ func TestResponsesMessagesConvertsFunctionCalls(t *testing.T) {
 	}
 }
 
+func TestResponsesMessagesAcceptsNullInstructionsAndRefusal(t *testing.T) {
+	messages, err := responsesMessages(map[string]any{
+		"instructions": nil,
+		"input": []any{map[string]any{
+			"type": "message",
+			"role": "assistant",
+			"content": []any{map[string]any{
+				"type":    "refusal",
+				"refusal": "I cannot help with that.",
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected one message, got %#v", messages)
+	}
+	message := messages[0].(map[string]any)
+	content := message["content"].([]any)
+	want := map[string]any{"type": "text", "text": "I cannot help with that."}
+	if !reflect.DeepEqual(content[0], want) {
+		t.Fatalf("unexpected refusal conversion: %#v", content[0])
+	}
+}
+
 func TestHandleInputTokensRequiresBearerKey(t *testing.T) {
 	dispatched := false
 	dispatch := func(context.Context, string, string, []byte, http.Header) (*http.Response, error) {
@@ -170,13 +196,38 @@ func TestHandleInputTokensRequiresBearerKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, responsesInputTokensPath, strings.NewReader(`{"model":"gpt-oss-120b","input":"hello"}`))
 	rec := httptest.NewRecorder()
 
-	handleInputTokens(rec, req, "", nil, dispatch)
+	handleInputTokens(rec, req, "", "", nil, dispatch)
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", rec.Code)
 	}
 	if dispatched {
 		t.Fatal("unauthenticated request was dispatched")
+	}
+}
+
+func TestHandleInputTokensUsesSubdomainModel(t *testing.T) {
+	var dispatchedModel string
+	dispatch := func(_ context.Context, modelName, _ string, _ []byte, _ http.Header) (*http.Response, error) {
+		dispatchedModel = modelName
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"count":5}`)),
+		}, nil
+	}
+	req := httptest.NewRequest(http.MethodPost, chatInputTokensPath, strings.NewReader(`{
+		"messages":[{"role":"user","content":"hello"}]
+	}`))
+	rec := httptest.NewRecorder()
+
+	handleInputTokens(rec, req, "secret-key", "subdomain-model", nil, dispatch)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if dispatchedModel != "subdomain-model" {
+		t.Fatalf("expected subdomain model, got %q", dispatchedModel)
 	}
 }
 
@@ -193,7 +244,7 @@ func TestHandleInputTokensForwardsTokenizeError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, chatInputTokensPath, strings.NewReader(`{"model":"gpt-oss-120b","messages":[]}`))
 	rec := httptest.NewRecorder()
 
-	handleInputTokens(rec, req, "secret-key", nil, dispatch)
+	handleInputTokens(rec, req, "secret-key", "", nil, dispatch)
 
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d", rec.Code)

--- a/main.go
+++ b/main.go
@@ -515,6 +515,19 @@ func main() {
 			return
 		}
 
+		if isInputTokensPath(r.URL.Path) {
+			dispatch := func(ctx context.Context, modelName, path string, body []byte, headers http.Header) (*http.Response, error) {
+				if routeCtx, ok := routeContextClient.Lookup(ctx, apiKey, modelName); ok {
+					ctx = manager.WithCallerOrg(ctx, routeCtx.OrgID)
+				}
+				return em.DoModelRequest(ctx, modelName, path, body, headers)
+			}
+			handleInputTokens(w, r, apiKey, modelName, func(body map[string]any) (string, error) {
+				return resolveAutoModel(em, body)
+			}, dispatch)
+			return
+		}
+
 		// WebSocket upgrade on /v1/realtime: extract model from ?model= query parameter, skip body parsing
 		if isWebSocketUpgrade(r) && r.URL.Path == "/v1/realtime" {
 			if modelName == "" {
@@ -587,17 +600,6 @@ func main() {
 			} else if r.URL.Path == "/metrics" {
 				// Expose Prometheus metrics
 				promhttp.Handler().ServeHTTP(w, r)
-				return
-			} else if isInputTokensPath(r.URL.Path) {
-				dispatch := func(ctx context.Context, modelName, path string, body []byte, headers http.Header) (*http.Response, error) {
-					if routeCtx, ok := routeContextClient.Lookup(ctx, apiKey, modelName); ok {
-						ctx = manager.WithCallerOrg(ctx, routeCtx.OrgID)
-					}
-					return em.DoModelRequest(ctx, modelName, path, body, headers)
-				}
-				handleInputTokens(w, r, apiKey, func(body map[string]any) (string, error) {
-					return resolveAutoModel(em, body)
-				}, dispatch)
 				return
 			} else if r.URL.Path == "/v1/models" {
 				ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)

--- a/main.go
+++ b/main.go
@@ -588,6 +588,17 @@ func main() {
 				// Expose Prometheus metrics
 				promhttp.Handler().ServeHTTP(w, r)
 				return
+			} else if isInputTokensPath(r.URL.Path) {
+				dispatch := func(ctx context.Context, modelName, path string, body []byte, headers http.Header) (*http.Response, error) {
+					if routeCtx, ok := routeContextClient.Lookup(ctx, apiKey, modelName); ok {
+						ctx = manager.WithCallerOrg(ctx, routeCtx.OrgID)
+					}
+					return em.DoModelRequest(ctx, modelName, path, body, headers)
+				}
+				handleInputTokens(w, r, apiKey, func(body map[string]any) (string, error) {
+					return resolveAutoModel(em, body)
+				}, dispatch)
+				return
 			} else if r.URL.Path == "/v1/models" {
 				ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 				defer cancel()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -36,6 +36,7 @@ type Enclave struct {
 	proxy     *httputil.ReverseProxy
 	metrics   *enclaveMetrics
 	cb        *circuitBreaker
+	pricing   func(string) (ModelPricing, bool)
 
 	// inflight counts requests currently proxied through this enclave —
 	// a live load signal, unlike the polled queue depth, which can be up
@@ -153,6 +154,7 @@ func (m *Model) ReservationPools(orgID string) (primary, spill map[string]bool) 
 type EnclaveManager struct {
 	models               *sync.Map // model name -> *Model
 	multimodalModels     sync.Map  // sticky set of multimodal chat model names
+	modelPricing         atomic.Pointer[map[string]ModelPricing]
 	initConfigURL        string
 	updateConfigURL      string
 	controlPlaneURL      string
@@ -339,6 +341,7 @@ func (em *EnclaveManager) addEnclave(
 		proxy:     newProxy(host, verification.TLSPublicKeyFP, modelName, em.billingCollector, cb),
 		metrics:   newEnclaveMetrics(host, modelName),
 		cb:        cb,
+		pricing:   em.ModelPricing,
 	}
 	model.Enclaves[host].updateOverloadConfig(model.Overload)
 	CircuitBreakerState.WithLabelValues(modelName, host).Set(float64(cbClosed))
@@ -823,7 +826,13 @@ func (e *Enclave) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Wrap the ResponseWriter to capture usage and write trailer
-	wrapper := &usageMetricsWriter{ResponseWriter: w, model: e.modelName}
+	var pricing *ModelPricing
+	if e.pricing != nil {
+		if value, ok := e.pricing(e.modelName); ok {
+			pricing = &value
+		}
+	}
+	wrapper := &usageMetricsWriter{ResponseWriter: w, model: e.modelName, pricing: pricing}
 
 	// Store wrapper in request context for ModifyResponse to access
 	ctx := context.WithValue(r.Context(), usageWriterKey{}, wrapper)
@@ -980,7 +989,7 @@ func (em *EnclaveManager) sync() error {
 		return fmt.Errorf("failed to fetch config: %v", err)
 	}
 
-	em.refreshMultimodalModels()
+	em.refreshModelMetadata()
 
 	// Fetch hardware measurements
 	hwMeasurements, err := em.sigstoreClient.LatestHardwareMeasurements()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tinfoilsh/confidential-model-router/cacheroute"
 	"github.com/tinfoilsh/confidential-model-router/config"
 	"github.com/tinfoilsh/confidential-model-router/ratelimit"
+	"github.com/tinfoilsh/confidential-model-router/tokencount"
 )
 
 type Enclave struct {
@@ -833,6 +834,9 @@ func (e *Enclave) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	wrapper := &usageMetricsWriter{ResponseWriter: w, model: e.modelName, pricing: pricing}
+	if pricing != nil && pricing.CostKnownWithoutUsage() {
+		wrapper.usage = &tokencount.Usage{}
+	}
 
 	// Store wrapper in request context for ModifyResponse to access
 	ctx := context.WithValue(r.Context(), usageWriterKey{}, wrapper)

--- a/manager/model_metadata.go
+++ b/manager/model_metadata.go
@@ -13,10 +13,18 @@ import (
 
 const modelMetadataHTTPTimeout = 10 * time.Second
 
+type ModelPricing struct {
+	InputTokenPricePer1M       float64  `json:"inputTokenPricePer1M"`
+	OutputTokenPricePer1M      float64  `json:"outputTokenPricePer1M"`
+	CachedInputTokenPricePer1M *float64 `json:"cachedInputTokenPricePer1M,omitempty"`
+	RequestPrice               float64  `json:"requestPrice"`
+}
+
 type openAIModelEntry struct {
-	ID         string `json:"id"`
-	Multimodal bool   `json:"multimodal"`
-	Type       string `json:"type"`
+	ID         string        `json:"id"`
+	Multimodal bool          `json:"multimodal"`
+	Type       string        `json:"type"`
+	Pricing    *ModelPricing `json:"pricing"`
 }
 
 type openAIModelsList struct {
@@ -29,9 +37,29 @@ func (em *EnclaveManager) IsMultimodal(modelName string) bool {
 	return ok
 }
 
-// refreshMultimodalModels updates the sticky multimodal cache in the
-// background. Best-effort: failures and missing entries leave the cache as-is.
-func (em *EnclaveManager) refreshMultimodalModels() {
+// ModelPricing returns the latest published prices for a model.
+func (em *EnclaveManager) ModelPricing(modelName string) (ModelPricing, bool) {
+	if em == nil {
+		return ModelPricing{}, false
+	}
+	pricing := em.modelPricing.Load()
+	if pricing == nil {
+		return ModelPricing{}, false
+	}
+	value, ok := (*pricing)[modelName]
+	return value, ok
+}
+
+func (p ModelPricing) valid() bool {
+	if p.InputTokenPricePer1M < 0 || p.OutputTokenPricePer1M < 0 || p.RequestPrice < 0 {
+		return false
+	}
+	return p.CachedInputTokenPricePer1M == nil || *p.CachedInputTokenPricePer1M >= 0
+}
+
+// refreshModelMetadata updates the model pricing and sticky multimodal cache
+// in the background. Best-effort: failures leave both caches as-is.
+func (em *EnclaveManager) refreshModelMetadata() {
 	if em.controlPlaneURL == "" {
 		return
 	}
@@ -62,7 +90,11 @@ func (em *EnclaveManager) refreshMultimodalModels() {
 			return
 		}
 
+		pricing := make(map[string]ModelPricing, len(parsed.Data))
 		for _, e := range parsed.Data {
+			if e.ID != "" && e.Pricing != nil && e.Pricing.valid() {
+				pricing[e.ID] = *e.Pricing
+			}
 			// Restrict to chat-shaped models so non-chat services that carry
 			// multimodal:true don't route PDFs as page images.
 			if e.ID == "" || !e.Multimodal || (e.Type != "" && e.Type != "chat") {
@@ -70,5 +102,6 @@ func (em *EnclaveManager) refreshMultimodalModels() {
 			}
 			em.multimodalModels.Store(e.ID, struct{}{})
 		}
+		em.modelPricing.Store(&pricing)
 	}()
 }

--- a/manager/model_metadata.go
+++ b/manager/model_metadata.go
@@ -39,9 +39,6 @@ func (em *EnclaveManager) IsMultimodal(modelName string) bool {
 
 // ModelPricing returns the latest published prices for a model.
 func (em *EnclaveManager) ModelPricing(modelName string) (ModelPricing, bool) {
-	if em == nil {
-		return ModelPricing{}, false
-	}
 	pricing := em.modelPricing.Load()
 	if pricing == nil {
 		return ModelPricing{}, false

--- a/manager/pricing.go
+++ b/manager/pricing.go
@@ -12,6 +12,14 @@ const (
 	costDecimalPlaces = 12
 )
 
+// CostKnownWithoutUsage reports whether request price alone determines cost.
+func (p ModelPricing) CostKnownWithoutUsage() bool {
+	if p.InputTokenPricePer1M != 0 || p.OutputTokenPricePer1M != 0 {
+		return false
+	}
+	return p.CachedInputTokenPricePer1M == nil || *p.CachedInputTokenPricePer1M == 0
+}
+
 func requestCostUSD(usage *tokencount.Usage, pricing ModelPricing) float64 {
 	cachedPromptTokens, _ := usage.CachedPromptTokens()
 	uncachedPromptTokens := max(0, usage.PromptTokens-cachedPromptTokens)

--- a/manager/pricing.go
+++ b/manager/pricing.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"math"
 	"strconv"
 	"strings"
 
@@ -8,8 +9,8 @@ import (
 )
 
 const (
-	pricingTokenUnit  = 1_000_000
-	costDecimalPlaces = 12
+	pricingTokenUnit      = 1_000_000
+	costSignificantDigits = 15
 )
 
 // CostKnownWithoutUsage reports whether request price alone determines cost.
@@ -22,7 +23,9 @@ func (p ModelPricing) CostKnownWithoutUsage() bool {
 
 func requestCostUSD(usage *tokencount.Usage, pricing ModelPricing) float64 {
 	cachedPromptTokens, _ := usage.CachedPromptTokens()
+	cachedPromptTokens = max(0, cachedPromptTokens)
 	uncachedPromptTokens := max(0, usage.PromptTokens-cachedPromptTokens)
+	completionTokens := max(0, usage.CompletionTokens)
 	cachedInputPrice := pricing.InputTokenPricePer1M
 	if pricing.CachedInputTokenPricePer1M != nil {
 		cachedInputPrice = *pricing.CachedInputTokenPricePer1M
@@ -31,15 +34,19 @@ func requestCostUSD(usage *tokencount.Usage, pricing ModelPricing) float64 {
 	return pricing.RequestPrice +
 		float64(uncachedPromptTokens)*pricing.InputTokenPricePer1M/pricingTokenUnit +
 		float64(cachedPromptTokens)*cachedInputPrice/pricingTokenUnit +
-		float64(usage.CompletionTokens)*pricing.OutputTokenPricePer1M/pricingTokenUnit
+		float64(completionTokens)*pricing.OutputTokenPricePer1M/pricingTokenUnit
 }
 
 func formatRequestCostUSD(usage *tokencount.Usage, pricing ModelPricing) string {
-	formatted := strconv.FormatFloat(requestCostUSD(usage, pricing), 'f', costDecimalPlaces, 64)
-	formatted = strings.TrimRight(formatted, "0")
-	formatted = strings.TrimRight(formatted, ".")
-	if formatted == "" {
+	cost := requestCostUSD(usage, pricing)
+	if cost == 0 {
 		return "0"
 	}
-	return formatted
+	decimalPlaces := max(0, costSignificantDigits-1-int(math.Floor(math.Log10(math.Abs(cost)))))
+	formatted := strconv.FormatFloat(cost, 'f', decimalPlaces, 64)
+	if decimalPlaces == 0 {
+		return formatted
+	}
+	formatted = strings.TrimRight(formatted, "0")
+	return strings.TrimRight(formatted, ".")
 }

--- a/manager/pricing.go
+++ b/manager/pricing.go
@@ -1,0 +1,37 @@
+package manager
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/tinfoilsh/confidential-model-router/tokencount"
+)
+
+const (
+	pricingTokenUnit  = 1_000_000
+	costDecimalPlaces = 12
+)
+
+func requestCostUSD(usage *tokencount.Usage, pricing ModelPricing) float64 {
+	cachedPromptTokens, _ := usage.CachedPromptTokens()
+	uncachedPromptTokens := max(0, usage.PromptTokens-cachedPromptTokens)
+	cachedInputPrice := pricing.InputTokenPricePer1M
+	if pricing.CachedInputTokenPricePer1M != nil {
+		cachedInputPrice = *pricing.CachedInputTokenPricePer1M
+	}
+
+	return pricing.RequestPrice +
+		float64(uncachedPromptTokens)*pricing.InputTokenPricePer1M/pricingTokenUnit +
+		float64(cachedPromptTokens)*cachedInputPrice/pricingTokenUnit +
+		float64(usage.CompletionTokens)*pricing.OutputTokenPricePer1M/pricingTokenUnit
+}
+
+func formatRequestCostUSD(usage *tokencount.Usage, pricing ModelPricing) string {
+	formatted := strconv.FormatFloat(requestCostUSD(usage, pricing), 'f', costDecimalPlaces, 64)
+	formatted = strings.TrimRight(formatted, "0")
+	formatted = strings.TrimRight(formatted, ".")
+	if formatted == "" {
+		return "0"
+	}
+	return formatted
+}

--- a/manager/pricing.go
+++ b/manager/pricing.go
@@ -9,44 +9,51 @@ import (
 )
 
 const (
-	pricingTokenUnit      = 1_000_000
-	costSignificantDigits = 15
+	nanosPerDollar          = 1_000_000_000
+	nanosPerTokenMultiplier = 1_000
+	nanodollarDecimalPlaces = 9
 )
 
 // CostKnownWithoutUsage reports whether request price alone determines cost.
 func (p ModelPricing) CostKnownWithoutUsage() bool {
-	if p.InputTokenPricePer1M != 0 || p.OutputTokenPricePer1M != 0 {
+	if tokenPriceNanos(p.InputTokenPricePer1M) != 0 || tokenPriceNanos(p.OutputTokenPricePer1M) != 0 {
 		return false
 	}
-	return p.CachedInputTokenPricePer1M == nil || *p.CachedInputTokenPricePer1M == 0
+	return p.CachedInputTokenPricePer1M == nil || tokenPriceNanos(*p.CachedInputTokenPricePer1M) == 0
 }
 
-func requestCostUSD(usage *tokencount.Usage, pricing ModelPricing) float64 {
+func tokenPriceNanos(pricePer1M float64) int64 {
+	return int64(math.Round(pricePer1M * nanosPerTokenMultiplier))
+}
+
+func requestPriceNanos(price float64) int64 {
+	return int64(math.Round(price * nanosPerDollar))
+}
+
+func requestCostNanos(usage *tokencount.Usage, pricing ModelPricing) int64 {
 	cachedPromptTokens, _ := usage.CachedPromptTokens()
 	cachedPromptTokens = max(0, cachedPromptTokens)
 	uncachedPromptTokens := max(0, usage.PromptTokens-cachedPromptTokens)
 	completionTokens := max(0, usage.CompletionTokens)
-	cachedInputPrice := pricing.InputTokenPricePer1M
+	cachedInputPriceNanos := tokenPriceNanos(pricing.InputTokenPricePer1M)
 	if pricing.CachedInputTokenPricePer1M != nil {
-		cachedInputPrice = *pricing.CachedInputTokenPricePer1M
+		cachedInputPriceNanos = tokenPriceNanos(*pricing.CachedInputTokenPricePer1M)
 	}
 
-	return pricing.RequestPrice +
-		float64(uncachedPromptTokens)*pricing.InputTokenPricePer1M/pricingTokenUnit +
-		float64(cachedPromptTokens)*cachedInputPrice/pricingTokenUnit +
-		float64(completionTokens)*pricing.OutputTokenPricePer1M/pricingTokenUnit
+	return requestPriceNanos(pricing.RequestPrice) +
+		int64(uncachedPromptTokens)*tokenPriceNanos(pricing.InputTokenPricePer1M) +
+		int64(cachedPromptTokens)*cachedInputPriceNanos +
+		int64(completionTokens)*tokenPriceNanos(pricing.OutputTokenPricePer1M)
 }
 
 func formatRequestCostUSD(usage *tokencount.Usage, pricing ModelPricing) string {
-	cost := requestCostUSD(usage, pricing)
-	if cost == 0 {
-		return "0"
+	costNanos := requestCostNanos(usage, pricing)
+	wholeDollars := costNanos / nanosPerDollar
+	fractionalNanos := costNanos % nanosPerDollar
+	if fractionalNanos == 0 {
+		return strconv.FormatInt(wholeDollars, 10)
 	}
-	decimalPlaces := max(0, costSignificantDigits-1-int(math.Floor(math.Log10(math.Abs(cost)))))
-	formatted := strconv.FormatFloat(cost, 'f', decimalPlaces, 64)
-	if decimalPlaces == 0 {
-		return formatted
-	}
-	formatted = strings.TrimRight(formatted, "0")
-	return strings.TrimRight(formatted, ".")
+	fraction := strconv.FormatInt(fractionalNanos, 10)
+	fraction = strings.Repeat("0", nanodollarDecimalPlaces-len(fraction)) + fraction
+	return strconv.FormatInt(wholeDollars, 10) + "." + strings.TrimRight(fraction, "0")
 }

--- a/manager/pricing_test.go
+++ b/manager/pricing_test.go
@@ -53,6 +53,30 @@ func TestRequestCostUSD(t *testing.T) {
 			},
 			expected: "0.001",
 		},
+		{
+			name:  "preserves sub-picodollar prices",
+			usage: &tokencount.Usage{},
+			pricing: ModelPricing{
+				RequestPrice: 0.00000000000005,
+			},
+			expected: "0.00000000000005",
+		},
+		{
+			name: "clamps negative token counts",
+			usage: &tokencount.Usage{
+				PromptTokens:     -100,
+				CompletionTokens: -50,
+				PromptTokensDetails: &tokencount.PromptTokensDetails{
+					CachedTokens: 25,
+				},
+			},
+			pricing: ModelPricing{
+				InputTokenPricePer1M:  1,
+				OutputTokenPricePer1M: 2,
+				RequestPrice:          0.01,
+			},
+			expected: "0.01",
+		},
 	}
 
 	for _, tt := range tests {

--- a/manager/pricing_test.go
+++ b/manager/pricing_test.go
@@ -54,12 +54,12 @@ func TestRequestCostUSD(t *testing.T) {
 			expected: "0.001",
 		},
 		{
-			name:  "preserves sub-picodollar prices",
+			name:  "matches nanodollar billing precision",
 			usage: &tokencount.Usage{},
 			pricing: ModelPricing{
 				RequestPrice: 0.00000000000005,
 			},
-			expected: "0.00000000000005",
+			expected: "0",
 		},
 		{
 			name: "clamps negative token counts",

--- a/manager/pricing_test.go
+++ b/manager/pricing_test.go
@@ -1,0 +1,100 @@
+package manager
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tinfoilsh/confidential-model-router/tokencount"
+)
+
+func TestRequestCostUSD(t *testing.T) {
+	cachedPrice := 0.25
+	tests := []struct {
+		name     string
+		usage    *tokencount.Usage
+		pricing  ModelPricing
+		expected string
+	}{
+		{
+			name: "uncached input and output",
+			usage: &tokencount.Usage{
+				PromptTokens:     1_000,
+				CompletionTokens: 500,
+			},
+			pricing: ModelPricing{
+				InputTokenPricePer1M:  1.5,
+				OutputTokenPricePer1M: 5.25,
+			},
+			expected: "0.004125",
+		},
+		{
+			name: "cached input discount and request price",
+			usage: &tokencount.Usage{
+				PromptTokens:        1_000,
+				CompletionTokens:    500,
+				PromptTokensDetails: &tokencount.PromptTokensDetails{CachedTokens: 400},
+			},
+			pricing: ModelPricing{
+				InputTokenPricePer1M:       1,
+				OutputTokenPricePer1M:      2,
+				CachedInputTokenPricePer1M: &cachedPrice,
+				RequestPrice:               0.01,
+			},
+			expected: "0.0117",
+		},
+		{
+			name: "cached input falls back to full input price",
+			usage: &tokencount.Usage{
+				PromptTokens:        1_000,
+				PromptTokensDetails: &tokencount.PromptTokensDetails{CachedTokens: 400},
+			},
+			pricing: ModelPricing{
+				InputTokenPricePer1M: 1,
+			},
+			expected: "0.001",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatRequestCostUSD(tt.usage, tt.pricing); got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestModelPricingJSONAndLookup(t *testing.T) {
+	var models openAIModelsList
+	err := json.Unmarshal([]byte(`{
+		"data": [{
+			"id": "priced-model",
+			"pricing": {
+				"inputTokenPricePer1M": 1.5,
+				"outputTokenPricePer1M": 5.25,
+				"cachedInputTokenPricePer1M": 0.375,
+				"requestPrice": 0.01
+			}
+		}]
+	}`), &models)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(models.Data) != 1 || models.Data[0].Pricing == nil {
+		t.Fatal("expected model pricing to decode")
+	}
+
+	em := &EnclaveManager{}
+	pricingByModel := map[string]ModelPricing{"priced-model": *models.Data[0].Pricing}
+	em.modelPricing.Store(&pricingByModel)
+	pricing, ok := em.ModelPricing("priced-model")
+	if !ok {
+		t.Fatal("expected cached model pricing")
+	}
+	if pricing.CachedInputTokenPricePer1M == nil || *pricing.CachedInputTokenPricePer1M != 0.375 {
+		t.Fatalf("unexpected cached input price: %+v", pricing.CachedInputTokenPricePer1M)
+	}
+	if _, ok := em.ModelPricing("missing-model"); ok {
+		t.Fatal("did not expect pricing for missing model")
+	}
+}

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -319,6 +319,10 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 
 		// Check if client requested usage metrics in response header/trailer
 		usageMetricsRequested := req.Header.Get(UsageMetricsRequestHeader) == "true"
+		var responsePricing *ModelPricing
+		if wrapper, ok := req.Context().Value(usageWriterKey{}).(*usageMetricsWriter); ok {
+			responsePricing = wrapper.pricing
+		}
 		if streaming && usageMetricsRequested {
 			addTrailerHeader(resp.Header, UsageMetricsResponseHeader)
 			if wrapper, ok := req.Context().Value(usageWriterKey{}).(*usageMetricsWriter); ok {
@@ -327,6 +331,10 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 		}
 
 		var handlerCalled atomic.Bool
+		if !streaming && usageMetricsRequested && resp.StatusCode == http.StatusOK &&
+			responsePricing != nil && responsePricing.CostKnownWithoutUsage() {
+			resp.Header.Set(UsageMetricsResponseHeader, FormatUsage(&tokencount.Usage{}, modelName, responsePricing))
+		}
 
 		// Create a usage handler that will be called when usage is extracted
 		usageHandler := func(usage *tokencount.Usage) {
@@ -413,11 +421,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				usageHandler(jsonResp.Usage)
 
 				// Set usage header directly on response
-				var pricing *ModelPricing
-				if wrapper, ok := req.Context().Value(usageWriterKey{}).(*usageMetricsWriter); ok {
-					pricing = wrapper.pricing
-				}
-				resp.Header.Set(UsageMetricsResponseHeader, FormatUsage(jsonResp.Usage, modelName, pricing))
+				resp.Header.Set(UsageMetricsResponseHeader, FormatUsage(jsonResp.Usage, modelName, responsePricing))
 			} else if billingCollector != nil && apiKey != "" {
 				emitZeroTokenEvent()
 			}

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -413,7 +413,11 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				usageHandler(jsonResp.Usage)
 
 				// Set usage header directly on response
-				resp.Header.Set(UsageMetricsResponseHeader, FormatUsage(jsonResp.Usage, modelName))
+				var pricing *ModelPricing
+				if wrapper, ok := req.Context().Value(usageWriterKey{}).(*usageMetricsWriter); ok {
+					pricing = wrapper.pricing
+				}
+				resp.Header.Set(UsageMetricsResponseHeader, FormatUsage(jsonResp.Usage, modelName, pricing))
 			} else if billingCollector != nil && apiKey != "" {
 				emitZeroTokenEvent()
 			}
@@ -462,7 +466,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 // FormatUsage formats token usage for the response header. It is the single
 // source of truth for the header format so every path that emits usage
 // metrics produces an identical value.
-func FormatUsage(usage *tokencount.Usage, model string) string {
+func FormatUsage(usage *tokencount.Usage, model string, pricing *ModelPricing) string {
 	formatted := "prompt=" + strconv.Itoa(usage.PromptTokens) +
 		",completion=" + strconv.Itoa(usage.CompletionTokens) +
 		",total=" + strconv.Itoa(usage.TotalTokens)
@@ -475,6 +479,9 @@ func FormatUsage(usage *tokencount.Usage, model string) string {
 
 	if model != "" {
 		formatted += ",model=" + model
+	}
+	if pricing != nil {
+		formatted += ",cost_usd=" + formatRequestCostUSD(usage, *pricing)
 	}
 
 	return formatted

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -92,6 +92,84 @@ func TestProxyUsageMetrics_IncludesCachedTokensForAllModels(t *testing.T) {
 	}
 }
 
+func TestProxyUsageMetrics_IncludesRequestPriceWithoutUsage(t *testing.T) {
+	proxy := setupTestProxyWithModel(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("response body"))
+	}), "request-priced-model")
+
+	req := httptest.NewRequest("POST", "/v1/audio/speech", nil)
+	req.Header.Set(UsageMetricsRequestHeader, "true")
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{
+		ResponseWriter: rec,
+		pricing:        &ModelPricing{RequestPrice: 0.02},
+	}
+	ctx := context.WithValue(req.Context(), usageWriterKey{}, wrapper)
+
+	proxy.ServeHTTP(wrapper, req.WithContext(ctx))
+
+	got := rec.Header().Get(UsageMetricsResponseHeader)
+	want := "prompt=0,completion=0,total=0,model=request-priced-model,cost_usd=0.02"
+	if got != want {
+		t.Fatalf("usage header = %q, want %q", got, want)
+	}
+}
+
+func TestProxyUsageMetrics_OmitsUnknownTokenCostWithoutUsage(t *testing.T) {
+	proxy := setupTestProxyWithModel(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("response body"))
+	}), "token-priced-model")
+
+	req := httptest.NewRequest("POST", "/v1/audio/speech", nil)
+	req.Header.Set(UsageMetricsRequestHeader, "true")
+	rec := httptest.NewRecorder()
+	wrapper := &usageMetricsWriter{
+		ResponseWriter: rec,
+		pricing: &ModelPricing{
+			InputTokenPricePer1M: 0.15,
+			RequestPrice:         0.02,
+		},
+	}
+	ctx := context.WithValue(req.Context(), usageWriterKey{}, wrapper)
+
+	proxy.ServeHTTP(wrapper, req.WithContext(ctx))
+
+	if got := rec.Header().Get(UsageMetricsResponseHeader); got != "" {
+		t.Fatalf("expected unknown cost to be omitted, got %q", got)
+	}
+}
+
+func TestProxyUsageMetrics_IncludesRequestPriceInTrailerWithoutUsage(t *testing.T) {
+	proxy := setupTestProxyWithModel(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("data: [DONE]\n\n"))
+	}), "request-priced-model")
+	enclave := &Enclave{
+		host:      "test-enclave",
+		modelName: "request-priced-model",
+		proxy:     proxy,
+		pricing: func(string) (ModelPricing, bool) {
+			return ModelPricing{RequestPrice: 0.02}, true
+		},
+	}
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req.Header.Set(UsageMetricsRequestHeader, "true")
+	rec := httptest.NewRecorder()
+
+	enclave.ServeHTTP(rec, req)
+
+	got := rec.Header().Get(UsageMetricsResponseHeader)
+	want := "prompt=0,completion=0,total=0,model=request-priced-model,cost_usd=0.02"
+	if got != want {
+		t.Fatalf("usage trailer = %q, want %q", got, want)
+	}
+}
+
 // --- Circuit breaker tests ---
 
 func TestCircuitBreaker_StartsClosed(t *testing.T) {

--- a/manager/usage_writer.go
+++ b/manager/usage_writer.go
@@ -18,6 +18,7 @@ type usageMetricsWriter struct {
 	http.ResponseWriter
 	usage          *tokencount.Usage
 	model          string
+	pricing        *ModelPricing
 	trailerEnabled bool
 	mu             sync.Mutex
 }
@@ -50,7 +51,7 @@ func (w *usageMetricsWriter) FormatUsage() string {
 	if w.usage == nil {
 		return ""
 	}
-	return FormatUsage(w.usage, w.model)
+	return FormatUsage(w.usage, w.model, w.pricing)
 }
 
 // WriteTrailer writes the usage metrics as an HTTP trailer

--- a/manager/usage_writer_test.go
+++ b/manager/usage_writer_test.go
@@ -43,6 +43,7 @@ func TestUsageMetricsWriter_FormatUsage(t *testing.T) {
 		name     string
 		usage    *tokencount.Usage
 		model    string
+		pricing  *ModelPricing
 		expected string
 	}{
 		{
@@ -74,6 +75,21 @@ func TestUsageMetricsWriter_FormatUsage(t *testing.T) {
 			},
 			model:    "kimi-k2-6",
 			expected: "prompt=69,completion=20,total=89,cached_prompt_tokens=64,uncached_prompt_tokens=5,model=kimi-k2-6",
+		},
+		{
+			name: "appends request cost when pricing is available",
+			usage: &tokencount.Usage{
+				PromptTokens:        100,
+				CompletionTokens:    50,
+				TotalTokens:         150,
+				PromptTokensDetails: &tokencount.PromptTokensDetails{CachedTokens: 40},
+			},
+			model: "priced-model",
+			pricing: &ModelPricing{
+				InputTokenPricePer1M:  0.15,
+				OutputTokenPricePer1M: 0.6,
+			},
+			expected: "prompt=100,completion=50,total=150,cached_prompt_tokens=40,uncached_prompt_tokens=60,model=priced-model,cost_usd=0.000045",
 		},
 		{
 			name: "zero values",
@@ -123,7 +139,7 @@ func TestUsageMetricsWriter_FormatUsage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			wrapper := &usageMetricsWriter{ResponseWriter: rec, model: tt.model}
+			wrapper := &usageMetricsWriter{ResponseWriter: rec, model: tt.model, pricing: tt.pricing}
 
 			if tt.usage != nil {
 				wrapper.SetUsage(tt.usage)
@@ -278,7 +294,13 @@ func TestUsageMetrics_NonStreamingFlow(t *testing.T) {
 		}
 
 		// Wrap writer
-		wrapper := &usageMetricsWriter{ResponseWriter: w}
+		wrapper := &usageMetricsWriter{
+			ResponseWriter: w,
+			pricing: &ModelPricing{
+				InputTokenPricePer1M:  0.15,
+				OutputTokenPricePer1M: 0.6,
+			},
+		}
 
 		// Simulate usage extraction (normally done by tokencount)
 		usage := &tokencount.Usage{
@@ -304,7 +326,7 @@ func TestUsageMetrics_NonStreamingFlow(t *testing.T) {
 
 	// Check response header
 	usageHeader := rec.Header().Get(UsageMetricsResponseHeader)
-	expected := "prompt=100,completion=25,total=125"
+	expected := "prompt=100,completion=25,total=125,cost_usd=0.00003"
 	if usageHeader != expected {
 		t.Errorf("expected usage header %q, got %q", expected, usageHeader)
 	}
@@ -325,7 +347,13 @@ func TestUsageMetrics_StreamingFlow(t *testing.T) {
 		w.Header().Set("Transfer-Encoding", "chunked")
 
 		// Wrap writer
-		wrapper := &usageMetricsWriter{ResponseWriter: w}
+		wrapper := &usageMetricsWriter{
+			ResponseWriter: w,
+			pricing: &ModelPricing{
+				InputTokenPricePer1M:  0.15,
+				OutputTokenPricePer1M: 0.6,
+			},
+		}
 
 		// Write streaming data
 		w.WriteHeader(http.StatusOK)
@@ -366,7 +394,7 @@ func TestUsageMetrics_StreamingFlow(t *testing.T) {
 
 	// Check the usage header was set (httptest.ResponseRecorder stores trailers in Header)
 	usageHeader := rec.Header().Get(UsageMetricsResponseHeader)
-	expected := "prompt=50,completion=10,total=60"
+	expected := "prompt=50,completion=10,total=60,cost_usd=0.0000135"
 	if usageHeader != expected {
 		t.Errorf("expected usage trailer %q, got %q", expected, usageHeader)
 	}

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -592,7 +592,11 @@ func (s *chatStreamer) finalize(
 	}
 
 	if s.usageMetricsRequested && finalUsage != nil {
-		s.w.Header().Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usageFromRaw(finalUsage), modelName))
+		var pricing *manager.ModelPricing
+		if value, ok := em.ModelPricing(modelName); ok {
+			pricing = &value
+		}
+		s.w.Header().Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usageFromRaw(finalUsage), modelName, pricing))
 	}
 	s.emitBillingEvent(r, em, modelName, finalUsage)
 	return s.writeErr

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -591,12 +591,10 @@ func (s *chatStreamer) finalize(
 		}
 	}
 
-	if s.usageMetricsRequested && finalUsage != nil {
-		var pricing *manager.ModelPricing
-		if value, ok := em.ModelPricing(modelName); ok {
-			pricing = &value
+	if s.usageMetricsRequested {
+		if formatted := formatUsageMetrics(em, usageFromRaw(finalUsage), modelName); formatted != "" {
+			s.w.Header().Set(manager.UsageMetricsResponseHeader, formatted)
 		}
-		s.w.Header().Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usageFromRaw(finalUsage), modelName, pricing))
 	}
 	s.emitBillingEvent(r, em, modelName, finalUsage)
 	return s.writeErr

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -233,7 +233,7 @@ func TestChatStreamerFinalizeSkipsAlreadyStreamedClientToolCalls(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
-	if err := streamer.finalize(req, nil, "gpt-oss-120b", result, clientToolCalls); err != nil {
+	if err := streamer.finalize(req, newTestEnclaveManager(), "gpt-oss-120b", result, clientToolCalls); err != nil {
 		t.Fatalf("finalize returned error: %v", err)
 	}
 
@@ -263,9 +263,7 @@ func TestChatStreamerFinalizeEmitsFinishAndUsage(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
-	// nil enclave manager is fine because the auth header is absent so
-	// emitBillingEvent short-circuits before dereferencing it.
-	if err := streamer.finalize(req, nil, "gpt-oss-120b", result, nil); err != nil {
+	if err := streamer.finalize(req, newTestEnclaveManager(), "gpt-oss-120b", result, nil); err != nil {
 		t.Fatalf("finalize returned error: %v", err)
 	}
 
@@ -302,7 +300,7 @@ func TestChatStreamerFinalizeForcesToolCallsFinishReason(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
-	if err := streamer.finalize(req, nil, "gpt-oss-120b", result, clientToolCalls); err != nil {
+	if err := streamer.finalize(req, newTestEnclaveManager(), "gpt-oss-120b", result, clientToolCalls); err != nil {
 		t.Fatalf("finalize returned error: %v", err)
 	}
 

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -816,12 +816,10 @@ func (s *responsesStreamer) finalize(r *http.Request, em *manager.EnclaveManager
 		"response": completed,
 	})
 
-	if s.usageMetricsRequested && usage != nil {
-		var pricing *manager.ModelPricing
-		if value, ok := em.ModelPricing(modelName); ok {
-			pricing = &value
+	if s.usageMetricsRequested {
+		if formatted := formatUsageMetrics(em, usageFromRaw(usage), modelName); formatted != "" {
+			s.w.Header().Set(manager.UsageMetricsResponseHeader, formatted)
 		}
-		s.w.Header().Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usageFromRaw(usage), modelName, pricing))
 	}
 	s.emitBillingEvent(r, em, modelName, usage)
 	return s.writeErr

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -817,7 +817,11 @@ func (s *responsesStreamer) finalize(r *http.Request, em *manager.EnclaveManager
 	})
 
 	if s.usageMetricsRequested && usage != nil {
-		s.w.Header().Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usageFromRaw(usage), modelName))
+		var pricing *manager.ModelPricing
+		if value, ok := em.ModelPricing(modelName); ok {
+			pricing = &value
+		}
+		s.w.Header().Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usageFromRaw(usage), modelName, pricing))
 	}
 	s.emitBillingEvent(r, em, modelName, usage)
 	return s.writeErr

--- a/toolruntime/responses_stream_test.go
+++ b/toolruntime/responses_stream_test.go
@@ -141,7 +141,7 @@ func TestResponsesStreamerFinalizeEmitsCompletedEvent(t *testing.T) {
 	}})
 
 	req := httptest.NewRequest("POST", "/v1/responses", nil)
-	if err := streamer.finalize(req, nil, "gpt-oss-120b", responsesIterationResult{}); err != nil {
+	if err := streamer.finalize(req, newTestEnclaveManager(), "gpt-oss-120b", responsesIterationResult{}); err != nil {
 		t.Fatalf("finalize returned error: %v", err)
 	}
 
@@ -306,7 +306,7 @@ func TestResponsesStreamerFinalizeAttachesAnnotationsToCompletedOutput(t *testin
 		},
 	}
 	req := httptest.NewRequest("POST", "/v1/responses", nil)
-	if err := streamer.finalize(req, nil, "gpt-oss-120b", responsesIterationResult{}); err != nil {
+	if err := streamer.finalize(req, newTestEnclaveManager(), "gpt-oss-120b", responsesIterationResult{}); err != nil {
 		t.Fatalf("finalize returned error: %v", err)
 	}
 	body := rec.Body.String()
@@ -618,7 +618,7 @@ func TestResponsesStreamerCompletedOutputKeepsPersistedAutoContinueCalls(t *test
 	}
 
 	req := httptest.NewRequest("POST", "/v1/responses", nil)
-	if err := streamer.finalize(req, nil, "gpt-oss-120b", responsesIterationResult{}); err != nil {
+	if err := streamer.finalize(req, newTestEnclaveManager(), "gpt-oss-120b", responsesIterationResult{}); err != nil {
 		t.Fatalf("finalize returned error: %v", err)
 	}
 

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -442,14 +442,25 @@ func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested boo
 	}
 
 	usage := usageFromRaw(response.body["usage"])
-	if usage == nil {
+	formatted := formatUsageMetrics(em, usage, modelName)
+	if formatted == "" {
 		return
 	}
+	response.header.Set(manager.UsageMetricsResponseHeader, formatted)
+}
+
+func formatUsageMetrics(em *manager.EnclaveManager, usage *tokencount.Usage, modelName string) string {
 	var pricing *manager.ModelPricing
 	if value, ok := em.ModelPricing(modelName); ok {
 		pricing = &value
 	}
-	response.header.Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usage, modelName, pricing))
+	if usage == nil {
+		if pricing == nil || !pricing.CostKnownWithoutUsage() {
+			return ""
+		}
+		usage = &tokencount.Usage{}
+	}
+	return manager.FormatUsage(usage, modelName, pricing)
 }
 
 func emitBillingEvent(em *manager.EnclaveManager, r *http.Request, response *upstreamJSONResponse, modelName string, streaming bool) {

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -451,10 +451,8 @@ func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested boo
 
 func formatUsageMetrics(em *manager.EnclaveManager, usage *tokencount.Usage, modelName string) string {
 	var pricing *manager.ModelPricing
-	if em != nil {
-		if value, ok := em.ModelPricing(modelName); ok {
-			pricing = &value
-		}
+	if value, ok := em.ModelPricing(modelName); ok {
+		pricing = &value
 	}
 	if usage == nil {
 		if pricing == nil || !pricing.CostKnownWithoutUsage() {

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -451,8 +451,10 @@ func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested boo
 
 func formatUsageMetrics(em *manager.EnclaveManager, usage *tokencount.Usage, modelName string) string {
 	var pricing *manager.ModelPricing
-	if value, ok := em.ModelPricing(modelName); ok {
-		pricing = &value
+	if em != nil {
+		if value, ok := em.ModelPricing(modelName); ok {
+			pricing = &value
+		}
 	}
 	if usage == nil {
 		if pricing == nil || !pricing.CostKnownWithoutUsage() {

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -166,7 +166,7 @@ func Handle(w http.ResponseWriter, r *http.Request, em *manager.EnclaveManager, 
 		if err != nil {
 			return writeUpstreamError(w, err)
 		}
-		applyUsageMetrics(response, usageMetricsRequested, modelName)
+		applyUsageMetrics(response, usageMetricsRequested, modelName, em)
 		emitBillingEvent(em, r, response, modelName, false)
 		return writeJSONResponse(w, response)
 	case "/v1/responses":
@@ -180,7 +180,7 @@ func Handle(w http.ResponseWriter, r *http.Request, em *manager.EnclaveManager, 
 		if err != nil {
 			return writeUpstreamError(w, err)
 		}
-		applyUsageMetrics(response, usageMetricsRequested, modelName)
+		applyUsageMetrics(response, usageMetricsRequested, modelName, em)
 		emitBillingEvent(em, r, response, modelName, false)
 		return writeJSONResponse(w, response)
 	default:
@@ -431,7 +431,7 @@ func usageMap(usage *tokencount.Usage, inputTokensKey, outputTokensKey, detailsK
 	return usageMap
 }
 
-func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested bool, modelName string) {
+func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested bool, modelName string, em *manager.EnclaveManager) {
 	if response == nil {
 		return
 	}
@@ -445,7 +445,11 @@ func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested boo
 	if usage == nil {
 		return
 	}
-	response.header.Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usage, modelName))
+	var pricing *manager.ModelPricing
+	if value, ok := em.ModelPricing(modelName); ok {
+		pricing = &value
+	}
+	response.header.Set(manager.UsageMetricsResponseHeader, manager.FormatUsage(usage, modelName, pricing))
 }
 
 func emitBillingEvent(em *manager.EnclaveManager, r *http.Request, response *upstreamJSONResponse, modelName string, streaming bool) {

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -19,6 +19,10 @@ import (
 	usagereporting "github.com/tinfoilsh/usage-reporting-go"
 )
 
+func newTestEnclaveManager() *manager.EnclaveManager {
+	return &manager.EnclaveManager{}
+}
+
 func TestReplaceRouterOwnedResponsesTools(t *testing.T) {
 	replaced := replaceRouterOwnedResponsesTools([]any{
 		map[string]any{"type": "web_search"},


### PR DESCRIPTION
## Summary
- cache model pricing from `/v1/models` and append exact `cost_usd` values to requested usage headers and trailers
- add free, bearer-gated `/v1/responses/input_tokens` and `/v1/chat/completions/input_tokens` endpoints backed by each model enclave's `/tokenize` route
- translate common Responses inputs, images, function calls, outputs, and function tools into the model's chat template without running inference

## Notes
- cached tokens fall back to the full input rate when no cached-input rate is published
- token-count calls are intentionally not billed or rate-limited
- stateful Responses inputs and hosted/non-function tools remain unsupported by the conversion layer

## Testing
- `go test ./...`
- `go vet ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds request cost reporting and free input-token counting endpoints so users can estimate spend and validate prompts without running inference. Costs appear as `cost_usd` in the `X-Usage-Metrics` header/trailer, including for request-priced models even when token usage is absent, using billing-precision formatting.

- **New Features**
  - Cache model pricing from `/v1/models` and append `cost_usd` to `X-Usage-Metrics`, honoring cached vs. uncached input rates (fall back to full input rate when no cached rate exists) and `requestPrice`; omit token-priced costs until usage is known.
  - Add bearer-gated, free endpoints `POST /v1/chat/completions/input_tokens` and `POST /v1/responses/input_tokens` that call each model’s `/tokenize` to return `input_tokens`. Convert Responses payloads (instructions, text/image parts, grouped function calls/outputs, function tools) into the model’s chat template; respect `reasoning.effort`, continuation flags, and `tool_choice=none`; skip stateful inputs and hosted/non-function tools.

- **Bug Fixes**
  - Align reported costs with billing precision and emit them consistently across streaming and non-streaming responses, including subdomain routes; format `cost_usd` to match nanodollar billing precision.
  - Preserve prompt options in token counts (`chat_template_kwargs`, `add_special_tokens`, `chat_template`, `mm_processor_kwargs`, `media_io_kwargs`).

<sup>Written for commit 89fdae243ffb6b39e573b77709fe1972f280c2f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

