### PR TITLE
chore: update tinfoil-go to v0.15.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinfoilsh/confidential-model-router
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
-	github.com/tinfoilsh/tinfoil-go v0.15.2
+	github.com/tinfoilsh/tinfoil-go v0.15.3
 	github.com/tinfoilsh/usage-reporting-go v0.1.3
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -51,7 +51,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/google/certificate-transparency-go v1.3.3 // indirect
 	github.com/google/go-containerregistry v0.21.7 // indirect
-	github.com/google/go-sev-guest v0.15.0 // indirect
 	github.com/google/go-tdx-guest v0.3.1 // indirect
 	github.com/google/logger v1.1.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
@@ -77,6 +76,7 @@ require (
 	github.com/sigstore/timestamp-authority/v2 v2.1.3 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/theupdateframework/go-tuf/v2 v2.4.2 // indirect
+	github.com/tinfoilsh/go-sev-guest v0.0.0-20260818055935-bec7bdb637fd // indirect
 	github.com/transparency-dev/formats v0.1.1 // indirect
 	github.com/transparency-dev/merkle v0.0.2 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,6 @@ github.com/google/go-configfs-tsm v0.2.2 h1:YnJ9rXIOj5BYD7/0DNnzs8AOp7UcvjfTvt21
 github.com/google/go-configfs-tsm v0.2.2/go.mod h1:EL1GTDFMb5PZQWDviGfZV9n87WeGTR/JUg13RfwkgRo=
 github.com/google/go-containerregistry v0.21.7 h1:/vPFuVXDjtFREsVArW+0h1CIl5urnOhzei4X2DMW9IU=
 github.com/google/go-containerregistry v0.21.7/go.mod h1:kjSbt7/zMsKLWfnHrIvKvhXHUw91jbe9DNjPPJ32gXE=
-github.com/google/go-sev-guest v0.15.0 h1:Xzfut5mbhcVb7TyPiyc5PolLUzdai7VH3QpyvXwcW9Y=
-github.com/google/go-sev-guest v0.15.0/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
 github.com/google/go-tdx-guest v0.3.1 h1:gl0KvjdsD4RrJzyLefDOvFOUH3NAJri/3qvaL5m83Iw=
 github.com/google/go-tdx-guest v0.3.1/go.mod h1:/rc3d7rnPykOPuY8U9saMyEps0PZDThLk/RygXm04nE=
 github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
@@ -314,8 +312,10 @@ github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qv
 github.com/theupdateframework/go-tuf v0.7.0/go.mod h1:uEB7WSY+7ZIugK6R1hiBMBjQftaFzn7ZCDJcp1tCUug=
 github.com/theupdateframework/go-tuf/v2 v2.4.2 h1:w7976/W8uTwlsegP5nRymlpjPgrwSh+AXUf85is6nJk=
 github.com/theupdateframework/go-tuf/v2 v2.4.2/go.mod h1:JqBrIUnNLAaNq/8GmBcEMFWfAFBbqp/MkJEJseXKbks=
-github.com/tinfoilsh/tinfoil-go v0.15.2 h1:etQEW4S0o4C/b1c2JaT/fNrtn9Ll4vPrjq230yF2FDg=
-github.com/tinfoilsh/tinfoil-go v0.15.2/go.mod h1:efO+aJz4bZsfzSEJo5EuXetJoxk2DQTSAzb9teydnvY=
+github.com/tinfoilsh/go-sev-guest v0.0.0-20260818055935-bec7bdb637fd h1:qprAQDbhLiW9wxztGqgZgxUlKTnN6jJZx/FQl9HyLH8=
+github.com/tinfoilsh/go-sev-guest v0.0.0-20260818055935-bec7bdb637fd/go.mod h1:2L/TPoX4xeq44MkhftLSU6JBpdwzLPIsFvijrGKKe1s=
+github.com/tinfoilsh/tinfoil-go v0.15.3 h1:KEpyWCN6YRlXEEFCNM/K2t5MJXZ3IPFTF0ugaTOGT74=
+github.com/tinfoilsh/tinfoil-go v0.15.3/go.mod h1:wylSJUke2bS5+M7vOCBLrdmU8QEuW/DHnNqbLLMvVLk=
 github.com/tinfoilsh/usage-reporting-go v0.1.3 h1:q3WJK1auo65BFDxQ+hkSRXF6B+jKhii3RUxeU18hvkA=
 github.com/tinfoilsh/usage-reporting-go v0.1.3/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
 github.com/tink-crypto/tink-go-awskms/v3 v3.0.0 h1:XSohRhCkXAVI0iaCnWB/GS05TEmpnKurQmzaY1jzt3Y=


### PR DESCRIPTION
## Summary

- update tinfoil-go from v0.15.2 to v0.15.3 for Turin SEV-SNP attestation v2 support
- update the required Go version from 1.26.5 to 1.26.6
- select the reviewed tinfoilsh/go-sev-guest fork used by the tinfoil-go verifier path (an older google/go-sev-guest remains transitively elsewhere in the graph)

Uses platform-endorsements v0.0.11 for the Turin IOMMU write-safe policy.

## Validation

- `go test -count=1 -race -p 1 ./...`
- `go vet ./...`
- `go build ./...`
- `go mod verify`
- `go mod tidy` leaves the module files unchanged
- `govulncheck ./...`: 0 reachable vulnerabilities
