### PR TITLE
Add glm-5-3 to the trust anchor

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -26,6 +26,9 @@ models:
   glm-5-2:
     repo: tinfoilsh/confidential-glm5-2-b200
 
+  glm-5-3:
+    repo: tinfoilsh/confidential-glm5-3-nvfp4
+
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
 


### PR DESCRIPTION
Adds `glm-5-3` → `tinfoilsh/confidential-glm5-3-nvfp4` to the embedded model→repo map. Requires a router release and rollout (stage all routers, then accept); the runtime config block (enclave list, rate limits, overload, cache_route) is applied separately via backoffice. The repo's Latest release (v0.0.2) is the tag deployed on the candidate enclave.
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `glm-5-3` to the trust anchor's model→repo map, pointing to `tinfoilsh/confidential-glm5-3-nvfp4`. Requires a router release and rollout (stage all routers, then accept); runtime config (enclave list, rate limits, overload, `cache_route`) is applied separately via backoffice. The repo's Latest release (v0.0.2) is the tag deployed on the candidate enclave.

<sup>Written for commit 7d164eefe76e19efa1236f131c4507287f09a73a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
