### PR TITLE
fix: avoid repeatedly routing to unreachable replicas

### DIFF
--- a/manager/circuitbreaker.go
+++ b/manager/circuitbreaker.go
@@ -68,6 +68,15 @@ func (cb *circuitBreaker) RecordFailure() {
 	}
 }
 
+// RecordUnavailable opens the circuit immediately when no backend response
+// was received. Unlike an HTTP 5xx, a transport failure cannot be a healthy
+// application response and retrying the same replica only prolongs an outage.
+func (cb *circuitBreaker) RecordUnavailable() {
+	cb.lastFailureNano.Store(time.Now().UnixNano())
+	cb.consecutiveFailures.Store(cbFailureThreshold)
+	cb.storeState(cbOpen)
+}
+
 // Closed reports whether the circuit breaker is in the closed (healthy) state.
 func (cb *circuitBreaker) Closed() bool {
 	return cb.loadState() == cbClosed

--- a/manager/http_client.go
+++ b/manager/http_client.go
@@ -183,7 +183,7 @@ func postToEnclave(ctx context.Context, client *http.Client, enclave *Enclave, p
 		} else {
 			ProxyFailureTotal.WithLabelValues(enclave.modelName, enclave.host, reason).Inc()
 			if enclave.cb != nil {
-				enclave.cb.RecordFailure()
+				enclave.cb.RecordUnavailable()
 				publishBreakerState(enclave.modelName, enclave.host, enclave.cb)
 			}
 		}

--- a/manager/http_client_test.go
+++ b/manager/http_client_test.go
@@ -94,8 +94,11 @@ func TestPostToEnclaveInflight(t *testing.T) {
 	if got := e2.inflight.Load(); got != 0 {
 		t.Fatalf("in-flight after error = %d, want 0", got)
 	}
-	if got := e2.cb.ConsecutiveFailures(); got != 1 {
-		t.Fatalf("breaker failures after transport error = %d, want 1", got)
+	if got := e2.cb.State(); got != cbOpen {
+		t.Fatalf("breaker state after transport error = %d, want open", got)
+	}
+	if got := e2.cb.ConsecutiveFailures(); got != cbFailureThreshold {
+		t.Fatalf("breaker failures after transport error = %d, want %d", got, cbFailureThreshold)
 	}
 }
 

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -252,7 +252,9 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 			ClientCancellationsTotal.WithLabelValues(modelName, host).Inc()
 			ProbeClaimFromContext(r.Context()).Abort()
 		} else {
-			recordFailure(reason)
+			ProxyFailureTotal.WithLabelValues(modelName, host, reason).Inc()
+			cb.RecordUnavailable()
+			publishBreakerState(modelName, host, cb)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)

--- a/manager/proxy_test.go
+++ b/manager/proxy_test.go
@@ -199,6 +199,18 @@ func TestCircuitBreaker_OpensAfterThreshold(t *testing.T) {
 	}
 }
 
+func TestCircuitBreaker_TransportFailureOpensImmediately(t *testing.T) {
+	cb := newCircuitBreaker()
+	cb.RecordUnavailable()
+
+	if cb.State() != cbOpen {
+		t.Fatalf("expected open after transport failure, got %d", cb.State())
+	}
+	if cb.ConsecutiveFailures() != cbFailureThreshold {
+		t.Fatalf("expected failure threshold after transport failure, got %d", cb.ConsecutiveFailures())
+	}
+}
+
 func TestCircuitBreaker_SuccessResetsClosed(t *testing.T) {
 	cb := newCircuitBreaker()
 	for i := 0; i < cbFailureThreshold; i++ {


### PR DESCRIPTION
## Summary
- open a replica's circuit immediately when a transport failure prevents any backend response
- apply the same behavior to public proxy and internal model requests
- retain the existing failure threshold for backend HTTP errors and verify transport handling with tests

## Testing
- `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens a replica's circuit breaker immediately on transport failures so routing stops hitting unreachable replicas instead of waiting for the failure threshold.

- Applies to both public proxy and internal model requests.
- HTTP 5xx errors continue to use the existing failure threshold.

<sup>Written for commit 2ce0b016de5bb374244914548e422892393e0c00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

