### PR TITLE
Billing emission and reporter delivery metrics

### DIFF
--- a/billing/events.go
+++ b/billing/events.go
@@ -8,11 +8,51 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
 
 	usagereporting "github.com/tinfoilsh/usage-reporting-go"
 	usageclient "github.com/tinfoilsh/usage-reporting-go/client"
 )
+
+// Emission counters pair with the proxy's router_request_* observation
+// metrics: observed-vs-emitted localizes a loss to the usage handler, while
+// the usage_reporter_* counters below localize it to enqueueing or delivery.
+var (
+	eventsEmitted = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "router_billing_events_emitted_total",
+		Help: "Billing events handed to the usage reporter, by model.",
+	}, []string{"model"})
+	promptTokensEmitted = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "router_billing_prompt_tokens_emitted_total",
+		Help: "Prompt tokens on billing events handed to the usage reporter, by model.",
+	}, []string{"model"})
+
+	reporterStatsOnce sync.Once
+)
+
+// registerReporterStats exports the reporter's delivery accounting as
+// Prometheus counters. Registered once for the process-lifetime collector;
+// extra collectors (tests) are ignored.
+func registerReporterStats(reporter *usageclient.ReporterClient) {
+	reporterStatsOnce.Do(func() {
+		counter := func(name, help string, read func(usageclient.Stats) uint64) prometheus.CounterFunc {
+			return prometheus.NewCounterFunc(prometheus.CounterOpts{Name: name, Help: help}, func() float64 {
+				return float64(read(reporter.Stats()))
+			})
+		}
+		prometheus.MustRegister(
+			counter("usage_reporter_enqueued_events_total", "Events accepted into the reporter buffer.", func(s usageclient.Stats) uint64 { return s.Enqueued }),
+			counter("usage_reporter_delivered_events_total", "Events in batches acknowledged with HTTP 2xx.", func(s usageclient.Stats) uint64 { return s.DeliveredEvents }),
+			counter("usage_reporter_delivered_batches_total", "Batches acknowledged with HTTP 2xx.", func(s usageclient.Stats) uint64 { return s.DeliveredBatches }),
+			counter("usage_reporter_failed_events_total", "Events discarded with a failed batch (no retry).", func(s usageclient.Stats) uint64 { return s.FailedEvents }),
+			counter("usage_reporter_failed_batches_total", "Batches that failed delivery and were discarded.", func(s usageclient.Stats) uint64 { return s.FailedBatches }),
+			counter("usage_reporter_dropped_buffer_full_total", "Oldest events overwritten on buffer overflow.", func(s usageclient.Stats) uint64 { return s.DroppedBufferFull }),
+			counter("usage_reporter_dropped_disabled_total", "Events discarded because the reporter is not configured.", func(s usageclient.Stats) uint64 { return s.DroppedDisabled }),
+		)
+	})
+}
 
 // Event represents a billing event with token usage. CachedPromptTokens is the
 // subset of PromptTokens that the model served from its prompt cache; the
@@ -65,6 +105,7 @@ func NewCollector(controlPlaneURL, reporterID, reporterSecret string) *Collector
 			Secret:     reporterSecret,
 		}),
 	}
+	registerReporterStats(c.reporter)
 	return c
 }
 
@@ -103,6 +144,9 @@ func (c *Collector) AddEvent(event Event) {
 				Quantity: cachedInputTokens,
 			})
 		}
+
+		eventsEmitted.WithLabelValues(event.Model).Inc()
+		promptTokensEmitted.WithLabelValues(event.Model).Add(float64(inputTokens))
 
 		c.reporter.AddEvent(usagereporting.Event{
 			RequestID:  event.RequestID,

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/tinfoilsh/tinfoil-go v0.15.3
-	github.com/tinfoilsh/usage-reporting-go v0.1.3
+	github.com/tinfoilsh/usage-reporting-go v0.1.4-0.20260828195033-137ba94bd456
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,10 @@ github.com/tinfoilsh/tinfoil-go v0.15.3 h1:KEpyWCN6YRlXEEFCNM/K2t5MJXZ3IPFTF0uga
 github.com/tinfoilsh/tinfoil-go v0.15.3/go.mod h1:wylSJUke2bS5+M7vOCBLrdmU8QEuW/DHnNqbLLMvVLk=
 github.com/tinfoilsh/usage-reporting-go v0.1.3 h1:q3WJK1auo65BFDxQ+hkSRXF6B+jKhii3RUxeU18hvkA=
 github.com/tinfoilsh/usage-reporting-go v0.1.3/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
+github.com/tinfoilsh/usage-reporting-go v0.1.4-0.20260828194414-37bf25b92009 h1:2hktMcnMR4tBEJlRqI4OLHmlBRXnP81F+rG9W1aT+Ig=
+github.com/tinfoilsh/usage-reporting-go v0.1.4-0.20260828194414-37bf25b92009/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
+github.com/tinfoilsh/usage-reporting-go v0.1.4-0.20260828195033-137ba94bd456 h1:I1ft7+jcHkJbkB/45uhhcyl6gq+vj/kW70GnMDEuEYk=
+github.com/tinfoilsh/usage-reporting-go v0.1.4-0.20260828195033-137ba94bd456/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
 github.com/tink-crypto/tink-go-awskms/v3 v3.0.0 h1:XSohRhCkXAVI0iaCnWB/GS05TEmpnKurQmzaY1jzt3Y=
 github.com/tink-crypto/tink-go-awskms/v3 v3.0.0/go.mod h1:+7MXsShLzVbSQ6dI0Pe4JuZM52jD1jQ1itAygd/MDsA=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.3.0 h1:3s6YMgMOBZRU8qG6ybpKSF2Sau+y3sMvxR911M59SwA=


### PR DESCRIPTION
Adds `router_billing_events_emitted_total{model}` and `router_billing_prompt_tokens_emitted_total{model}` at the billing event emission site, and exposes the usage reporter's delivery accounting (from tinfoilsh/usage-reporting-go#11) as `usage_reporter_*` counters on /metrics, so event emission and delivery can be monitored end to end. Depends on tinfoilsh/usage-reporting-go#11.