### PR TITLE
fix: preserve tool-loop usage accounting when streams end early

### DIFF
--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -185,6 +185,14 @@ func (s *chatStreamer) pumpUpstream(reader *sseReader) (chatIterationResult, err
 		clientForwarder: forwarder,
 	}
 	result := chatIterationResult{}
+	// Fold the turn's usage into the running totals on every exit path,
+	// including early error returns, so an interrupted turn still reaches
+	// the accumulator.
+	defer func() {
+		if result.usage != nil {
+			s.usageTotals.Add(&upstreamJSONResponse{body: map[string]any{"usage": result.usage}})
+		}
+	}()
 	doneSeen := false
 	for {
 		if s.writeErr != nil {
@@ -263,9 +271,6 @@ func (s *chatStreamer) pumpUpstream(reader *sseReader) (chatIterationResult, err
 
 	result.toolCalls = builder.toolCalls()
 	result.rawToolCalls = builder.raw()
-	if result.usage != nil {
-		s.usageTotals.Add(&upstreamJSONResponse{body: map[string]any{"usage": result.usage}})
-	}
 	if !doneSeen {
 		return result, newUpstreamStreamError("upstream stream ended without a terminal [DONE] marker")
 	}
@@ -965,8 +970,18 @@ func (b *chatToolCallBuilder) raw() []any {
 func buildChatStreamRequest(body map[string]any, tools []*mcp.Tool, prompt *mcp.GetPromptResult) (map[string]any, map[string]struct{}) {
 	reqBody, autoContinueTools := buildChatUpstreamRequest(body, tools, prompt)
 	reqBody["stream"] = true
-	reqBody["stream_options"] = map[string]any{"include_usage": true}
+	reqBody["stream_options"] = streamUsageOptions()
 	return reqBody, autoContinueTools
+}
+
+// streamUsageOptions returns the stream_options set on every upstream
+// tool-loop turn. continuous_usage_stats keeps per-chunk usage flowing so
+// an interrupted turn still has usage to account for.
+func streamUsageOptions() map[string]any {
+	return map[string]any{
+		"include_usage":          true,
+		"continuous_usage_stats": true,
+	}
 }
 
 func runChatStreaming(
@@ -1125,7 +1140,7 @@ func runChatStreaming(
 	// and stream it to the client directly.
 	finalBody := forcedFinalChatRequest(reqBody)
 	finalBody["stream"] = true
-	finalBody["stream_options"] = map[string]any{"include_usage": true}
+	finalBody["stream_options"] = streamUsageOptions()
 	result, err := streamer.runIteration(ctx, em, modelName, finalBody, requestHeaders)
 	if err != nil {
 		return streamer.terminateWithError(r, em, modelName, err)

--- a/toolruntime/chat_stream_test.go
+++ b/toolruntime/chat_stream_test.go
@@ -88,6 +88,46 @@ func TestChatStreamerPumpEmitsContentAndToolCalls(t *testing.T) {
 	}
 }
 
+func TestChatStreamerPumpFoldsUsageOnTruncatedStream(t *testing.T) {
+	streamer, _ := newTestChatStreamer(t)
+	// Continuous usage stats put a usage block on mid-stream chunks; the
+	// stream then ends without [DONE], as happens when the upstream
+	// request is cancelled mid-turn.
+	upstream := strings.Join([]string{
+		`data: {"id":"up_1","created":1700000001,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{"role":"assistant"}}]}`,
+		`data: {"id":"up_1","choices":[{"index":0,"delta":{"content":"partial"}}],"usage":{"prompt_tokens":10,"completion_tokens":7,"total_tokens":17}}`,
+		"",
+	}, "\n\n")
+
+	_, err := streamer.pumpUpstream(newSSEReader(strings.NewReader(upstream)))
+	if err == nil {
+		t.Fatal("expected error for stream without terminal [DONE] marker")
+	}
+
+	usage := streamer.finalUsage()
+	if usage == nil {
+		t.Fatal("expected usage from truncated stream to be accumulated")
+	}
+	if usage["prompt_tokens"].(int) != 10 || usage["completion_tokens"].(int) != 7 {
+		t.Fatalf("unexpected accumulated usage: %#v", usage)
+	}
+}
+
+func TestBuildChatStreamRequestEnablesContinuousUsage(t *testing.T) {
+	req, _ := buildChatStreamRequest(
+		map[string]any{"model": "m", "messages": []any{}}, nil, nil)
+	opts, _ := req["stream_options"].(map[string]any)
+	if opts == nil {
+		t.Fatal("stream request missing stream_options")
+	}
+	if opts["include_usage"] != true {
+		t.Error("stream_options missing include_usage")
+	}
+	if opts["continuous_usage_stats"] != true {
+		t.Error("stream_options missing continuous_usage_stats")
+	}
+}
+
 func TestChatStreamerPumpForwardsClientToolCallDeltasLive(t *testing.T) {
 	streamer, rec := newTestChatStreamer(t)
 	streamer.autoContinueTools = map[string]struct{}{"render_stat_cards": {}}

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -192,8 +192,10 @@ func Handle(w http.ResponseWriter, r *http.Request, em *manager.EnclaveManager, 
 			}
 			return nil
 		}
-		response, err := runChatLoop(ctx, em, registry, body, modelName, requestHeaders, promptResult, routerOpts, eventFlags, harmony, dl)
+		usageTotals := &usageAccumulator{}
+		response, err := runChatLoop(ctx, em, registry, body, modelName, requestHeaders, promptResult, routerOpts, eventFlags, harmony, dl, usageTotals)
 		if err != nil {
+			emitAccumulatedBillingEvent(em, r, modelName, usageTotals, false)
 			return writeUpstreamError(w, err)
 		}
 		applyUsageMetrics(response, usageMetricsRequested, modelName, em)
@@ -206,8 +208,10 @@ func Handle(w http.ResponseWriter, r *http.Request, em *manager.EnclaveManager, 
 			}
 			return nil
 		}
-		response, err := runResponsesLoop(ctx, em, registry, body, modelName, requestHeaders, promptResult, routerOpts, eventFlags, harmony, dl)
+		usageTotals := &usageAccumulator{}
+		response, err := runResponsesLoop(ctx, em, registry, body, modelName, requestHeaders, promptResult, routerOpts, eventFlags, harmony, dl, usageTotals)
 		if err != nil {
+			emitAccumulatedBillingEvent(em, r, modelName, usageTotals, false)
 			return writeUpstreamError(w, err)
 		}
 		applyUsageMetrics(response, usageMetricsRequested, modelName, em)
@@ -303,14 +307,14 @@ func toolSessionHeaders(r *http.Request, requestID, rootRequestID, modelName str
 // Loop wrappers
 // ---------------------------------------------------------------------------
 
-func runChatLoop(ctx context.Context, em *manager.EnclaveManager, registry *sessionRegistry, body map[string]any, modelName string, requestHeaders http.Header, prompt *mcp.GetPromptResult, routerOpts *RouterOptions, eventFlags tinfoilEventFlags, harmony bool, dl *devLog) (*upstreamJSONResponse, error) {
+func runChatLoop(ctx context.Context, em *manager.EnclaveManager, registry *sessionRegistry, body map[string]any, modelName string, requestHeaders http.Header, prompt *mcp.GetPromptResult, routerOpts *RouterOptions, eventFlags tinfoilEventFlags, harmony bool, dl *devLog, usageTotals *usageAccumulator) (*upstreamJSONResponse, error) {
 	adapter := newChatLoopAdapter(body, prompt, registry.allTools(), registry.ownedTools(), modelName, requestHeaders, routerOpts)
-	return runToolLoop(ctx, em, registry, modelName, requestHeaders, adapter, eventFlags, harmony, dl)
+	return runToolLoop(ctx, em, registry, modelName, requestHeaders, adapter, eventFlags, harmony, dl, usageTotals)
 }
 
-func runResponsesLoop(ctx context.Context, em *manager.EnclaveManager, registry *sessionRegistry, body map[string]any, modelName string, requestHeaders http.Header, prompt *mcp.GetPromptResult, routerOpts *RouterOptions, eventFlags tinfoilEventFlags, harmony bool, dl *devLog) (*upstreamJSONResponse, error) {
+func runResponsesLoop(ctx context.Context, em *manager.EnclaveManager, registry *sessionRegistry, body map[string]any, modelName string, requestHeaders http.Header, prompt *mcp.GetPromptResult, routerOpts *RouterOptions, eventFlags tinfoilEventFlags, harmony bool, dl *devLog, usageTotals *usageAccumulator) (*upstreamJSONResponse, error) {
 	adapter := newResponsesLoopAdapter(body, prompt, registry.allTools(), registry.ownedTools(), routerOpts)
-	return runToolLoop(ctx, em, registry, modelName, requestHeaders, adapter, eventFlags, harmony, dl)
+	return runToolLoop(ctx, em, registry, modelName, requestHeaders, adapter, eventFlags, harmony, dl, usageTotals)
 }
 
 // ---------------------------------------------------------------------------
@@ -518,6 +522,21 @@ func emitBillingEvent(em *manager.EnclaveManager, r *http.Request, response *ups
 		RequestPath:        r.URL.Path,
 		Streaming:          streaming,
 	})
+}
+
+// emitAccumulatedBillingEvent records usage collected from completed
+// tool-loop turns when the loop exits without a final response. No event
+// is emitted when nothing was accumulated.
+func emitAccumulatedBillingEvent(em *manager.EnclaveManager, r *http.Request, modelName string, totals *usageAccumulator, streaming bool) {
+	usage := totals.Usage()
+	if usage == nil {
+		return
+	}
+	response := &upstreamJSONResponse{
+		header: http.Header{},
+		body:   map[string]any{"usage": chatUsageMap(usage)},
+	}
+	emitBillingEvent(em, r, response, modelName, streaming)
 }
 
 func responseRequestID(headers ...http.Header) string {

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -125,9 +125,9 @@ func runToolLoop(
 	eventFlags tinfoilEventFlags,
 	harmony bool,
 	dl *devLog,
+	usageTotals *usageAccumulator,
 ) (*upstreamJSONResponse, error) {
 	reqBody := adapter.buildInitialRequest()
-	usageTotals := usageAccumulator{}
 	citeState := citations.State{NextIndex: 1, Harmony: harmony}
 	toolCalls := toolCallLog{}
 	opts := adapter.options()


### PR DESCRIPTION
Superseded by #479 — a minimal, streaming-only revision of this change (one production file, +30/−5). Branch was deleted on close so this PR could not be reopened.