### PR TITLE
Keep credentials fresh during long-running chats

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,16 +136,17 @@ func getEnvBool(envKey string) bool {
 }
 
 var (
-	port                = flag.String("l", getEnvOrDefault("PORT", "8089"), "port to listen on (env: PORT)")
-	controlPlaneURL     = flag.String("C", getEnvOrDefault("CONTROL_PLANE_URL", "https://api.tinfoil.sh"), "control plane URL (env: CONTROL_PLANE_URL)")
-	usageReporterID     = flag.String("usage-reporter-id", getEnvOrDefault("USAGE_REPORTER_ID", "model-router"), "usage reporter ID (env: USAGE_REPORTER_ID)")
-	usageReporterSecret = flag.String("usage-reporter-secret", getEnvOrDefault("USAGE_REPORTER_SECRET", ""), "usage reporter HMAC secret (env: USAGE_REPORTER_SECRET)")
-	usageContextSecret  = flag.String("usage-context-secret", getEnvOrDefault("USAGE_CONTEXT_SECRET", ""), "usage-context HMAC secret used to sign request-context propagated to tool services (env: USAGE_CONTEXT_SECRET)")
-	verbose             = flag.Bool("v", getEnvBool("VERBOSE"), "enable verbose logging (env: VERBOSE)")
-	initConfigURL       = flag.String("i", getEnvOrDefault("INIT_CONFIG_URL", ""), "optional path to initial config.yml (requires to append @sha256:<hex> for integrity) (env: INIT_CONFIG_URL)")
-	updateConfigURL     = flag.String("u", getEnvOrDefault("UPDATE_CONFIG_URL", "https://raw.githubusercontent.com/tinfoilsh/confidential-model-router/main/config.yml"), "path to runtime config.yml (env: UPDATE_CONFIG_URL)")
-	domain              = flag.String("d", getEnvOrDefault("DOMAIN", "localhost"), "domain used by this router (env: DOMAIN)")
-	refreshInterval     = flag.Duration("r", getEnvOrDefaultDuration("REFRESH_INTERVAL", 5*time.Minute), "refresh interval for syncing enclave config (env: REFRESH_INTERVAL)")
+	port                      = flag.String("l", getEnvOrDefault("PORT", "8089"), "port to listen on (env: PORT)")
+	controlPlaneURL           = flag.String("C", getEnvOrDefault("CONTROL_PLANE_URL", "https://api.tinfoil.sh"), "control plane URL (env: CONTROL_PLANE_URL)")
+	usageReporterID           = flag.String("usage-reporter-id", getEnvOrDefault("USAGE_REPORTER_ID", "model-router"), "usage reporter ID (env: USAGE_REPORTER_ID)")
+	usageReporterSecret       = flag.String("usage-reporter-secret", getEnvOrDefault("USAGE_REPORTER_SECRET", ""), "usage reporter HMAC secret (env: USAGE_REPORTER_SECRET)")
+	usageContextSecret        = flag.String("usage-context-secret", getEnvOrDefault("USAGE_CONTEXT_SECRET", ""), "usage-context HMAC secret used to sign request-context propagated to tool services (env: USAGE_CONTEXT_SECRET)")
+	inferenceDelegationSecret = flag.String("inference-delegation-secret", "", "secret used to delegate inference access tokens (env: INFERENCE_DELEGATION_SECRET)")
+	verbose                   = flag.Bool("v", getEnvBool("VERBOSE"), "enable verbose logging (env: VERBOSE)")
+	initConfigURL             = flag.String("i", getEnvOrDefault("INIT_CONFIG_URL", ""), "optional path to initial config.yml (requires to append @sha256:<hex> for integrity) (env: INIT_CONFIG_URL)")
+	updateConfigURL           = flag.String("u", getEnvOrDefault("UPDATE_CONFIG_URL", "https://raw.githubusercontent.com/tinfoilsh/confidential-model-router/main/config.yml"), "path to runtime config.yml (env: UPDATE_CONFIG_URL)")
+	domain                    = flag.String("d", getEnvOrDefault("DOMAIN", "localhost"), "domain used by this router (env: DOMAIN)")
+	refreshInterval           = flag.Duration("r", getEnvOrDefaultDuration("REFRESH_INTERVAL", 5*time.Minute), "refresh interval for syncing enclave config (env: REFRESH_INTERVAL)")
 	// debug enables non-production behaviors such as honoring
 	// LOCAL_MCP_ENDPOINT_<MODEL> env vars to bypass attested TLS
 	// pinning for MCP tool servers during local development. MUST
@@ -432,6 +433,12 @@ func main() {
 	if *usageContextSecret == "" {
 		log.Fatal("USAGE_CONTEXT_SECRET is required")
 	}
+	if *inferenceDelegationSecret == "" {
+		*inferenceDelegationSecret = os.Getenv("INFERENCE_DELEGATION_SECRET")
+	}
+	if *inferenceDelegationSecret == "" && !*debug {
+		log.Fatal("INFERENCE_DELEGATION_SECRET is required")
+	}
 
 	// A routing-secret skew between replicas silently re-homes keys on only
 	// the skewed instance, so tolerate the classic source — a trailing
@@ -456,7 +463,7 @@ func main() {
 		manager.SetMetricsPollAPIKey(strings.TrimSpace(key))
 	}
 
-	em, err := manager.NewEnclaveManager(configFile, *controlPlaneURL, *usageReporterID, *usageReporterSecret, *usageContextSecret, *initConfigURL, *updateConfigURL, *refreshInterval)
+	em, err := manager.NewEnclaveManager(configFile, *controlPlaneURL, *usageReporterID, *usageReporterSecret, *usageContextSecret, *inferenceDelegationSecret, *initConfigURL, *updateConfigURL, *refreshInterval, *debug)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/manager/delegated_auth.go
+++ b/manager/delegated_auth.go
@@ -1,0 +1,261 @@
+package manager
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	delegationRefreshBuffer = time.Minute
+	delegationHTTPTimeout   = 10 * time.Second
+	delegationResponseLimit = 1 << 20
+	firstPartyChatClientID  = "tinfoil-chat"
+	chatProduct             = "chat"
+)
+
+const delegationSecretHeader = "X-Tinfoil-Delegation-Secret"
+
+type AuthorizationProvider interface {
+	Authorization(context.Context) (string, error)
+}
+
+type authorizationProviderKey struct{}
+
+func WithAuthorizationProvider(ctx context.Context, provider AuthorizationProvider) context.Context {
+	return context.WithValue(ctx, authorizationProviderKey{}, provider)
+}
+
+func authorizationFromContext(ctx context.Context) (string, bool, error) {
+	provider, ok := ctx.Value(authorizationProviderKey{}).(AuthorizationProvider)
+	if !ok {
+		return "", false, nil
+	}
+	authorization, err := provider.Authorization(ctx)
+	if err != nil {
+		return "", true, err
+	}
+	return authorization, true, nil
+}
+
+func AuthorizationProviderFromContext(ctx context.Context) AuthorizationProvider {
+	provider, _ := ctx.Value(authorizationProviderKey{}).(AuthorizationProvider)
+	return provider
+}
+
+func IsFirstPartyChatAccessJWT(token string) bool {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return false
+	}
+	header, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return false
+	}
+	var metadata struct {
+		Type string `json:"typ"`
+	}
+	if err := json.Unmarshal(header, &metadata); err != nil {
+		return false
+	}
+	if strings.TrimPrefix(strings.ToLower(metadata.Type), "application/") != "at+jwt" {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	var claims struct {
+		ClientID string `json:"client_id"`
+		Product  string `json:"product"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return false
+	}
+	return claims.ClientID == firstPartyChatClientID && claims.Product == chatProduct
+}
+
+type delegationRequest struct {
+	SubjectToken  string `json:"subject_token,omitempty"`
+	RootRequestID string `json:"root_request_id,omitempty"`
+	GrantToken    string `json:"grant_token,omitempty"`
+}
+
+type delegationResponse struct {
+	AccessToken          string    `json:"access_token"`
+	AccessTokenExpiresAt time.Time `json:"access_token_expires_at"`
+	GrantToken           string    `json:"grant_token"`
+	GrantExpiresAt       time.Time `json:"grant_expires_at"`
+}
+
+type delegatedAuthorization struct {
+	mu                   sync.Mutex
+	refreshing           *delegationRefresh
+	client               *http.Client
+	endpoint             string
+	secret               string
+	now                  func() time.Time
+	tokens               delegationResponse
+	useAccessUntilExpiry bool
+}
+
+type delegationRefresh struct {
+	done chan struct{}
+	err  error
+}
+
+type DelegationHTTPError struct {
+	StatusCode int
+	RetryAfter string
+}
+
+func (e *DelegationHTTPError) Error() string {
+	return fmt.Sprintf("delegation endpoint returned status %d", e.StatusCode)
+}
+
+func validateDelegationControlPlaneURL(controlPlaneURL string, debug bool) error {
+	if debug {
+		return nil
+	}
+	parsed, err := url.Parse(controlPlaneURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return fmt.Errorf("control plane URL must use HTTPS for inference delegation")
+	}
+	return nil
+}
+
+func (em *EnclaveManager) NewDelegatedAuthorizationProvider(ctx context.Context, subjectToken, rootRequestID string) (AuthorizationProvider, error) {
+	provider := &delegatedAuthorization{
+		client:   em.delegationHTTPClient,
+		endpoint: strings.TrimRight(em.controlPlaneURL, "/") + "/api/internal/inference/delegate",
+		secret:   em.inferenceDelegationSecret,
+		now:      time.Now,
+	}
+	exchangeCtx, cancel := context.WithTimeout(ctx, delegationHTTPTimeout)
+	defer cancel()
+	tokens, err := provider.exchange(exchangeCtx, delegationRequest{SubjectToken: subjectToken, RootRequestID: rootRequestID})
+	if err != nil {
+		return nil, fmt.Errorf("exchange inference credential: %w", err)
+	}
+	provider.tokens = tokens
+	provider.useAccessUntilExpiry = !provider.now().Add(delegationRefreshBuffer).Before(tokens.AccessTokenExpiresAt)
+	return provider, nil
+}
+
+func (em *EnclaveManager) WithDelegatedAuthorization(ctx context.Context, authorization, rootRequestID string) (context.Context, bool, error) {
+	subjectToken := BearerToken(authorization)
+	if !IsFirstPartyChatAccessJWT(subjectToken) {
+		return ctx, false, nil
+	}
+	provider, err := em.NewDelegatedAuthorizationProvider(ctx, subjectToken, rootRequestID)
+	if err != nil {
+		return ctx, true, err
+	}
+	return WithAuthorizationProvider(ctx, provider), true, nil
+}
+
+func (p *delegatedAuthorization) Authorization(ctx context.Context) (string, error) {
+	for {
+		p.mu.Lock()
+		now := p.now()
+		if now.Before(p.tokens.AccessTokenExpiresAt) && (p.useAccessUntilExpiry || now.Add(delegationRefreshBuffer).Before(p.tokens.AccessTokenExpiresAt)) {
+			token := p.tokens.AccessToken
+			p.mu.Unlock()
+			return "Bearer " + token, nil
+		}
+		if refresh := p.refreshing; refresh != nil {
+			p.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-refresh.done:
+				if refresh.err != nil {
+					return "", fmt.Errorf("refresh inference credential: %w", refresh.err)
+				}
+				continue
+			}
+		}
+		refresh := &delegationRefresh{done: make(chan struct{})}
+		p.refreshing = refresh
+		grantToken := p.tokens.GrantToken
+		grantExpiresAt := p.tokens.GrantExpiresAt
+		p.mu.Unlock()
+		go p.refresh(refresh, grantToken, grantExpiresAt)
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-refresh.done:
+			if refresh.err != nil {
+				return "", fmt.Errorf("refresh inference credential: %w", refresh.err)
+			}
+		}
+	}
+}
+
+func (p *delegatedAuthorization) refresh(refresh *delegationRefresh, grantToken string, grantExpiresAt time.Time) {
+	ctx, cancel := context.WithTimeout(context.Background(), delegationHTTPTimeout)
+	defer cancel()
+
+	var tokens delegationResponse
+	var err error
+	if grantToken == "" || !p.now().Before(grantExpiresAt) {
+		err = fmt.Errorf("delegation grant expired")
+	} else {
+		tokens, err = p.exchange(ctx, delegationRequest{GrantToken: grantToken})
+	}
+
+	p.mu.Lock()
+	if err == nil {
+		p.tokens = tokens
+		p.useAccessUntilExpiry = !p.now().Add(delegationRefreshBuffer).Before(tokens.AccessTokenExpiresAt)
+	}
+	refresh.err = err
+	p.refreshing = nil
+	close(refresh.done)
+	p.mu.Unlock()
+}
+
+func (p *delegatedAuthorization) exchange(ctx context.Context, payload delegationRequest) (delegationResponse, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return delegationResponse{}, fmt.Errorf("encode delegation request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return delegationResponse{}, fmt.Errorf("build delegation request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(delegationSecretHeader, p.secret)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return delegationResponse{}, fmt.Errorf("send delegation request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return delegationResponse{}, &DelegationHTTPError{
+			StatusCode: resp.StatusCode,
+			RetryAfter: resp.Header.Get("Retry-After"),
+		}
+	}
+	var result delegationResponse
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, delegationResponseLimit))
+	if err := decoder.Decode(&result); err != nil {
+		return delegationResponse{}, fmt.Errorf("decode delegation response: %w", err)
+	}
+	if result.AccessToken == "" || result.GrantToken == "" || result.AccessTokenExpiresAt.IsZero() || result.GrantExpiresAt.IsZero() {
+		return delegationResponse{}, fmt.Errorf("delegation endpoint returned incomplete credentials")
+	}
+	if now := p.now(); !now.Before(result.AccessTokenExpiresAt) || !now.Before(result.GrantExpiresAt) {
+		return delegationResponse{}, fmt.Errorf("delegation endpoint returned expired credentials")
+	}
+	return result, nil
+}

--- a/manager/delegated_auth_test.go
+++ b/manager/delegated_auth_test.go
@@ -1,0 +1,348 @@
+package manager
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func accessJWT(t *testing.T, clientID, product string) string {
+	t.Helper()
+	header, err := json.Marshal(map[string]string{"alg": "none", "typ": "at+jwt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(map[string]string{"client_id": clientID, "product": product})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(header) + "." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}
+
+func typedAccessJWT(t *testing.T) string {
+	t.Helper()
+	return accessJWT(t, firstPartyChatClientID, chatProduct)
+}
+
+func writeDelegationResponse(t *testing.T, w http.ResponseWriter, accessToken, grantToken string, accessExpiry, grantExpiry time.Time) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(delegationResponse{
+		AccessToken:          accessToken,
+		AccessTokenExpiresAt: accessExpiry,
+		GrantToken:           grantToken,
+		GrantExpiresAt:       grantExpiry,
+	}); err != nil {
+		t.Errorf("encode delegation response: %v", err)
+	}
+}
+
+func TestIsFirstPartyChatAccessJWT(t *testing.T) {
+	if !IsFirstPartyChatAccessJWT(typedAccessJWT(t)) {
+		t.Fatal("expected first-party Chat at+jwt token to be recognized")
+	}
+	for _, token := range []string{
+		"opaque-key",
+		"e30.e30.signature",
+		"bad.payload.signature",
+		accessJWT(t, "third-party", chatProduct),
+		accessJWT(t, firstPartyChatClientID, "api"),
+	} {
+		if IsFirstPartyChatAccessJWT(token) {
+			t.Fatalf("ineligible credential %q must not be delegated", token)
+		}
+	}
+}
+
+func TestIneligibleAuthorizationDoesNotExchange(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		calls.Add(1)
+	}))
+	defer server.Close()
+	em := &EnclaveManager{controlPlaneURL: server.URL, delegationHTTPClient: server.Client()}
+	ctx := context.Background()
+
+	for _, authorization := range []string{
+		"Bearer opaque-key",
+		"Bearer " + accessJWT(t, "third-party", chatProduct),
+		"Bearer " + accessJWT(t, firstPartyChatClientID, "api"),
+	} {
+		gotCtx, delegated, err := em.WithDelegatedAuthorization(ctx, authorization, "root")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if delegated || gotCtx != ctx {
+			t.Fatalf("ineligible authorization must preserve the original context: %q", authorization)
+		}
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("delegation calls = %d, want 0", got)
+	}
+}
+
+func TestDelegatedAuthorizationInitialExchangeAndRefresh(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	subjectToken := typedAccessJWT(t)
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/internal/inference/delegate" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get(delegationSecretHeader); got != "delegation-secret" {
+			t.Errorf("delegation secret = %q", got)
+		}
+		var request delegationRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		switch calls.Add(1) {
+		case 1:
+			if request.SubjectToken != subjectToken || request.RootRequestID != "root-request" || request.GrantToken != "" {
+				t.Errorf("unexpected initial request: %#v", request)
+			}
+			writeDelegationResponse(t, w, "child-1", "grant-1", now.Add(90*time.Minute), now.Add(4*time.Hour))
+		case 2:
+			if request.GrantToken != "grant-1" || request.SubjectToken != "" || request.RootRequestID != "" {
+				t.Errorf("unexpected refresh request: %#v", request)
+			}
+			writeDelegationResponse(t, w, "child-2", "grant-2", now.Add(3*time.Hour), now.Add(6*time.Hour))
+		default:
+			t.Errorf("unexpected delegation call %d", calls.Load())
+		}
+	}))
+	defer server.Close()
+
+	em := &EnclaveManager{
+		controlPlaneURL:           server.URL,
+		inferenceDelegationSecret: "delegation-secret",
+		delegationHTTPClient:      server.Client(),
+	}
+	provider, err := em.NewDelegatedAuthorizationProvider(context.Background(), subjectToken, "root-request")
+	if err != nil {
+		t.Fatalf("initial exchange: %v", err)
+	}
+	delegated := provider.(*delegatedAuthorization)
+	delegated.now = func() time.Time { return now }
+	if got, err := provider.Authorization(context.Background()); err != nil || got != "Bearer child-1" {
+		t.Fatalf("initial authorization = %q, %v", got, err)
+	}
+	now = now.Add(2 * time.Hour)
+	if got, err := provider.Authorization(context.Background()); err != nil || got != "Bearer child-2" {
+		t.Fatalf("refreshed authorization = %q, %v", got, err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("delegation calls = %d, want 2", got)
+	}
+}
+
+func TestDelegatedAuthorizationShortLivedRefreshSingleflight(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	var calls atomic.Int32
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := calls.Add(1)
+		if call == 1 {
+			writeDelegationResponse(t, w, "child-1", "grant-1", now.Add(30*time.Minute), now.Add(4*time.Hour))
+			return
+		}
+		if call == 2 {
+			close(refreshStarted)
+			<-releaseRefresh
+			writeDelegationResponse(t, w, "child-2", "grant-2", now.Add(30*time.Second), now.Add(6*time.Hour))
+			return
+		}
+		t.Errorf("unexpected delegation call %d", call)
+	}))
+	defer server.Close()
+
+	em := &EnclaveManager{controlPlaneURL: server.URL, inferenceDelegationSecret: "secret", delegationHTTPClient: server.Client()}
+	provider, err := em.NewDelegatedAuthorizationProvider(context.Background(), typedAccessJWT(t), "root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	delegated := provider.(*delegatedAuthorization)
+	now = now.Add(time.Hour)
+	delegated.now = func() time.Time { return now }
+
+	const callers = 20
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			authorization, err := provider.Authorization(context.Background())
+			if err == nil && authorization != "Bearer child-2" {
+				err = fmt.Errorf("authorization = %q", authorization)
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	<-refreshStarted
+	close(releaseRefresh)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("delegation calls = %d, want initial plus one refresh", got)
+	}
+	for range 3 {
+		if authorization, err := provider.Authorization(context.Background()); err != nil || authorization != "Bearer child-2" {
+			t.Fatalf("short-lived authorization = %q, %v", authorization, err)
+		}
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("short-lived token caused repeated refreshes: calls = %d", got)
+	}
+}
+
+func TestDelegatedAuthorizationCanceledWaiterDoesNotCancelRefresh(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	var calls atomic.Int32
+	controlPlane := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		close(refreshStarted)
+		<-releaseRefresh
+		writeDelegationResponse(t, w, "child", "grant", now.Add(time.Hour), now.Add(2*time.Hour))
+	}))
+	defer controlPlane.Close()
+	provider := &delegatedAuthorization{
+		client:   controlPlane.Client(),
+		endpoint: controlPlane.URL,
+		secret:   "secret",
+		now:      func() time.Time { return now },
+		tokens: delegationResponse{
+			AccessToken:          "expired",
+			AccessTokenExpiresAt: now,
+			GrantToken:           "grant",
+			GrantExpiresAt:       now.Add(2 * time.Hour),
+		},
+	}
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	canceledResult := make(chan error, 1)
+	go func() {
+		_, err := provider.Authorization(canceledCtx)
+		canceledResult <- err
+	}()
+	<-refreshStarted
+	cancel()
+	if err := <-canceledResult; !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled waiter error = %v", err)
+	}
+
+	healthyResult := make(chan error, 1)
+	go func() {
+		authorization, err := provider.Authorization(context.Background())
+		if err == nil && authorization != "Bearer child" {
+			err = fmt.Errorf("authorization = %q", authorization)
+		}
+		healthyResult <- err
+	}()
+	close(releaseRefresh)
+	if err := <-healthyResult; err != nil {
+		t.Fatal(err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("refresh calls = %d, want 1", got)
+	}
+}
+
+func TestValidateDelegationControlPlaneURL(t *testing.T) {
+	if err := validateDelegationControlPlaneURL("https://api.tinfoil.sh", false); err != nil {
+		t.Fatalf("HTTPS production URL rejected: %v", err)
+	}
+	if err := validateDelegationControlPlaneURL("http://api.tinfoil.sh", false); err == nil {
+		t.Fatal("expected production HTTP URL to be rejected")
+	}
+	if err := validateDelegationControlPlaneURL("http://127.0.0.1:8080", true); err != nil {
+		t.Fatalf("debug local URL rejected: %v", err)
+	}
+}
+
+func TestNewEnclaveManagerRejectsHTTPControlPlane(t *testing.T) {
+	_, err := NewEnclaveManager(nil, "http://api.tinfoil.sh", "reporter", "reporting-secret", "context-secret", "delegation-secret", "", "", time.Minute, false)
+	if err == nil || !strings.Contains(err.Error(), "must use HTTPS") {
+		t.Fatalf("constructor error = %v, want HTTPS validation error", err)
+	}
+}
+
+func TestDelegationHTTPErrorPreservesStatusAndRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "42")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"access_token":"must-not-leak"}`))
+	}))
+	defer server.Close()
+	provider := &delegatedAuthorization{client: server.Client(), endpoint: server.URL, secret: "secret", now: time.Now}
+
+	_, err := provider.exchange(context.Background(), delegationRequest{GrantToken: "grant"})
+	var httpErr *DelegationHTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error type = %T, want *DelegationHTTPError", err)
+	}
+	if httpErr.StatusCode != http.StatusTooManyRequests || httpErr.RetryAfter != "42" {
+		t.Fatalf("delegation HTTP error = %#v", httpErr)
+	}
+	if strings.Contains(err.Error(), "must-not-leak") {
+		t.Fatal("delegation error leaked response body")
+	}
+}
+
+func TestPostToEnclaveDelegationFailureBlocksDownstream(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	controlPlane := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer controlPlane.Close()
+	provider := &delegatedAuthorization{
+		client:   controlPlane.Client(),
+		endpoint: controlPlane.URL,
+		secret:   "secret",
+		now:      func() time.Time { return now },
+		tokens: delegationResponse{
+			AccessToken:          "expired-child",
+			AccessTokenExpiresAt: now,
+			GrantToken:           "grant",
+			GrantExpiresAt:       now.Add(time.Hour),
+		},
+	}
+	var downstreamCalls atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		downstreamCalls.Add(1)
+	}))
+	defer server.Close()
+	enclave := &Enclave{host: strings.TrimPrefix(server.URL, "https://"), modelName: "test-model"}
+	headers := http.Header{"Authorization": []string{"Bearer original"}}
+	ctx := WithAuthorizationProvider(context.Background(), provider)
+
+	if _, err := postToEnclave(ctx, server.Client(), enclave, "/v1/chat/completions", []byte("{}"), headers, nil); err == nil {
+		t.Fatal("expected delegated authorization failure")
+	}
+	if got := downstreamCalls.Load(); got != 0 {
+		t.Fatalf("downstream calls = %d, want 0", got)
+	}
+	if got := headers.Get("Authorization"); got != "Bearer original" {
+		t.Fatalf("original headers changed to %q", got)
+	}
+}

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -161,6 +161,12 @@ func postToEnclave(ctx context.Context, client *http.Client, enclave *Enclave, p
 			req.Header.Add(key, value)
 		}
 	}
