### PR TITLE
Add glm-5-3-flash

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -29,6 +29,9 @@ models:
   glm-5-3:
     repo: tinfoilsh/confidential-glm5-3-nvfp4
 
+  glm-5-3-flash:
+    repo: tinfoilsh/confidential-glm5-3-flash
+
   gpt-oss-120b:
     repo: tinfoilsh/confidential-gpt-oss-120b
 


### PR DESCRIPTION
Trust-anchor entry for `glm-5-3-flash` → `tinfoilsh/confidential-glm5-3-flash`. Needs a router release + rollout; runtime config (enclave list, rate limits) follows via backoffice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `glm-5-3-flash` to the trust anchor so it can be routed. Requires a router release and rollout; runtime config like enclave lists and rate limits will be set via backoffice.

<sup>Written for commit c0146ececf21a81945d5a126ef162d195a7dd194. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

