### PR TITLE
fix: stop long streaming responses dying after five minutes

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,23 @@ var version = "dev"
 
 const maxRequestBodySize int64 = 64 * 1024 * 1024
 
+const (
+	// serverReadTimeout is the absolute deadline armed on the connection at
+	// request start. In net/http it is never cleared while the handler runs,
+	// so it also caps how long a streaming response can live: when it fires,
+	// the server's background read errors and the request context is
+	// canceled, aborting the proxied stream. It must therefore exceed the
+	// longest legitimate completion stream.
+	serverReadTimeout = 60 * time.Minute
+	// serverReadHeaderTimeout bounds reading request headers. Set explicitly
+	// because an unset value falls back to serverReadTimeout, which would
+	// allow slow-header (slowloris) connections to linger for an hour.
+	serverReadHeaderTimeout = time.Minute
+	// serverIdleTimeout bounds idle keep-alive connections between requests.
+	// Set explicitly because an unset value falls back to serverReadTimeout.
+	serverIdleTimeout = 2 * time.Minute
+)
+
 // rateLimitIdentity returns the identity used to key rate limiting. For OAuth
 // JWT access tokens it is the token's `sub` claim, so a user's bucket stays
 // stable across the short-lived token's ~15m refreshes (and across multiple
@@ -1083,10 +1100,12 @@ func main() {
 
 	// Setup graceful shutdown
 	server := &http.Server{
-		Addr:         ":" + *port,
-		Handler:      nil,             // Use default ServeMux
-		ReadTimeout:  5 * time.Minute, // Increased to support large RAG payloads
-		WriteTimeout: 0,               // Disabled to support long-running streaming responses
+		Addr:              ":" + *port,
+		Handler:           nil, // Use default ServeMux
+		ReadTimeout:       serverReadTimeout,
+		ReadHeaderTimeout: serverReadHeaderTimeout,
+		IdleTimeout:       serverIdleTimeout,
+		WriteTimeout:      0, // Disabled to support long-running streaming responses
 	}
 
 	// Handle shutdown signals


### PR DESCRIPTION
## Summary

Users report that long streaming completions (e.g. long coding prompts) consistently die after 5-10 minutes with a client-side connection error, while short responses work fine.

Root cause: the server's `ReadTimeout: 5 * time.Minute` arms an absolute read deadline on the connection at request start that is never cleared while the handler runs. When it fires mid-stream, the server's background read errors, the request context is canceled, and `httputil.ReverseProxy` aborts the upstream enclave request — killing the stream. These deaths are miscounted as *client* cancellations in our metrics. The existing comment on `WriteTimeout: 0` shows we knew write timeouts break streaming; `ReadTimeout` has the same lethal effect via context cancellation.

## Changes

- Raise `ReadTimeout` to 60 minutes so it remains only a generous whole-request ceiling rather than a stream killer.
- Set `ReadHeaderTimeout` (1m) and `IdleTimeout` (2m) explicitly — when unset they fall back to `ReadTimeout`, which would otherwise allow hour-long slow-header (slowloris) connections and idle keep-alives.
- Named constants with comments explaining the streaming interaction so this doesn't regress.

## Notes

- Companion controlplane PR raises the matching 10-minute `http.Client` timeout on the `/v1/*` inference proxy, which is the second kill timer in the same reported window.
- `go test ./...` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops long streaming completions from dying after ~5 minutes by fixing `net/http` server timeouts. Streams can now run up to 60 minutes without mid-stream cancellation.

- **Bug Fixes**
  - Increased `ReadTimeout` to 60m to avoid the read deadline canceling streams.
  - Set `ReadHeaderTimeout` to 1m to bound header reads and prevent slowloris.
  - Set `IdleTimeout` to 2m; kept `WriteTimeout` at 0 for streaming.
  - Note: companion controlplane change raises the `/v1/*` proxy `http.Client` timeout.

<sup>Written for commit f50c86dc0307fb9a14658466a931b23989bb35ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