+	if authorization, ok, err := authorizationFromContext(ctx); err != nil {
+		claim.Abort()
+		return nil, fmt.Errorf("resolve delegated authorization: %w", err)
+	} else if ok {
+		req.Header.Set("Authorization", authorization)
+	}
 	req.ContentLength = int64(len(body))
 	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(body)))
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -153,23 +153,25 @@ func (m *Model) ReservationPools(orgID string) (primary, spill map[string]bool) 
 }
 
 type EnclaveManager struct {
-	models               *sync.Map // model name -> *Model
-	multimodalModels     sync.Map  // sticky set of multimodal chat model names
-	modelPricing         atomic.Pointer[map[string]ModelPricing]
-	initConfigURL        string
-	updateConfigURL      string
-	controlPlaneURL      string
-	sigstoreClient       *sigstore.Client
-	billingCollector     *billing.Collector
-	usageContextSecret   string
-	requestTracker       *ratelimit.RequestTracker
-	cacheRouteShadow     *cacheroute.Shadow
-	refreshInterval      time.Duration
-	stateMu              sync.Mutex
-	errors               []string
-	lastSuccessfulUpdate time.Time
-	lastAttemptedUpdate  time.Time
-	debug                bool
+	models                    *sync.Map // model name -> *Model
+	multimodalModels          sync.Map  // sticky set of multimodal chat model names
+	modelPricing              atomic.Pointer[map[string]ModelPricing]
+	initConfigURL             string
+	updateConfigURL           string
+	controlPlaneURL           string
+	sigstoreClient            *sigstore.Client
+	billingCollector          *billing.Collector
+	usageContextSecret        string
+	inferenceDelegationSecret string
+	delegationHTTPClient      *http.Client
+	requestTracker            *ratelimit.RequestTracker
+	cacheRouteShadow          *cacheroute.Shadow
+	refreshInterval           time.Duration
+	stateMu                   sync.Mutex
+	errors                    []string
+	lastSuccessfulUpdate      time.Time
+	lastAttemptedUpdate       time.Time
+	debug                     bool
 }
 
 // SetDebugMode enables debug-only behaviors such as honoring the
