### PR TITLE
chore: remove kimi-k2-6

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -35,9 +35,6 @@ models:
   qwen3-tts:
     repo: tinfoilsh/confidential-realtime-models
 
-  kimi-k2-6:
-    repo: tinfoilsh/confidential-kimi-k2-6-b200
-
   deepseek-v4-flash:
     repo: tinfoilsh/confidential-deepseek-v4-flash
 


### PR DESCRIPTION
Removed kimi-k2-6 configuration from the YAML file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `kimi-k2-6` model from `config.yml` to retire it from selection. Previously this model was available via the models list; now it is absent and cannot be resolved by callers.

- Search and remove any references to `kimi-k2-6` in code, tests, and docs; update callers to a supported model.
- If any environment still deploys `tinfoilsh/confidential-kimi-k2-6-b200`, remove or replace it.
- Watch for errors from requests specifying `kimi-k2-6` and migrate those paths.

<sup>Written for commit e52470278d80b652f57a6373f491074b27e72504. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

