### PR TITLE
feat: add kimi-k3

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,6 +38,9 @@ models:
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6-b200
 
+  kimi-k3:
+    repo: tinfoilsh/confidential-kimi-k3
+
   websearch:
     repo: tinfoilsh/confidential-websearch
 


### PR DESCRIPTION
Adds the kimi-k3 model to the trust anchor, pinned to tinfoilsh/confidential-kimi-k3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `kimi-k3` model to the trust anchor, pinned to `tinfoilsh/confidential-kimi-k3`, so it can be selected and routed like existing models.

<sup>Written for commit eac899be41f72856431d9fe10c9fbc6f0efdc65a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