@@ -877,9 +879,12 @@ func (e *Enclave) String() string {
 }
 
 // NewEnclaveManager loads model repos from the local config file (not remote) into the enclave manager
-func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterID string, usageReporterSecret string, usageContextSecret string, initConfigURL string, updateConfigURL string, refreshInterval time.Duration) (*EnclaveManager, error) {
+func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterID string, usageReporterSecret string, usageContextSecret string, inferenceDelegationSecret string, initConfigURL string, updateConfigURL string, refreshInterval time.Duration, debug bool) (*EnclaveManager, error) {
 	if refreshInterval <= 0 {
 		return nil, fmt.Errorf("refresh interval must be positive, got %v", refreshInterval)
+	}
+	if err := validateDelegationControlPlaneURL(controlPlaneURL, debug); err != nil {
+		return nil, err
 	}
 
 	var cfg *config.Config
@@ -899,16 +904,19 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterI
 	}
 
 	em := &EnclaveManager{
-		models:             &sync.Map{},
-		initConfigURL:      initConfigURL,
-		updateConfigURL:    updateConfigURL,
-		controlPlaneURL:    controlPlaneURL,
-		sigstoreClient:     sigstoreClient,
-		billingCollector:   billing.NewCollector(controlPlaneURL, usageReporterID, usageReporterSecret),
-		usageContextSecret: usageContextSecret,
-		requestTracker:     ratelimit.NewRequestTracker(),
-		cacheRouteShadow:   cacheroute.NewShadow(nil),
-		refreshInterval:    refreshInterval,
+		models:                    &sync.Map{},
+		initConfigURL:             initConfigURL,
+		updateConfigURL:           updateConfigURL,
+		controlPlaneURL:           controlPlaneURL,
+		sigstoreClient:            sigstoreClient,
+		billingCollector:          billing.NewCollector(controlPlaneURL, usageReporterID, usageReporterSecret),
+		usageContextSecret:        usageContextSecret,
+		inferenceDelegationSecret: inferenceDelegationSecret,
+		delegationHTTPClient:      &http.Client{Timeout: delegationHTTPTimeout},
+		requestTracker:            ratelimit.NewRequestTracker(),
+		cacheRouteShadow:          cacheroute.NewShadow(nil),
+		refreshInterval:           refreshInterval,
+		debug:                     debug,
 	}
 
 	for modelName, modelConfig := range cfg.Models {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -912,7 +912,7 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterI
 		billingCollector:          billing.NewCollector(controlPlaneURL, usageReporterID, usageReporterSecret),
 		usageContextSecret:        usageContextSecret,
 		inferenceDelegationSecret: inferenceDelegationSecret,
-		delegationHTTPClient:      &http.Client{Timeout: delegationHTTPTimeout},
+		delegationHTTPClient:      &http.Client{},
 		requestTracker:            ratelimit.NewRequestTracker(),
 		cacheRouteShadow:          cacheroute.NewShadow(nil),
 		refreshInterval:           refreshInterval,

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -17,6 +17,7 @@ containers:
     secrets:
       - USAGE_REPORTER_SECRET
       - USAGE_CONTEXT_SECRET
+      - INFERENCE_DELEGATION_SECRET
       - CACHE_ROUTE_SECRET
       - METRICS_API_KEY
     healthcheck:

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -450,7 +450,7 @@ func TestChatStreamerFinalizeSkipsMultipleStreamedToolCallsWithoutIDs(t *testing
 	}
 	_, clientToolCalls := splitToolCalls(testOwnedTools, result.toolCalls)
 	_, externalClientCalls := splitClientToolCalls(streamer.autoContinueTools, clientToolCalls)
-	if err := streamer.finalize(httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil), nil, "gpt-oss-120b", result, externalClientCalls); err != nil {
+	if err := streamer.finalize(httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil), newTestEnclaveManager(), "gpt-oss-120b", result, externalClientCalls); err != nil {
 		t.Fatalf("finalize returned error: %v", err)
 	}
 

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -92,8 +92,12 @@ func (a *usageAccumulator) Usage() *tokencount.Usage {
 }
 
 type headerRoundTripper struct {
-	base    http.RoundTripper
-	headers http.Header
+	base               http.RoundTripper
+	headers            http.Header
+	authorization      manager.AuthorizationProvider
+	usageContext       usagereporting.Context
+	usageContextSecret string
+	now                func() time.Time
 }
 
 func (t *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -103,6 +107,21 @@ func (t *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 			if value != "" {
 				cloned.Header.Add(key, value)
 			}
+		}
+	}
+	if t.authorization != nil {
+		authorization, err := t.authorization.Authorization(req.Context())
+		if err != nil {
+			return nil, fmt.Errorf("resolve delegated tool authorization: %w", err)
+		}
+		cloned.Header.Set("Authorization", authorization)
+	}
+	if t.usageContextSecret != "" {
+		usageContext := t.usageContext
+		usageContext.APIKeyHash = usagereporting.HashAPIKey(manager.BearerToken(cloned.Header.Get("Authorization")))
+		usageContext.IssuedAt = t.now().UTC()
+		if err := usagereporting.SetHeaders(cloned.Header, usageContext, t.usageContextSecret); err != nil {
+			return nil, fmt.Errorf("sign tool usage context: %w", err)
 		}
 	}
 	base := t.base
