### PR TITLE
Fix streamed GenUI widget arguments

### DIFF
--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -41,6 +41,7 @@ type chatStreamer struct {
 	identityPinned bool
 
 	ownedTools              map[string]struct{}
+	autoContinueTools       map[string]struct{}
 	clientToolCallForwarder *clientToolCallDeltaForwarder
 }
 
@@ -64,7 +65,7 @@ const (
 )
 
 // chatToolCallBuilder assembles OpenAI streaming tool_call deltas into
-// final tool_call objects while forwarding client-owned deltas live.
+// final tool_call objects while forwarding ordinary client-owned deltas live.
 type chatToolCallBuilder struct {
 	entries         []*chatToolCallEntry
 	clientForwarder *clientToolCallDeltaForwarder
@@ -80,11 +81,14 @@ type chatToolCallEntry struct {
 
 type clientToolCallDeltaForwarder struct {
 	ownedTools            map[string]struct{}
+	autoContinueTools     map[string]struct{}
 	emit                  func(map[string]any)
 	stateByUpstreamIndex  map[int]*clientToolCallDeltaState
 	clientIndexByUpstream map[int]int
 	nextClientIndex       int
 	streamedIDs           map[string]bool
+	bufferingFromIndex    int
+	bufferingActive       bool
 }
 
 type clientToolCallDeltaState struct {
@@ -98,6 +102,8 @@ const (
 	clientToolCallForwardPending clientToolCallForwardMode = iota
 	clientToolCallForwardLive
 	clientToolCallForwardDrop
+	clientToolCallForwardBuffered
+	clientToolCallForwardDeferred
 )
 
 // ---------------------------------------------------------------------------
@@ -262,6 +268,7 @@ func (s *chatStreamer) pumpUpstream(reader *sseReader) (chatIterationResult, err
 	if !doneSeen {
 		return result, newUpstreamStreamError("upstream stream ended without a terminal [DONE] marker")
 	}
+	forwarder.flushBuffered(builder.entries)
 	return result, nil
 }
 
@@ -415,6 +422,7 @@ func (s *chatStreamer) getClientToolCallForwarder() *clientToolCallDeltaForwarde
 	if s.clientToolCallForwarder == nil {
 		s.clientToolCallForwarder = newClientToolCallDeltaForwarder(
 			s.ownedTools,
+			s.autoContinueTools,
 			s.emitClientToolCallDelta,
 		)
 	}
@@ -659,7 +667,7 @@ func (s *chatStreamer) terminateWithError(r *http.Request, em *manager.EnclaveMa
 // chatToolCallBuilder methods
 // ---------------------------------------------------------------------------
 
-// ingest merges tool_call fragments and forwards client-owned deltas live.
+// ingest merges tool_call fragments and forwards ordinary client-owned deltas live.
 func (b *chatToolCallBuilder) ingest(rawCalls []any) {
 	for _, item := range rawCalls {
 		m, _ := item.(map[string]any)
@@ -699,10 +707,12 @@ func (b *chatToolCallBuilder) ingest(rawCalls []any) {
 
 func newClientToolCallDeltaForwarder(
 	ownedTools map[string]struct{},
+	autoContinueTools map[string]struct{},
 	emit func(map[string]any),
 ) *clientToolCallDeltaForwarder {
 	return &clientToolCallDeltaForwarder{
 		ownedTools:            ownedTools,
+		autoContinueTools:     autoContinueTools,
 		emit:                  emit,
 		stateByUpstreamIndex:  map[int]*clientToolCallDeltaState{},
 		clientIndexByUpstream: map[int]int{},
@@ -720,6 +730,8 @@ func (f *clientToolCallDeltaForwarder) resetIteration() {
 	}
 	f.stateByUpstreamIndex = map[int]*clientToolCallDeltaState{}
 	f.clientIndexByUpstream = map[int]int{}
+	f.bufferingFromIndex = 0
+	f.bufferingActive = false
 }
 
 func (f *clientToolCallDeltaForwarder) ingest(
@@ -737,6 +749,10 @@ func (f *clientToolCallDeltaForwarder) ingest(
 		return
 	case clientToolCallForwardDrop:
 		return
+	case clientToolCallForwardBuffered:
+		return
+	case clientToolCallForwardDeferred:
+		return
 	}
 	if toolName == "" {
 		state.pending = append(state.pending, rawDelta)
@@ -745,6 +761,19 @@ func (f *clientToolCallDeltaForwarder) ingest(
 	if _, isRouterOwned := f.ownedTools[toolName]; isRouterOwned {
 		state.mode = clientToolCallForwardDrop
 		state.pending = nil
+		return
+	}
+	if _, isAutoContinue := f.autoContinueTools[toolName]; isAutoContinue {
+		state.mode = clientToolCallForwardBuffered
+		state.pending = nil
+		f.beginBufferingAt(upstreamIndex)
+		f.clientIndex(upstreamIndex)
+		return
+	}
+	if f.bufferingActive && upstreamIndex > f.bufferingFromIndex {
+		state.mode = clientToolCallForwardDeferred
+		state.pending = nil
+		f.clientIndex(upstreamIndex)
 		return
 	}
 	state.mode = clientToolCallForwardLive
@@ -777,6 +806,48 @@ func (f *clientToolCallDeltaForwarder) forward(upstreamIndex int, rawDelta map[s
 		forwarded["function"] = fn
 	}
 	f.emit(forwarded)
+}
+
+func (f *clientToolCallDeltaForwarder) beginBufferingAt(upstreamIndex int) {
+	if !f.bufferingActive || upstreamIndex < f.bufferingFromIndex {
+		f.bufferingFromIndex = upstreamIndex
+	}
+	f.bufferingActive = true
+}
+
+func (f *clientToolCallDeltaForwarder) flushBuffered(entries []*chatToolCallEntry) {
+	if f == nil || f.emit == nil {
+		return
+	}
+	for upstreamIndex, entry := range entries {
+		state := f.stateByUpstreamIndex[upstreamIndex]
+		if state == nil || entry == nil || (state.mode != clientToolCallForwardBuffered && state.mode != clientToolCallForwardDeferred) {
+			continue
+		}
+		arguments := entry.arguments
+		if state.mode == clientToolCallForwardBuffered {
+			if repaired, changed := sanitizeToolCallArgumentsJSON(arguments); changed && jsonBytesValid(repaired) {
+				arguments = repaired
+			}
+		}
+		toolType := entry.toolType
+		if toolType == "" {
+			toolType = "function"
+		}
+		forwarded := map[string]any{
+			"index": f.clientIndex(upstreamIndex),
+			"id":    entry.id,
+			"type":  toolType,
+			"function": map[string]any{
+				"name":      entry.functionName,
+				"arguments": string(arguments),
+			},
+		}
+		if entry.id != "" {
+			f.streamedIDs[entry.id] = true
+		}
+		f.emit(forwarded)
+	}
 }
 
 func (f *clientToolCallDeltaForwarder) clientIndex(upstreamIndex int) int {
@@ -934,6 +1005,7 @@ func runChatStreaming(
 		eventFlags:           eventFlags,
 		emitter:              nil,
 		ownedTools:           ownedTools,
+		autoContinueTools:    autoContinueTools,
 	}
 	streamer.emitter = citations.NewEmitter(streamer.citations)
 

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -87,6 +87,7 @@ type clientToolCallDeltaForwarder struct {
 	clientIndexByUpstream map[int]int
 	nextClientIndex       int
 	streamedIDs           map[string]bool
+	streamedWithoutIDs    map[string]int
 	bufferingFromIndex    int
 	bufferingActive       bool
 }
@@ -717,6 +718,7 @@ func newClientToolCallDeltaForwarder(
 		stateByUpstreamIndex:  map[int]*clientToolCallDeltaState{},
 		clientIndexByUpstream: map[int]int{},
 		streamedIDs:           map[string]bool{},
+		streamedWithoutIDs:    map[string]int{},
 	}
 }
 
@@ -730,6 +732,7 @@ func (f *clientToolCallDeltaForwarder) resetIteration() {
 	}
 	f.stateByUpstreamIndex = map[int]*clientToolCallDeltaState{}
 	f.clientIndexByUpstream = map[int]int{}
+	f.streamedWithoutIDs = map[string]int{}
 	f.bufferingFromIndex = 0
 	f.bufferingActive = false
 }
@@ -821,7 +824,13 @@ func (f *clientToolCallDeltaForwarder) flushBuffered(entries []*chatToolCallEntr
 	}
 	for upstreamIndex, entry := range entries {
 		state := f.stateByUpstreamIndex[upstreamIndex]
-		if state == nil || entry == nil || (state.mode != clientToolCallForwardBuffered && state.mode != clientToolCallForwardDeferred) {
+		if state == nil || entry == nil {
+			continue
+		}
+		if entry.id == "" && (state.mode == clientToolCallForwardLive || state.mode == clientToolCallForwardBuffered || state.mode == clientToolCallForwardDeferred) {
+			f.streamedWithoutIDs[entry.functionName]++
+		}
+		if state.mode != clientToolCallForwardBuffered && state.mode != clientToolCallForwardDeferred {
 			continue
 		}
 		arguments := entry.arguments
@@ -862,12 +871,16 @@ func (f *clientToolCallDeltaForwarder) clientIndex(upstreamIndex int) int {
 }
 
 func (f *clientToolCallDeltaForwarder) unstreamed(calls []toolCall) []toolCall {
-	if f == nil || len(f.streamedIDs) == 0 {
+	if f == nil || (len(f.streamedIDs) == 0 && len(f.streamedWithoutIDs) == 0) {
 		return calls
 	}
 	out := make([]toolCall, 0, len(calls))
 	for _, call := range calls {
 		if call.id != "" && f.streamedIDs[call.id] {
+			continue
+		}
+		if call.id == "" && f.streamedWithoutIDs[call.name] > 0 {
+			f.streamedWithoutIDs[call.name]--
 			continue
 		}
 		out = append(out, call)

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -434,6 +434,35 @@ func TestChatStreamerFinalizeSkipsAlreadyStreamedClientToolCalls(t *testing.T) {
 	}
 }
 
+func TestChatStreamerFinalizeSkipsMultipleStreamedToolCallsWithoutIDs(t *testing.T) {
+	streamer, rec := newTestChatStreamer(t)
+	streamer.autoContinueTools = map[string]struct{}{"render_artifact_preview": {}}
+	upstream := strings.Join([]string{
+		`data: {"id":"up_1","created":1700000001,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"lookup_order","arguments":"{\"id\":1}"}},{"index":1,"type":"function","function":{"name":"render_artifact_preview","arguments":"{\"title\":\"Demo\"}"}},{"index":2,"type":"function","function":{"name":"lookup_order","arguments":"{\"id\":2}"}}]}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		"data: [DONE]",
+		"",
+	}, "\n\n")
+
+	result, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(upstream)))
+	if err != nil {
+		t.Fatalf("pumpUpstream returned error: %v", err)
+	}
+	_, clientToolCalls := splitToolCalls(testOwnedTools, result.toolCalls)
+	_, externalClientCalls := splitClientToolCalls(streamer.autoContinueTools, clientToolCalls)
+	if err := streamer.finalize(httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil), nil, "gpt-oss-120b", result, externalClientCalls); err != nil {
+		t.Fatalf("finalize returned error: %v", err)
+	}
+
+	calls := emittedChatToolCallDeltas(t, rec.Body.String())
+	if len(calls) != 3 {
+		t.Fatalf("expected each empty-ID tool call once, got %d: %s", len(calls), rec.Body.String())
+	}
+	assertChatToolCallDelta(t, calls[0], 0, "", "lookup_order", `{"id":1}`)
+	assertChatToolCallDelta(t, calls[1], 1, "", "render_artifact_preview", `{"title":"Demo"}`)
+	assertChatToolCallDelta(t, calls[2], 2, "", "lookup_order", `{"id":2}`)
+}
+
 func TestChatStreamerFinalizeEmitsFinishAndUsage(t *testing.T) {
 	streamer, rec := newTestChatStreamer(t)
 	streamer.usageTotals.Add(&upstreamJSONResponse{body: map[string]any{

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -90,6 +90,7 @@ func TestChatStreamerPumpEmitsContentAndToolCalls(t *testing.T) {
 
 func TestChatStreamerPumpForwardsClientToolCallDeltasLive(t *testing.T) {
 	streamer, rec := newTestChatStreamer(t)
+	streamer.autoContinueTools = map[string]struct{}{"render_stat_cards": {}}
 	upstream := strings.Join([]string{
 		`data: {"id":"up_1","created":1700000001,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{"role":"assistant"}}]}`,
 		`data: {"id":"up_1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_search","type":"function","function":{"name":"search","arguments":"{\"query\":\"go\"}"}},{"index":1,"id":"call_widget","type":"function","function":{"name":"render_artifact_preview","arguments":"{\"title\":\"Demo"}}]}}]}`,
@@ -134,6 +135,193 @@ func TestChatStreamerPumpForwardsClientToolCallDeltasLive(t *testing.T) {
 	}
 	if !strings.Contains(body, `\"source\":{\"type\":\"markdown\"`) {
 		t.Fatalf("expected continued argument fragment, got %s", body)
+	}
+}
+
+func TestChatStreamerPumpBuffersFragmentedAutoContinueArguments(t *testing.T) {
+	streamer, rec := newTestChatStreamer(t)
+	streamer.autoContinueTools = map[string]struct{}{"render_artifact_preview": {}}
+	upstream := strings.Join([]string{
+		`data: {"id":"up_1","created":1700000001,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_widget","type":"function","function":{"name":"render_artifact_preview","arguments":"{\"title\":\"Demo"}}]}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\"body\":\"Hello\"}"}}]}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		"data: [DONE]",
+		"",
+	}, "\n\n")
+
+	if _, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(upstream))); err != nil {
+		t.Fatalf("pumpUpstream returned error: %v", err)
+	}
+
+	calls := emittedChatToolCallDeltas(t, rec.Body.String())
+	if len(calls) != 1 {
+		t.Fatalf("expected one completed tool_call delta, got %d: %s", len(calls), rec.Body.String())
+	}
+	assertChatToolCallDelta(t, calls[0], 0, "call_widget", "render_artifact_preview", `{"title":"Demo","body":"Hello"}`)
+}
+
+func TestChatStreamerPumpRepairsAutoContinueTrailingProse(t *testing.T) {
+	streamer, rec := newTestChatStreamer(t)
+	streamer.autoContinueTools = map[string]struct{}{"render_artifact_preview": {}}
+	rawArguments := `{"title":"Demo"}I will explain the artifact next.`
+	upstream := chatToolCallTurn("up_1", "call_widget", "render_artifact_preview", rawArguments)
+
+	if _, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(upstream))); err != nil {
+		t.Fatalf("pumpUpstream returned error: %v", err)
+	}
+
+	calls := emittedChatToolCallDeltas(t, rec.Body.String())
+	if len(calls) != 1 {
+		t.Fatalf("expected one repaired tool_call delta, got %d", len(calls))
+	}
+	assertChatToolCallDelta(t, calls[0], 0, "call_widget", "render_artifact_preview", `{"title":"Demo"}`)
+}
+
+func TestChatStreamerPumpPreservesIrreparableAutoContinueArguments(t *testing.T) {
+	streamer, rec := newTestChatStreamer(t)
+	streamer.autoContinueTools = map[string]struct{}{"render_artifact_preview": {}}
+	rawArguments := `{"title":"Demo"`
+	upstream := chatToolCallTurn("up_1", "call_widget", "render_artifact_preview", rawArguments)
+
+	if _, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(upstream))); err != nil {
+		t.Fatalf("pumpUpstream returned error: %v", err)
+	}
+
+	calls := emittedChatToolCallDeltas(t, rec.Body.String())
+	if len(calls) != 1 {
+		t.Fatalf("expected one passthrough tool_call delta, got %d", len(calls))
+	}
+	assertChatToolCallDelta(t, calls[0], 0, "call_widget", "render_artifact_preview", rawArguments)
+}
+
+func TestChatStreamerPumpPreservesLargeAutoContinueArguments(t *testing.T) {
+	const largePayloadLength = 5000
+
+	streamer, rec := newTestChatStreamer(t)
+	streamer.autoContinueTools = map[string]struct{}{"render_artifact_preview": {}}
+	rawArguments := `{"body":"` + strings.Repeat("x", largePayloadLength) + `"}`
+	upstream := chatToolCallTurn("up_1", "call_widget", "render_artifact_preview", rawArguments)
+
+	if _, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(upstream))); err != nil {
+		t.Fatalf("pumpUpstream returned error: %v", err)
+	}
+
+	calls := emittedChatToolCallDeltas(t, rec.Body.String())
+	if len(calls) != 1 {
+		t.Fatalf("expected one large tool_call delta, got %d", len(calls))
+	}
+	assertChatToolCallDelta(t, calls[0], 0, "call_widget", "render_artifact_preview", rawArguments)
+}
+
+func TestChatStreamerPumpPreservesOrderAfterBufferedAutoContinueCall(t *testing.T) {
+	streamer, rec := newTestChatStreamer(t)
+	streamer.autoContinueTools = map[string]struct{}{"render_artifact_preview": {}}
+	ordinaryArguments := `{"id":1}leave this trailing text`
+	upstream := strings.Join([]string{
+		`data: {"id":"up_1","created":1700000001,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_widget","type":"function","function":{"name":"render_artifact_preview","arguments":"{\"title\":\"Demo\"}extra prose"}},{"index":1,"id":"call_lookup","type":"function","function":{"name":"lookup_order","arguments":` + jsonStringChat(ordinaryArguments) + `}}]}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		"data: [DONE]",
+		"",
+	}, "\n\n")
+
+	if _, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(upstream))); err != nil {
+		t.Fatalf("pumpUpstream returned error: %v", err)
+	}
+
+	calls := emittedChatToolCallDeltas(t, rec.Body.String())
+	if len(calls) != 2 {
+		t.Fatalf("expected two completed tool_call deltas, got %d: %s", len(calls), rec.Body.String())
+	}
+	assertChatToolCallDelta(t, calls[0], 0, "call_widget", "render_artifact_preview", `{"title":"Demo"}`)
+	assertChatToolCallDelta(t, calls[1], 1, "call_lookup", "lookup_order", ordinaryArguments)
+}
+
+func TestChatStreamerKeepsOrdinaryCallBeforeAutoContinueLive(t *testing.T) {
+	streamer, rec := newTestChatStreamer(t)
+	streamer.autoContinueTools = map[string]struct{}{"render_artifact_preview": {}}
+	builder := &chatToolCallBuilder{clientForwarder: streamer.getClientToolCallForwarder()}
+	builder.ingest([]any{
+		map[string]any{
+			"index": float64(0),
+			"id":    "call_lookup",
+			"type":  "function",
+			"function": map[string]any{
+				"name":      "lookup_order",
+				"arguments": `{"id":`,
+			},
+		},
+		map[string]any{
+			"index": float64(1),
+			"id":    "call_widget",
+			"type":  "function",
+			"function": map[string]any{
+				"name":      "render_artifact_preview",
+				"arguments": `{"title":"Demo"}`,
+			},
+		},
+	})
+	builder.ingest([]any{
+		map[string]any{
+			"index":    float64(0),
+			"function": map[string]any{"arguments": `1}`},
+		},
+	})
+
+	liveCalls := emittedChatToolCallDeltas(t, rec.Body.String())
+	if len(liveCalls) != 2 {
+		t.Fatalf("expected both ordinary argument fragments live before completion, got %d", len(liveCalls))
+	}
+	for _, call := range liveCalls {
+		if int(numberValue(call["index"])) != 0 {
+			t.Fatalf("expected live ordinary fragments at index 0, got %#v", call)
+		}
+	}
+
+	builder.clientForwarder.flushBuffered(builder.entries)
+	calls := emittedChatToolCallDeltas(t, rec.Body.String())
+	if len(calls) != 3 {
+		t.Fatalf("expected buffered auto-continue call after two live fragments, got %d", len(calls))
+	}
+	assertChatToolCallDelta(t, calls[2], 1, "call_widget", "render_artifact_preview", `{"title":"Demo"}`)
+}
+
+func emittedChatToolCallDeltas(t *testing.T, body string) []map[string]any {
+	t.Helper()
+	var calls []map[string]any
+	for _, frame := range strings.Split(body, "\n\n") {
+		data := strings.TrimPrefix(frame, "data: ")
+		if data == frame || data == "" || data == "[DONE]" {
+			continue
+		}
+		var chunk map[string]any
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			t.Fatalf("decode emitted chunk: %v", err)
+		}
+		choices, _ := chunk["choices"].([]any)
+		if len(choices) == 0 {
+			continue
+		}
+		choice, _ := choices[0].(map[string]any)
+		delta, _ := choice["delta"].(map[string]any)
+		rawCalls, _ := delta["tool_calls"].([]any)
+		for _, rawCall := range rawCalls {
+			call, _ := rawCall.(map[string]any)
+			if call != nil {
+				calls = append(calls, call)
+			}
+		}
+	}
+	return calls
+}
+
+func assertChatToolCallDelta(t *testing.T, call map[string]any, index int, id, name, arguments string) {
+	t.Helper()
+	if int(numberValue(call["index"])) != index || stringValue(call["id"]) != id || stringValue(call["type"]) != "function" {
+		t.Fatalf("unexpected tool_call metadata: %#v", call)
+	}
+	function, _ := call["function"].(map[string]any)
+	if stringValue(function["name"]) != name || stringValue(function["arguments"]) != arguments {
+		t.Fatalf("unexpected tool_call function: %#v", function)
 	}
 }
 


### PR DESCRIPTION
## Summary
- buffer auto-continued client widget arguments until their upstream turn completes
- repair Kimi-style trailing prose before forwarding while preserving irreparable payloads for client retry
- keep ordinary client tools live and preserve mixed tool-call ordering without artifact size limits

## Tests
- `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes streamed GenUI widget tool_call arguments by buffering auto-continued calls and repairing trailing prose before forwarding. Prevents duplicate anonymous client calls while keeping ordinary client tool calls live and in order.

- **Bug Fixes**
  - Buffer auto-continue widget tool_calls and flush after the upstream turn completes.
  - Repair trailing prose in arguments; pass through original payload if irreparable for client retry.
  - Deduplicate anonymous client tool_calls (no id) to avoid double sending.
  - Keep ordinary client tools streaming live and preserve order with buffered calls.
  - Added tests for buffering, repair, passthrough, deduplication, ordering, and state reset.

<sup>Written for commit 8d8231d6f513eb94c6073a6fe6b7a1c59f680361. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

