### PR TITLE
chore: update cvmimage to v0.11.0

### DIFF
--- a/.github/workflows/tinfoil-release-publish.yml
+++ b/.github/workflows/tinfoil-release-publish.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Measure image, attest, and publish the release
-        uses: tinfoilsh/measure-image-action@e9967c4a2dd60bacc7cce9e4315c5ebcd46118e9 # v0.9.2
+        uses: tinfoilsh/measure-image-action@ca4cfa35773897455c9e51409d61c75b8e377c27 # v0.10.2
         with:
           config-file: ${{ github.workspace }}/tinfoil-config.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,4 +1,4 @@
-cvm-version: 0.10.8
+cvm-version: 0.11.0
 memory: 16384
 cpus: 8
 


### PR DESCRIPTION
## Summary

- update `cvm-version` from `0.10.8` to `0.11.0`
- update `tinfoilsh/measure-image-action` from `v0.9.2` to latest `v0.10.2`, pinned to commit `ca4cfa35773897455c9e51409d61c75b8e377c27`

## Testing

- YAML parse check passed
- `git diff --check` passed
- `go test ./...` reaches a pre-existing panic in `TestChatStreamerFinalizeSkipsMultipleStreamedToolCallsWithoutIDs`; reproduced against `origin/main` at `6b7853a`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Confidential VM image to 0.11.0 and pins the release workflow to `tinfoilsh/measure-image-action` v0.10.2. This keeps the release attestation step current and compatible with the latest image metadata.

- Only changes `.github/workflows/tinfoil-release-publish.yml` and `tinfoil-config.yml`; no runtime behavior changes.
- Action is pinned to commit ca4cfa35773897455c9e51409d61c75b8e377c27 to avoid version drift.
- Sanity checks pass; `go test` hits a known panic also present on main.

<sup>Written for commit 20940b0c0e0aef67c409712e0d825251b90964fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