@@ -129,13 +148,24 @@ func (t *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 // toolcontext.ExtractRouterOptions).
 func Handle(w http.ResponseWriter, r *http.Request, em *manager.EnclaveManager, profiles []Profile, body map[string]any, modelName string, routerOpts *RouterOptions) error {
 	ctx := r.Context()
+	rootRequestID := ""
+	delegationRootRequestID := uuid.NewString()
+	delegatedCtx, delegated, err := em.WithDelegatedAuthorization(ctx, r.Header.Get("Authorization"), delegationRootRequestID)
+	if err != nil {
+		return err
+	}
+	if delegated {
+		rootRequestID = delegationRootRequestID
+		ctx = delegatedCtx
+		r = r.WithContext(ctx)
+	}
 	requestHeaders := modelRequestHeaders(r.Header)
 	usageMetricsRequested := r.Header.Get(manager.UsageMetricsRequestHeader) == "true"
 	eventFlags := parseTinfoilEventFlags(r.Header)
 	safetyOpts := parseSafetyOptIns(routerOpts, body)
 
 	dial := func(ctx context.Context, p Profile) (*mcp.ClientSession, error) {
-		return connectToolSession(ctx, em, p, r, modelName, body, safetyOpts)
+		return connectToolSession(ctx, em, p, r, rootRequestID, modelName, body, safetyOpts)
 	}
 	registry, err := buildSessionRegistry(ctx, profiles, dial)
 	if err != nil {
@@ -209,22 +239,26 @@ func newToolSessionRequestID(_ *http.Request) string {
 // connectToolSession opens one attested MCP session for a single
 // profile. buildSessionRegistry invokes it once per active profile
 // and aggregates the results into the per-request routing table.
-func connectToolSession(ctx context.Context, em *manager.EnclaveManager, profile Profile, r *http.Request, modelName string, body map[string]any, safety safetyOptIns) (*mcp.ClientSession, error) {
+func connectToolSession(ctx context.Context, em *manager.EnclaveManager, profile Profile, r *http.Request, rootRequestID, modelName string, body map[string]any, safety safetyOptIns) (*mcp.ClientSession, error) {
 	endpoint, httpClient, err := em.MCPServerEndpoint(ctx, profile.ToolServerModel)
 	if err != nil {
 		return nil, err
 	}
 
 	requestID := newToolSessionRequestID(r)
-
-	headers, err := toolSessionHeaders(r, requestID, modelName, body, safety, em.UsageContextSecret(), time.Now)
-	if err != nil {
-		return nil, err
+	if rootRequestID == "" {
+		rootRequestID = requestID
 	}
 
+	headers, usageContext := toolSessionHeaders(r, requestID, rootRequestID, modelName, body, safety)
+
 	httpClient.Transport = &headerRoundTripper{
-		base:    httpClient.Transport,
-		headers: headers,
+		base:               httpClient.Transport,
+		headers:            headers,
+		authorization:      manager.AuthorizationProviderFromContext(ctx),
+		usageContext:       usageContext,
+		usageContextSecret: em.UsageContextSecret(),
+		now:                time.Now,
 	}
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "router-tool-runtime", Version: "v1"}, nil)
@@ -234,16 +268,14 @@ func connectToolSession(ctx context.Context, em *manager.EnclaveManager, profile
 	}, nil)
 }
 
-// toolSessionHeaders builds the per-request HTTP headers attached to an
-// outbound MCP tool session. When usageContextSecret is set, it also signs a
-// usage-context header carrying BillCustomerRequest=true so the downstream
-// tool service bills its own per-session line item alongside the router's
-// token-based chat-completion billing. Double-charging is prevented by the
-// downstream reporter's per-RequestID dedup window: every internal MCP HTTP
-// call within one chat completion shares the same X-Tinfoil-Tool-Request-Id
-// (set by connectToolSession), so multiple model-initiated tool calls inside
-// a single chat completion collapse into a single billable session event.
-func toolSessionHeaders(r *http.Request, requestID, modelName string, body map[string]any, safety safetyOptIns, usageContextSecret string, now func() time.Time) (http.Header, error) {
+// toolSessionHeaders builds the stable HTTP headers and usage context attached
+// to an outbound MCP tool session. The transport refreshes the context's
+// IssuedAt and signature for every HTTP request while preserving its billing
+// identity. Double-charging is prevented by the downstream reporter's
+// per-RequestID dedup window: every internal MCP HTTP call within one chat
+// completion shares the same X-Tinfoil-Tool-Request-Id, so multiple
+// model-initiated tool calls collapse into a single billable session event.
+func toolSessionHeaders(r *http.Request, requestID, rootRequestID, modelName string, body map[string]any, safety safetyOptIns) (http.Header, usagereporting.Context) {
 	headers := make(http.Header)
 	headers.Set(toolcontext.HeaderRequestID, requestID)
 	headers.Set(toolcontext.HeaderModel, modelName)
@@ -255,25 +287,16 @@ func toolSessionHeaders(r *http.Request, requestID, modelName string, body map[s
 	if safety.injection != nil {
 		headers.Set(toolcontext.HeaderInjectionCheck, strconv.FormatBool(*safety.injection))
 	}
-	apiKey := ""
 	if auth := r.Header.Get("Authorization"); auth != "" {
 		headers.Set("Authorization", auth)
-		apiKey = manager.BearerToken(auth)
 	}
-	if usageContextSecret != "" {
-		if err := usagereporting.SetHeaders(headers, usagereporting.Context{
-			ContextID:           requestID,
-			RootRequestID:       requestID,
-			ParentService:       usagereporting.ServiceRouter,
-			APIKeyHash:          usagereporting.HashAPIKey(apiKey),
-			Depth:               1,
-			BillCustomerRequest: true,
-			IssuedAt:            now().UTC(),
-		}, usageContextSecret); err != nil {
-			return nil, fmt.Errorf("sign tool usage context: %w", err)
-		}
+	return headers, usagereporting.Context{
+		ContextID:           requestID,
+		RootRequestID:       rootRequestID,
+		ParentService:       usagereporting.ServiceRouter,
+		Depth:               1,
+		BillCustomerRequest: true,
 	}
-	return headers, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -1,6 +1,7 @@
 package toolruntime
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -21,6 +22,23 @@ import (
 
 func newTestEnclaveManager() *manager.EnclaveManager {
 	return &manager.EnclaveManager{}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type sequenceAuthorizationProvider struct {
+	tokens []string
+	next   int
+}
+
+func (p *sequenceAuthorizationProvider) Authorization(context.Context) (string, error) {
+	token := p.tokens[p.next]
+	p.next++
+	return "Bearer " + token, nil
 }
 
 func TestReplaceRouterOwnedResponsesTools(t *testing.T) {
@@ -1097,70 +1115,142 @@ func TestChatAdapterStripRouterToolCallsPreservesUnparseableEntries(t *testing.T
 	}
 }
 
-// TestToolSessionHeadersSignsUsageContext asserts that outbound MCP tool
-// session headers carry a usage-context signed with BillCustomerRequest=true
-// and ParentService=router, so downstream tool services bill their own
-// per-session line item alongside the router's chat-completion billing.
-// Per-RequestID dedup in the downstream reporter prevents double-charging
-// across multiple internal tool calls within one chat completion.
-func TestToolSessionHeadersSignsUsageContext(t *testing.T) {
+// TestHeaderRoundTripperRefreshesUsageContext asserts that every outbound MCP
+// request receives a fresh usage-context signature without changing the
+// session's billing identity.
+func TestHeaderRoundTripperRefreshesUsageContext(t *testing.T) {
 	const secret = "tool-session-secret"
-	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	times := []time.Time{
+		time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 7, 14, 0, 0, 0, time.UTC),
+	}
 	req, err := http.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
 	req.Header.Set("Authorization", "Bearer tk_test")
 
-	headers, err := toolSessionHeaders(req, "req-1", "gpt-oss-120b", map[string]any{}, safetyOptIns{}, secret, func() time.Time { return now })
-	if err != nil {
-		t.Fatalf("build tool session headers: %v", err)
+	headers, usageContext := toolSessionHeaders(req, "req-1", "root-1", "gpt-oss-120b", map[string]any{}, safetyOptIns{})
+	var sentHeaders []http.Header
+	nowIndex := 0
+	transport := &headerRoundTripper{
+		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			sentHeaders = append(sentHeaders, req.Header.Clone())
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    req,
+			}, nil
+		}),
+		headers:            headers,
+		authorization:      &sequenceAuthorizationProvider{tokens: []string{"child-1", "child-2"}},
+		usageContext:       usageContext,
+		usageContextSecret: secret,
+		now: func() time.Time {
+			now := times[nowIndex]
+			nowIndex++
+			return now
+		},
 	}
 
-	got, ok, err := usagereporting.FromHeaders(headers, secret, now, time.Minute)
+	outbound, err := http.NewRequest(http.MethodPost, "https://tool.example/mcp", nil)
 	if err != nil {
-		t.Fatalf("parse usage context: %v", err)
+		t.Fatalf("build outbound request: %v", err)
 	}
-	if !ok {
-		t.Fatal("expected signed usage context to be present")
+	for range times {
+		resp, err := transport.RoundTrip(outbound)
+		if err != nil {
+			t.Fatalf("round trip: %v", err)
+		}
+		resp.Body.Close()
 	}
-	if got.RootRequestID != "req-1" {
-		t.Fatalf("root request id mismatch: got %q want req-1", got.RootRequestID)
+
+	if len(sentHeaders) != len(times) {
+		t.Fatalf("sent request count mismatch: got %d want %d", len(sentHeaders), len(times))
 	}
-	if got.ContextID != "req-1" {
-		t.Fatalf("context id mismatch: got %q want req-1", got.ContextID)
+	if headers.Get(usagereporting.HeaderContext) != "" || outbound.Header.Get(usagereporting.HeaderContext) != "" {
+		t.Fatal("usage context must only be added to cloned outbound requests")
 	}
-	if got.ParentService != usagereporting.ServiceRouter {
-		t.Fatalf("parent service mismatch: got %q want %q", got.ParentService, usagereporting.ServiceRouter)
+	if got := req.Header.Get("Authorization"); got != "Bearer tk_test" {
+		t.Fatalf("original request authorization changed to %q", got)
 	}
-	if !usagereporting.VerifyAPIKeyHash("tk_test", got.APIKeyHash) {
-		t.Fatalf("api key hash does not match forwarded authorization")
+	if sentHeaders[0].Get(usagereporting.HeaderContext) == sentHeaders[1].Get(usagereporting.HeaderContext) {
+		t.Fatal("usage context must be re-signed with a fresh timestamp")
 	}
-	if got.Depth != 1 {
-		t.Fatalf("depth mismatch: got %d want 1", got.Depth)
-	}
-	if !got.BillCustomerRequest {
-		t.Fatal("router-fanned-out tool calls must set BillCustomerRequest=true so downstream services bill their own session line item")
+
+	for i, sent := range sentHeaders {
+		got, ok, err := usagereporting.FromHeaders(sent, secret, times[i], time.Minute)
+		if err != nil {
+			t.Fatalf("parse usage context %d: %v", i, err)
+		}
+		if !ok {
+			t.Fatalf("expected signed usage context on request %d", i)
+		}
+		if !got.IssuedAt.Equal(times[i]) {
+			t.Fatalf("issued at mismatch: got %s want %s", got.IssuedAt, times[i])
+		}
+		if got.RootRequestID != "root-1" || got.ContextID != "req-1" {
+			t.Fatalf("request identity mismatch: got context=%q root=%q", got.ContextID, got.RootRequestID)
+		}
+		if got.ParentService != usagereporting.ServiceRouter {
+			t.Fatalf("parent service mismatch: got %q want %q", got.ParentService, usagereporting.ServiceRouter)
+		}
+		if !usagereporting.VerifyAPIKeyHash(fmt.Sprintf("child-%d", i+1), got.APIKeyHash) {
+			t.Fatal("api key hash does not match forwarded authorization")
+		}
+		if authorization := sent.Get("Authorization"); authorization != fmt.Sprintf("Bearer child-%d", i+1) {
+			t.Fatalf("authorization mismatch: got %q", authorization)
+		}
+		if got.Depth != 1 {
+			t.Fatalf("depth mismatch: got %d want 1", got.Depth)
+		}
+		if !got.BillCustomerRequest {
+			t.Fatal("router-fanned-out tool calls must set BillCustomerRequest=true")
+		}
+		if sent.Get("X-Tinfoil-Tool-Request-Id") != "req-1" {
+			t.Fatalf("tool request id mismatch: got %q", sent.Get("X-Tinfoil-Tool-Request-Id"))
+		}
 	}
 }
 
-// TestToolSessionHeadersOmitsUsageContextWhenSecretEmpty guards against the
+// TestHeaderRoundTripperOmitsUsageContextWhenSecretEmpty guards against the
 // router silently signing tool sessions with an empty secret if startup
-// validation is bypassed in tests; the helper must skip signing rather than
+// validation is bypassed in tests; the transport must skip signing rather than
 // produce a zero-secret HMAC.
-func TestToolSessionHeadersOmitsUsageContextWhenSecretEmpty(t *testing.T) {
+func TestHeaderRoundTripperOmitsUsageContextWhenSecretEmpty(t *testing.T) {
 	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
 	req, err := http.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
 
-	headers, err := toolSessionHeaders(req, "req-1", "gpt-oss-120b", map[string]any{}, safetyOptIns{}, "", func() time.Time { return now })
-	if err != nil {
-		t.Fatalf("build tool session headers: %v", err)
+	headers, usageContext := toolSessionHeaders(req, "req-1", "req-1", "gpt-oss-120b", map[string]any{}, safetyOptIns{})
+	var sentHeaders http.Header
+	transport := &headerRoundTripper{
+		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			sentHeaders = req.Header.Clone()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    req,
+			}, nil
+		}),
+		headers:      headers,
+		usageContext: usageContext,
 	}
+	outbound, err := http.NewRequest(http.MethodPost, "https://tool.example/mcp", nil)
+	if err != nil {
+		t.Fatalf("build outbound request: %v", err)
+	}
+	resp, err := transport.RoundTrip(outbound)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	resp.Body.Close()
 
-	if _, ok, err := usagereporting.FromHeaders(headers, "irrelevant", now, time.Minute); err != nil || ok {
+	if _, ok, err := usagereporting.FromHeaders(sentHeaders, "irrelevant", now, time.Minute); err != nil || ok {
 		t.Fatalf("expected no usage context when secret is empty (ok=%v err=%v)", ok, err)
 	}
 }


### PR DESCRIPTION
## Summary
- exchange first-party chat JWTs for renewable router-bound credentials
- refresh downstream model and tool authorization during long-running responses
- re-sign tool usage contexts for every request to avoid timestamp skew failures

## Deployment
- requires the controlplane delegation endpoint and matching `INFERENCE_DELEGATION_SECRET`
- deploy controlplane before model-router

## Tests
- `go test ./...`
- `go vet ./...`
- `go test -race ./manager ./toolruntime`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps chat and tool authorization fresh during long-running responses by delegating first‑party Chat `at+jwt` tokens to renewable router-bound credentials and re-signing tool usage context per request. Previously we forwarded the original JWT and signed the context once per session, which could expire mid-stream or fail due to timestamp skew; now we refresh with per-request timeouts and rotate signatures, blocking downstream calls on refresh failure.

- Delegation: exchanges eligible first‑party Chat tokens for short‑lived access tokens plus a refreshable grant via `/api/internal/inference/delegate`; refresh runs singleflight with request-scoped timeouts; ineligible tokens fall back to original Authorization unchanged.
- Propagation: injects delegated Authorization into downstream model and MCP tool requests; `postToEnclave` resolves Authorization from request context; tool HTTP transport re-signs `usagereporting` on every call while keeping RequestID/RootRequestID stable for billing dedup.
- Config/API: adds required `INFERENCE_DELEGATION_SECRET` (allowed empty only with `--debug`); validates `CONTROL_PLANE_URL` uses HTTPS unless `--debug`; updates `tinfoil-config.yml`; changes `NewEnclaveManager` to include `inferenceDelegationSecret` and `debug`. No client API changes.

**Rollout**
- Set `INFERENCE_DELEGATION_SECRET` and deploy the control plane delegation endpoint at `/api/internal/inference/delegate` before the router.
- Ensure `CONTROL_PLANE_URL` is HTTPS in production; use `--debug` only for local HTTP.

<sup>Written for commit f0f7fd671d067ab5b1c2557b6db95012b7df0c91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

