### PR TITLE
fix: preserve reasoning between streamed tool calls

### DIFF
--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -50,13 +50,12 @@ type chatStreamer struct {
 // decide whether to loop (router-owned tool calls present) or finalize (no
 // tool calls or only client-owned tool calls remain).
 type chatIterationResult struct {
-	content        string
-	reasoning      string
-	reasoningField string
-	toolCalls      []toolCall
-	rawToolCalls   []any
-	finishReason   string
-	usage          map[string]any
+	content          string
+	reasoningByField map[string]string
+	toolCalls        []toolCall
+	rawToolCalls     []any
+	finishReason     string
+	usage            map[string]any
 }
 
 const (
@@ -115,13 +114,30 @@ func (r *chatIterationResult) assistantMessage() map[string]any {
 		"role":    "assistant",
 		"content": r.content,
 	}
-	if r.reasoningField != "" {
-		message[r.reasoningField] = r.reasoning
+	for _, field := range []string{chatReasoningContentField, chatReasoningField} {
+		if reasoning := r.reasoningByField[field]; reasoning != "" {
+			message[field] = reasoning
+		}
 	}
 	if len(r.rawToolCalls) > 0 {
 		message["tool_calls"] = r.rawToolCalls
 	}
 	return message
+}
+
+func (r *chatIterationResult) accumulateReasoning(delta map[string]any, field string) {
+	reasoning := stringValue(delta[field])
+	if reasoning == "" {
+		return
+	}
+	if r.reasoningByField == nil {
+		r.reasoningByField = make(map[string]string, 2)
+	}
+	r.reasoningByField[field] += reasoning
+}
+
+func (r chatIterationResult) reasoningText() string {
+	return r.reasoningByField[chatReasoningContentField] + r.reasoningByField[chatReasoningField]
 }
 
 // ---------------------------------------------------------------------------
@@ -226,18 +242,8 @@ func (s *chatStreamer) pumpUpstream(reader *sseReader) (chatIterationResult, err
 		// the final reasoning fragment and the first content tokens,
 		// and splitting it content-first would hand clients the tail of
 		// the reasoning after the answer already started.
-		if r := stringValue(delta[chatReasoningContentField]); r != "" {
-			if result.reasoningField == "" {
-				result.reasoningField = chatReasoningContentField
-			}
-			result.reasoning += r
-		}
-		if r := stringValue(delta[chatReasoningField]); r != "" {
-			if result.reasoningField == "" {
-				result.reasoningField = chatReasoningField
-			}
-			result.reasoning += r
-		}
+		result.accumulateReasoning(delta, chatReasoningContentField)
+		result.accumulateReasoning(delta, chatReasoningField)
 		s.emitReasoningDelta(delta)
 		if content := stringValue(delta["content"]); content != "" {
 			result.content += content
@@ -956,7 +962,7 @@ func runChatStreaming(
 			return nil
 		}
 
-		dl.WriteStreamedTurn(i+1, result.usage, result.reasoning, result.content)
+		dl.WriteStreamedTurn(i+1, result.usage, result.reasoningText(), result.content)
 
 		routerToolCalls, clientToolCalls := splitToolCalls(ownedTools, result.toolCalls)
 		autoContinueCalls, externalClientCalls := splitClientToolCalls(autoContinueTools, clientToolCalls)

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -226,12 +226,13 @@ func (s *chatStreamer) pumpUpstream(reader *sseReader) (chatIterationResult, err
 		// the final reasoning fragment and the first content tokens,
 		// and splitting it content-first would hand clients the tail of
 		// the reasoning after the answer already started.
-		if r, ok := delta[chatReasoningContentField].(string); ok {
+		if r := stringValue(delta[chatReasoningContentField]); r != "" {
 			if result.reasoningField == "" {
 				result.reasoningField = chatReasoningContentField
 			}
 			result.reasoning += r
-		} else if r, ok := delta[chatReasoningField].(string); ok {
+		}
+		if r := stringValue(delta[chatReasoningField]); r != "" {
 			if result.reasoningField == "" {
 				result.reasoningField = chatReasoningField
 			}

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -45,18 +45,24 @@ type chatStreamer struct {
 }
 
 // chatIterationResult summarizes one upstream stream's payload once the
-// stream terminated: accumulated content, any parsed tool calls, and the
-// finish reason the upstream reported. Callers use this to decide whether
-// to loop (router-owned tool calls present) or finalize (no tool calls or
-// only client-owned tool calls remain).
+// stream terminated: accumulated reasoning and content, any parsed tool
+// calls, and the finish reason the upstream reported. Callers use this to
+// decide whether to loop (router-owned tool calls present) or finalize (no
+// tool calls or only client-owned tool calls remain).
 type chatIterationResult struct {
-	content      string
-	reasoning    string
-	toolCalls    []toolCall
-	rawToolCalls []any
-	finishReason string
-	usage        map[string]any
+	content        string
+	reasoning      string
+	reasoningField string
+	toolCalls      []toolCall
+	rawToolCalls   []any
+	finishReason   string
+	usage          map[string]any
 }
+
+const (
+	chatReasoningField        = "reasoning"
+	chatReasoningContentField = "reasoning_content"
+)
 
 // chatToolCallBuilder assembles OpenAI streaming tool_call deltas into
 // final tool_call objects while forwarding client-owned deltas live.
@@ -101,13 +107,16 @@ const (
 
 // assistantMessage builds the OpenAI-shaped assistant message that the
 // router appends to the messages array between iterations so the next
-// upstream call sees the tool_calls the model just emitted. We preserve
-// the exact raw tool_calls from the stream so serialization round-trips
-// byte-for-byte; the parsed form is only used for loop control.
+// upstream call sees the reasoning and tool_calls the model just emitted.
+// We preserve the exact raw tool_calls from the stream so serialization
+// round-trips byte-for-byte; the parsed form is only used for loop control.
 func (r *chatIterationResult) assistantMessage() map[string]any {
 	message := map[string]any{
 		"role":    "assistant",
 		"content": r.content,
+	}
+	if r.reasoningField != "" {
+		message[r.reasoningField] = r.reasoning
 	}
 	if len(r.rawToolCalls) > 0 {
 		message["tool_calls"] = r.rawToolCalls
@@ -217,9 +226,15 @@ func (s *chatStreamer) pumpUpstream(reader *sseReader) (chatIterationResult, err
 		// the final reasoning fragment and the first content tokens,
 		// and splitting it content-first would hand clients the tail of
 		// the reasoning after the answer already started.
-		if r := stringValue(delta["reasoning_content"]); r != "" {
+		if r, ok := delta[chatReasoningContentField].(string); ok {
+			if result.reasoningField == "" {
+				result.reasoningField = chatReasoningContentField
+			}
 			result.reasoning += r
-		} else if r := stringValue(delta["reasoning"]); r != "" {
+		} else if r, ok := delta[chatReasoningField].(string); ok {
+			if result.reasoningField == "" {
+				result.reasoningField = chatReasoningField
+			}
 			result.reasoning += r
 		}
 		s.emitReasoningDelta(delta)
@@ -370,11 +385,11 @@ func (s *chatStreamer) emitReasoningDelta(delta map[string]any) {
 		return
 	}
 	reasoningDelta := map[string]any{}
-	if reasoning := stringValue(delta["reasoning_content"]); reasoning != "" {
-		reasoningDelta["reasoning_content"] = reasoning
+	if reasoning := stringValue(delta[chatReasoningContentField]); reasoning != "" {
+		reasoningDelta[chatReasoningContentField] = reasoning
 	}
-	if reasoning := stringValue(delta["reasoning"]); reasoning != "" {
-		reasoningDelta["reasoning"] = reasoning
+	if reasoning := stringValue(delta[chatReasoningField]); reasoning != "" {
+		reasoningDelta[chatReasoningField] = reasoning
 	}
 	if len(reasoningDelta) == 0 {
 		return

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -699,6 +699,43 @@ func TestChatStreamerPumpForwardsReasoningDelta(t *testing.T) {
 	}
 }
 
+func TestChatStreamerPumpPreservesReasoningForNextToolIteration(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+	}{
+		{name: "Moonshot reasoning_content", field: chatReasoningContentField},
+		{name: "current vLLM reasoning", field: chatReasoningField},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			streamer, _ := newTestChatStreamer(t)
+			upstream := strings.Join([]string{
+				`data: {"id":"up_1","choices":[{"index":0,"delta":{"` + tt.field + `":"first "}}]}`,
+				`data: {"id":"up_1","choices":[{"index":0,"delta":{"` + tt.field + `":"second"}}]}`,
+				`data: {"id":"up_1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":"{}"}}]}}]}`,
+				`data: {"id":"up_1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+				"data: [DONE]",
+				"",
+			}, "\n\n")
+
+			result, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(upstream)))
+			if err != nil {
+				t.Fatalf("pumpUpstream returned error: %v", err)
+			}
+			message := result.assistantMessage()
+			if got := stringValue(message[tt.field]); got != "first second" {
+				t.Fatalf("expected complete %s in assistant message, got %q", tt.field, got)
+			}
+			toolCalls, ok := message["tool_calls"].([]any)
+			if !ok || len(toolCalls) != 1 {
+				t.Fatalf("expected tool call preserved in assistant message, got %#v", message)
+			}
+		})
+	}
+}
+
 // TestChatStreamerPumpEmitsReasoningBeforeContentOnCombinedDelta pins the
 // chunk ordering when one upstream delta carries both the final reasoning
 // fragment and the first content tokens (how reasoning parsers emit the

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -736,6 +736,49 @@ func TestChatStreamerPumpPreservesReasoningForNextToolIteration(t *testing.T) {
 	}
 }
 
+func TestChatStreamerPumpPreservesDualReasoningFields(t *testing.T) {
+	streamer, _ := newTestChatStreamer(t)
+	upstream := strings.Join([]string{
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{"reasoning_content":"legacy ","reasoning":"current"}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":"{}"}}]}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		"data: [DONE]",
+		"",
+	}, "\n\n")
+
+	result, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(upstream)))
+	if err != nil {
+		t.Fatalf("pumpUpstream returned error: %v", err)
+	}
+	if got := stringValue(result.assistantMessage()[chatReasoningContentField]); got != "legacy current" {
+		t.Fatalf("expected both reasoning fields to be preserved, got %q", got)
+	}
+}
+
+func TestChatStreamerPumpIgnoresEmptyReasoningFieldPrelude(t *testing.T) {
+	streamer, _ := newTestChatStreamer(t)
+	upstream := strings.Join([]string{
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{"reasoning_content":""}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{"reasoning":"actual"}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":"{}"}}]}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		"data: [DONE]",
+		"",
+	}, "\n\n")
+
+	result, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(upstream)))
+	if err != nil {
+		t.Fatalf("pumpUpstream returned error: %v", err)
+	}
+	message := result.assistantMessage()
+	if _, exists := message[chatReasoningContentField]; exists {
+		t.Fatalf("expected empty prelude field to be omitted, got %#v", message)
+	}
+	if got := stringValue(message[chatReasoningField]); got != "actual" {
+		t.Fatalf("expected non-empty reasoning field to be preserved, got %q", got)
+	}
+}
+
 // TestChatStreamerPumpEmitsReasoningBeforeContentOnCombinedDelta pins the
 // chunk ordering when one upstream delta carries both the final reasoning
 // fragment and the first content tokens (how reasoning parsers emit the

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -750,8 +750,12 @@ func TestChatStreamerPumpPreservesDualReasoningFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pumpUpstream returned error: %v", err)
 	}
-	if got := stringValue(result.assistantMessage()[chatReasoningContentField]); got != "legacy current" {
-		t.Fatalf("expected both reasoning fields to be preserved, got %q", got)
+	message := result.assistantMessage()
+	if got := stringValue(message[chatReasoningContentField]); got != "legacy " {
+		t.Fatalf("expected reasoning_content to be preserved independently, got %q", got)
+	}
+	if got := stringValue(message[chatReasoningField]); got != "current" {
+		t.Fatalf("expected reasoning to be preserved independently, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- retain streamed assistant reasoning before the next router-owned tool iteration
- preserve the upstream field name for Moonshot `reasoning_content` and current vLLM `reasoning`
- replay reasoning alongside the original tool calls in the subsequent model request
- apply protocol-local tool-loop preservation generically to current and future models

The router intentionally preserves reasoning only while continuing an active tool loop. Cross-request `all`, `tool-call-only`, and `none` policies are published by control plane and enforced by clients; the router cannot reconstruct reasoning omitted by a caller.

## Testing
- `go test ./toolruntime -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run ./...` not run because `golangci-lint` is unavailable locally

## Related PRs
- tinfoilsh/controlplane#554
- tinfoilsh/tinfoil-webapp#467
- tinfoilsh/tinfoil-ios#246