### PR TITLE
feat: split cache-route reuse metrics by caller priority class

### DIFF
--- a/cacheroute/cacheroute.go
+++ b/cacheroute/cacheroute.go
@@ -164,6 +164,12 @@ type Request struct {
 	// contents): the eligibility-floor input and the weight for the
 	// byte-weighted reuse metrics.
 	PromptBytes int
+	// Priority is the caller's priority class for the reuse metrics:
+	// "configured" when the control plane assigned the caller a vLLM
+	// priority, "none" otherwise. Set by the caller after extraction —
+	// the body alone cannot know it — and an unset value is recorded as
+	// "none".
+	Priority string
 
 	elapsed time.Duration // extraction cost, folded into ComputeSeconds
 }

--- a/cacheroute/metrics.go
+++ b/cacheroute/metrics.go
@@ -30,12 +30,14 @@ var (
 	// ReuseTotal classifies keyed requests against where the actual pick
 	// landed. repeat_cold = the prefix was warm on a replica the pick
 	// missed, i.e. the reuse cache-aware routing would have captured.
+	// Split by caller priority class so reserved-org traffic
+	// (priority=configured) reads separately from public traffic.
 	ReuseTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_cache_route_reuse_total",
-			Help: "Keyed requests by prefix-reuse classification against the actual pick (first_seen, repeat_warm, repeat_cold)",
+			Help: "Keyed requests by caller priority class (configured, none) and prefix-reuse classification against the actual pick (first_seen, repeat_warm, repeat_cold)",
 		},
-		[]string{"model", "outcome"},
+		[]string{"model", "priority", "outcome"},
 	)
 
 	// ReusePromptBytesTotal weights ReuseTotal by prompt bytes, since
@@ -43,9 +45,9 @@ var (
 	ReusePromptBytesTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "router_cache_route_reuse_prompt_bytes_total",
-			Help: "Prompt bytes of keyed requests by prefix-reuse classification (first_seen, repeat_warm, repeat_cold)",
+			Help: "Prompt bytes of keyed requests by caller priority class (configured, none) and prefix-reuse classification (first_seen, repeat_warm, repeat_cold)",
 		},
-		[]string{"model", "outcome"},
+		[]string{"model", "priority", "outcome"},
 	)
 
 	// PicksTotal counts the would-be pick per enclave, with the key's

