### PR TITLE
fix: update release builder to Go 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc AS builder
+FROM golang:1.26.6-alpine3.23@sha256:e57c41c1d5864341031181b0db34b9a537bb5773eb6428e4e5bdaea0f9135406 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- update the pinned Docker builder from Go 1.26.5 to Go 1.26.6
- align the release image with the Go version required by `go.mod`

This fixes the `v0.0.142` release failure at `go mod download`.

## Validation

- `docker build --build-arg VERSION=v0.0.142 -t confidential-model-router:v0.0.142-test .`
- `docker run --rm confidential-model-router:v0.0.142-test -h`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the pinned Docker builder from `golang:1.26.5-alpine3.23` to `golang:1.26.6-alpine3.23` to match `go.mod` and fix the v0.0.142 release. Previously the build failed at go mod download; now the release builds with Go 1.26.6, affecting only the builder stage and producing binaries compiled with 1.26.6.

<sup>Written for commit 34cb8696d8f9639de049222563d3d2a264ea421d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

