### PR TITLE
route: serve glm-5-2 from the blackwell build

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -24,7 +24,7 @@ models:
     repo: tinfoilsh/confidential-llama3-3-70b
 
   glm-5-2:
-    repo: tinfoilsh/confidential-glm5-2
+    repo: tinfoilsh/confidential-glm5-2-b200
 
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b


### PR DESCRIPTION
Points glm-5-2 at tinfoilsh/confidential-glm5-2-b200 (vLLM v0.27.0, 8xB200). Requires a router release to take effect; enclave placement follows in the live config.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches glm-5-2 to the B200 build (`tinfoilsh/confidential-glm5-2-b200`) using vLLM v0.27.0 on 8x B200s. Takes effect after the next router release; enclave placement remains in the live config.

<sup>Written for commit a813190a32869f97c146ee809f758cd12244bbe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