--- a/cacheroute/metrics_test.go
+++ b/cacheroute/metrics_test.go
@@ -39,8 +39,8 @@ func TestMetricContract(t *testing.T) {
 
 	want := map[string][]string{
 		"router_cache_route_requests_total":           {"model", "outcome"},
-		"router_cache_route_reuse_total":              {"model", "outcome"},
-		"router_cache_route_reuse_prompt_bytes_total": {"model", "outcome"},
+		"router_cache_route_reuse_total":              {"model", "priority", "outcome"},
+		"router_cache_route_reuse_prompt_bytes_total": {"model", "priority", "outcome"},
 		"router_cache_route_picks_total":              {"model", "enclave", "r"},
 		"router_cache_route_random_match_total":       {"model"},
 		"router_cache_route_load_demotions_total":     {"model"},

--- a/cacheroute/shadow.go
+++ b/cacheroute/shadow.go
@@ -261,9 +261,13 @@ func (s *Shadow) observe(model string, req *Request, pool Pool, actualHost strin
 
 	res := s.observeKeyed(model, req.Key, pool.Candidates, actualHost, d, cfg)
 
+	priority := req.Priority
+	if priority == "" {
+		priority = "none"
+	}
 	RequestsTotal.WithLabelValues(model, string(OutcomeKeyed)).Inc()
-	ReuseTotal.WithLabelValues(model, res.reuse).Inc()
-	ReusePromptBytesTotal.WithLabelValues(model, res.reuse).Add(float64(req.PromptBytes))
+	ReuseTotal.WithLabelValues(model, priority, res.reuse).Inc()
+	ReusePromptBytesTotal.WithLabelValues(model, priority, res.reuse).Add(float64(req.PromptBytes))
 	if res.repeat {
 		RepeatIntervalSeconds.WithLabelValues(model).Observe(res.interval.Seconds())
 	}

--- a/cacheroute/shadow_test.go
+++ b/cacheroute/shadow_test.go
@@ -78,7 +78,7 @@ func TestObserveClassification(t *testing.T) {
 	cfg := defaultSettings() // W = 10 min
 	req := keyedRequest(t, "one", 100)
 
-	reuse := func(outcome string) float64 { return counterValue(t, ReuseTotal, model, outcome) }
+	reuse := func(outcome string) float64 { return counterValue(t, ReuseTotal, model, "none", outcome) }
 	base := [3]float64{reuse(ReuseFirstSeen), reuse(ReuseRepeatWarm), reuse(ReuseRepeatCold)}
 	keyed := counterDelta(t, RequestsTotal, model, string(OutcomeKeyed))
 
@@ -112,6 +112,41 @@ func TestObserveClassification(t *testing.T) {
 	// All four keyed requests counted in the funnel.
 	if got := keyed(); got != 4 {
 		t.Fatalf("keyed = %v, want 4", got)
+	}
+}
+
+// TestReusePriorityLabel pins the caller-priority split on the reuse
+// metrics: a configured-priority request lands in the configured series
+// with its prompt bytes, and an unset Priority is recorded as "none".
+func TestReusePriorityLabel(t *testing.T) {
+	s, clock, _ := newTestShadow(t)
+	model := "prio-" + t.Name()
+	cfg := defaultSettings()
+	req := keyedRequest(t, "one", 100)
+
+	configured := counterDelta(t, ReuseTotal, model, "configured", ReuseFirstSeen)
+	configuredBytes := counterDelta(t, ReusePromptBytesTotal, model, "configured", ReuseFirstSeen)
+	noneWarm := counterDelta(t, ReuseTotal, model, "none", ReuseRepeatWarm)
+
+	req.Priority = "configured"
+	s.Observe(model, req, pool2(), "enclave-a", cfg)
+	if got := configured(); got != 1 {
+		t.Fatalf("configured first_seen = %v, want 1", got)
+	}
+	if got := configuredBytes(); got != 100 {
+		t.Fatalf("configured first_seen bytes = %v, want 100", got)
+	}
+
+	// The same key from a caller without a configured priority: the class
+	// is per-request, not per-key.
+	clock.advance(time.Minute)
+	req.Priority = ""
+	s.Observe(model, req, pool2(), "enclave-a", cfg)
+	if got := noneWarm(); got != 1 {
+		t.Fatalf("none repeat_warm = %v, want 1", got)
+	}
+	if got := configured(); got != 1 {
+		t.Fatalf("configured series grew to %v after a none request", got)
 	}
 }
 
@@ -150,8 +185,8 @@ func TestObserveByteWeighting(t *testing.T) {
 	model := "bytes-" + t.Name()
 	cfg := defaultSettings()
 	req := keyedRequest(t, "bw", 5000)
-	firstBytes := counterDelta(t, ReusePromptBytesTotal, model, ReuseFirstSeen)
-	coldBytes := counterDelta(t, ReusePromptBytesTotal, model, ReuseRepeatCold)
+	firstBytes := counterDelta(t, ReusePromptBytesTotal, model, "none", ReuseFirstSeen)
+	coldBytes := counterDelta(t, ReusePromptBytesTotal, model, "none", ReuseRepeatCold)
 
 	s.Observe(model, req, pool2(), "enclave-a", cfg)
 	clock.advance(time.Second)
@@ -205,16 +240,16 @@ func TestCapacityEviction(t *testing.T) {
 
 	// k1 survived (repeat), k2 was evicted (first_seen again) — the
 	// documented capacity bias.
-	warmBefore := counterValue(t, ReuseTotal, model, ReuseRepeatWarm)
+	warmBefore := counterValue(t, ReuseTotal, model, "none", ReuseRepeatWarm)
 	clock.advance(time.Second)
 	s.Observe(model, k1, pool2(), "enclave-a", cfg)
-	if got := counterValue(t, ReuseTotal, model, ReuseRepeatWarm) - warmBefore; got != 1 {
+	if got := counterValue(t, ReuseTotal, model, "none", ReuseRepeatWarm) - warmBefore; got != 1 {
 		t.Fatalf("k1 must still be tracked, warm delta = %v", got)
 	}
-	firstBefore := counterValue(t, ReuseTotal, model, ReuseFirstSeen)
+	firstBefore := counterValue(t, ReuseTotal, model, "none", ReuseFirstSeen)
 	clock.advance(time.Second)
 	s.Observe(model, k2, pool2(), "enclave-a", cfg)
-	if got := counterValue(t, ReuseTotal, model, ReuseFirstSeen) - firstBefore; got != 1 {
+	if got := counterValue(t, ReuseTotal, model, "none", ReuseFirstSeen) - firstBefore; got != 1 {
 		t.Fatalf("evicted k2 must classify first_seen, delta = %v", got)
 	}
 }
@@ -377,7 +412,7 @@ func TestObserveProbeServed(t *testing.T) {
 	}
 
 	// The probe still warmed its replica: a repeat onto it is warm.
-	warm := counterDelta(t, ReuseTotal, model, ReuseRepeatWarm)
+	warm := counterDelta(t, ReuseTotal, model, "none", ReuseRepeatWarm)
 	clock.advance(time.Second)
 	s.Observe(model, req, pool2(), "probe-c", cfg)
 	if got := warm(); got != 1 {
@@ -489,7 +524,7 @@ func TestObserveLanding(t *testing.T) {
 
 	matches := counterDelta(t, RandomMatchTotal, model)
 	landedPicks := counterDelta(t, PicksTotal, model, "enclave-b", "1")
-	warm := counterDelta(t, ReuseTotal, model, ReuseRepeatWarm)
+	warm := counterDelta(t, ReuseTotal, model, "none", ReuseRepeatWarm)
 
 	d := s.Decide(model, req, pool2(), cfg)
 	s.ObserveLanding(model, req, d, "enclave-b", cfg)
@@ -550,7 +585,7 @@ func TestObserveEnforced(t *testing.T) {
 
 	matches := counterDelta(t, RandomMatchTotal, model)
 	landedPicks := counterDelta(t, PicksTotal, model, "enclave-b", "1")
-	warm := counterDelta(t, ReuseTotal, model, ReuseRepeatWarm)
+	warm := counterDelta(t, ReuseTotal, model, "none", ReuseRepeatWarm)
 
 	// Land twice on enclave-b regardless of what the ranking would pick.
 	s.Observe(model, req, pool2(), "enclave-b", cfg)

--- a/main.go
+++ b/main.go
@@ -742,6 +742,13 @@ func main() {
 							"model": modelName,
 						}).Debug("injecting configured vLLM priority")
 					}
+					// Like the caller org above, the priority class must
+					// reach internal dispatches (the tool loop) so their
+					// cache-route reuse metrics split by the originating
+					// caller the way proxied requests do.
+					if hasConfiguredPriority {
+						r = r.WithContext(manager.WithCallerPriority(r.Context(), "configured"))
+					}
 				}
 
 				if r.URL.Path == "/v1/responses" || r.URL.Path == "/v1/chat/completions" {
@@ -875,6 +882,7 @@ func main() {
 							salt, _ := body["cache_salt"].(string)
 							cacheRouteSettings = s
 							cacheRouteReq = cacheroute.ExtractRequest(body, r.URL.Path, salt, s)
+							cacheRouteReq.Priority = priorityClass(hasConfiguredPriority)
 						}
 					}
 				}

--- a/manager/caller_priority.go
+++ b/manager/caller_priority.go
@@ -1,0 +1,28 @@
+package manager
+
+import "context"
+
+// callerPriorityContextKey carries the caller's priority class through
+// internal dispatches (the tool loop) so the cache-route reuse metrics
+// split them by the originating caller without threading the class through
+// every toolruntime signature.
+type callerPriorityContextKey struct{}
+
+// WithCallerPriority attaches the caller's priority class ("configured")
+// to the request context. The default class carries no information, so an
+// empty or "none" value leaves the context untouched.
+func WithCallerPriority(ctx context.Context, class string) context.Context {
+	if class == "" || class == "none" {
+		return ctx
+	}
+	return context.WithValue(ctx, callerPriorityContextKey{}, class)
+}
+
+// CallerPriorityFromContext returns the caller's priority class, or "none"
+// when absent.
+func CallerPriorityFromContext(ctx context.Context) string {
+	if class, _ := ctx.Value(callerPriorityContextKey{}).(string); class != "" {
+		return class
+	}
+	return "none"
+}

--- a/manager/caller_priority_test.go
+++ b/manager/caller_priority_test.go
@@ -1,0 +1,26 @@
+package manager
+
+import (
+	"context"
+	"testing"
+)
+
+// TestCallerPriorityContext pins the context round-trip: only "configured"
+// is worth carrying, and every other state — absent, empty, explicit
+// "none" — reads back as "none".
+func TestCallerPriorityContext(t *testing.T) {
+	ctx := context.Background()
+
+	if got := CallerPriorityFromContext(ctx); got != "none" {
+		t.Fatalf("absent = %q, want none", got)
+	}
+	if got := CallerPriorityFromContext(WithCallerPriority(ctx, "")); got != "none" {
+		t.Fatalf("empty = %q, want none", got)
+	}
+	if got := CallerPriorityFromContext(WithCallerPriority(ctx, "none")); got != "none" {
+		t.Fatalf("none = %q, want none", got)
+	}
+	if got := CallerPriorityFromContext(WithCallerPriority(ctx, "configured")); got != "configured" {
+		t.Fatalf("configured = %q, want configured", got)
+	}
+}

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -140,6 +140,7 @@ func (em *EnclaveManager) cacheRouteRequest(ctx context.Context, modelName, path
 	}
 	salt, _ := body["cache_salt"].(string)
 	req := cacheroute.ExtractRequest(body, path, salt, settings)
+	req.Priority = CallerPriorityFromContext(ctx)
 	primary, _ := model.ReservationPools(CallerOrgFromContext(ctx))
 	return req, settings, model.CacheRoutePoolIn(primary), true
 }


### PR DESCRIPTION
## Why

`router_cache_route_reuse_total` and `router_cache_route_reuse_prompt_bytes_total` had no `priority` label, so cache-routing dashboards could not separate reserved-org traffic from public traffic — the prefix-reuse panels on the Public Inference Overview dashboard currently include all callers.

## What

- Both reuse counters gain a `priority` label with the same closed enum the latency/duration series already use: `configured` | `none`. Cardinality doubles at most (2 classes × 3 outcomes per model).
- `cacheroute.Request` carries the class; an unset value is recorded as `none`, so the metric can never emit an empty label value.
- The proxy path stamps the class from the route-context lookup result (`priorityClass(hasConfiguredPriority)`).
- Internal dispatches (tool loop) inherit the class through the request context via a new `WithCallerPriority` / `CallerPriorityFromContext` pair in `manager`, mirroring how the caller org already propagates to reservation-pool selection — so a reserved caller's tool-session iterations are labeled like its proxied requests.

## Metrics contract

`TestMetricContract` updated: both reuse series are now pinned at `{model, priority, outcome}`. New `TestReusePriorityLabel` pins that the class is per-request (not per-key) and that unset records as `none`; new `TestCallerPriorityContext` pins the context round-trip.

**Dashboard note:** existing panels that query these series without a `priority` matcher keep working unchanged (the new label just splits series; sums are unaffected). After deploy, public-only panels can add `priority="none"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split cache-route reuse metrics by caller priority class so dashboards can separate reserved-org and public traffic. Existing queries keep working; sums are unchanged.

- **New Features**
  - Added `priority` label (`configured` | `none`) to router_cache_route_reuse_total and router_cache_route_reuse_prompt_bytes_total (aligned with latency/duration series).
  - Propagated class via `cacheroute.Request.Priority` (defaults to `none` if unset).
  - Stamped class in the proxy from route-context; internal dispatches inherit it via `manager.WithCallerPriority` / `CallerPriorityFromContext`.
  - Updated tests to pin the label set and context round-trip.

- **Migration**
  - No changes required to existing panels or alerts.
  - To filter: public-only panels use priority="none"; reserved-org panels use priority="configured".
  - Note: series cardinality increases due to the new label.

<sup>Written for commit 096eb9e2cc9f1e26ad479f38f7223464c44a6622. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

