### PR TITLE
route: add deepseek-v4-flash

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,6 +38,9 @@ models:
   kimi-k2-6:
     repo: tinfoilsh/confidential-kimi-k2-6-b200
 
+  deepseek-v4-flash:
+    repo: tinfoilsh/confidential-deepseek-v4-flash
+
   kimi-k3:
     repo: tinfoilsh/confidential-kimi-k3
 


### PR DESCRIPTION
Adds the deepseek-v4-flash trust anchor (tinfoilsh/confidential-deepseek-v4-flash 1M context). Requires a router release; enclave placement and traffic controls follow in the live config.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a new model route for deepseek-v4-flash by mapping it to `tinfoilsh/confidential-deepseek-v4-flash`. This makes the 1M-context DeepSeek V4 Flash deployment available through the router.

- **Dependencies**
  - Requires a router release to load the new model mapping. Enclave placement and traffic controls stay in live config.

<sup>Written for commit d67f544b544e7fe3a1c7df0c18cb6842e143d9ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

