### PR TITLE
fix: stop streams from stalling or truncating silently

### DIFF
--- a/tokencount/extractor.go
+++ b/tokencount/extractor.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // Usage represents token usage information from inference responses.
@@ -181,10 +183,27 @@ func NewStreamingTokenExtractor(reader io.ReadCloser, writer io.WriteCloser, mod
 	return s
 }
 
-// processStream processes the SSE stream, extracting token usage
+// processStream processes the SSE stream, extracting token usage.
+//
+// An upstream read failure (connection reset, TLS close, oversized line)
+// must not end the client's response as a clean EOF: the reverse proxy
+// would then terminate a 200 body mid-stream with no error frame, which
+// clients cannot distinguish from a short but complete answer. The
+// failure is propagated through the pipe so the proxy aborts the
+// connection and the client observes a real error.
 func (s *StreamingTokenExtractor) processStream() {
-	defer s.writer.Close()
 	defer s.reader.Close()
+	defer func() {
+		if err := s.scanner.Err(); err != nil {
+			if cw, ok := s.writer.(interface{ CloseWithError(error) error }); ok {
+				log.WithError(err).WithField("model", s.model).
+					Warn("upstream stream read failed; aborting client stream")
+				cw.CloseWithError(err)
+				return
+			}
+		}
+		s.writer.Close()
+	}()
 
 	lastLineWasFiltered := false
 	terminalEventPending := false

--- a/tokencount/extractor_streaming_test.go
+++ b/tokencount/extractor_streaming_test.go
@@ -1,7 +1,9 @@
 package tokencount
 
 import (
+	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -549,6 +551,55 @@ func TestLargeSSELineSurvivesScannerBuffer(t *testing.T) {
 	}
 	if string(output) != input {
 		t.Fatalf("large SSE line was truncated: got %d bytes, want %d", len(output), len(input))
+	}
+}
+
+// failingReader yields its prefix and then fails with err, standing in for
+// an upstream connection that drops mid-stream before [DONE].
+type failingReader struct {
+	prefix io.Reader
+	err    error
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	n, err := r.prefix.Read(p)
+	if err == io.EOF {
+		return n, r.err
+	}
+	return n, err
+}
+
+func (r *failingReader) Close() error { return nil }
+
+func TestUpstreamReadErrorAbortsClientStream(t *testing.T) {
+	prefix := "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n"
+	upstreamErr := errors.New("connection reset by peer")
+	pr, pw := io.Pipe()
+	extractor := NewStreamingTokenExtractor(
+		&failingReader{prefix: strings.NewReader(prefix), err: upstreamErr},
+		pw,
+		"test-model",
+	)
+
+	go extractor.processStream()
+	output, err := io.ReadAll(pr)
+	if !errors.Is(err, upstreamErr) {
+		t.Fatalf("ReadAll() error = %v, want upstream error to propagate", err)
+	}
+	if string(output) != prefix {
+		t.Fatalf("bytes received before the failure were altered:\n%q\nwant:\n%q", output, prefix)
+	}
+}
+
+func TestOversizedSSELineAbortsClientStream(t *testing.T) {
+	input := "data: {\"choices\":[{\"delta\":{\"content\":\"" + strings.Repeat("a", maxSSELineBytes+1) + "\"}}]}\n\n"
+	pr, pw := io.Pipe()
+	extractor := NewStreamingTokenExtractor(io.NopCloser(strings.NewReader(input)), pw, "test-model")
+
+	go extractor.processStream()
+	_, err := io.ReadAll(pr)
+	if !errors.Is(err, bufio.ErrTooLong) {
+		t.Fatalf("ReadAll() error = %v, want bufio.ErrTooLong", err)
 	}
 }
 

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -982,10 +982,14 @@ func runChatStreaming(
 	routerOpts *RouterOptions,
 	dl *devLog,
 ) error {
-	flusher, ok := w.(http.Flusher)
+	rawFlusher, ok := w.(http.Flusher)
 	if !ok {
 		return fmt.Errorf("streaming not supported")
 	}
+	heartbeat := newHeartbeatWriter(w, rawFlusher)
+	defer heartbeat.Stop()
+	w = heartbeat
+	flusher := heartbeat
 
 	tid := debugTraceID()
 	searchOpts := parseChatWebSearchOptions(routerOpts, body)

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -901,10 +901,14 @@ func runResponsesStreaming(
 	routerOpts *RouterOptions,
 	dl *devLog,
 ) error {
-	flusher, ok := w.(http.Flusher)
+	rawFlusher, ok := w.(http.Flusher)
 	if !ok {
 		return fmt.Errorf("streaming not supported")
 	}
+	heartbeat := newHeartbeatWriter(w, rawFlusher)
+	defer heartbeat.Stop()
+	w = heartbeat
+	flusher := heartbeat
 
 	searchOpts := parseResponsesWebSearchOptions(routerOpts, body)
 	tools := registry.allTools()

--- a/toolruntime/sse_heartbeat.go
+++ b/toolruntime/sse_heartbeat.go
@@ -108,41 +108,50 @@ func (h *heartbeatWriter) Stop() {
 	}
 }
 
+// run wakes exactly when the current idle period reaches
+// sseHeartbeatInterval. A fixed-cadence ticker would be wrong here: its
+// phase is set when the stream arms, but writes land at arbitrary offsets,
+// so a silence that begins just after a tick would not be caught until the
+// following one, stretching the worst case to nearly two intervals.
 func (h *heartbeatWriter) run() {
 	defer close(h.done)
-	ticker := time.NewTicker(sseHeartbeatInterval)
-	defer ticker.Stop()
+	timer := time.NewTimer(sseHeartbeatInterval)
+	defer timer.Stop()
 	for {
 		select {
 		case <-h.stop:
 			return
-		case now := <-ticker.C:
-			if !h.beat(now) {
+		case now := <-timer.C:
+			wait, ok := h.beat(now)
+			if !ok {
 				return
 			}
+			timer.Reset(wait)
 		}
 	}
 }
 
-// beat writes a heartbeat if the stream has been idle for a full interval.
-// It reports false once a write has failed, at which point the client is
-// gone and further heartbeats are pointless.
-func (h *heartbeatWriter) beat(now time.Time) bool {
+// beat writes a heartbeat if the stream has been idle for a full interval
+// and returns how long to wait before checking again: the remainder of the
+// current idle period if a write arrived in the meantime, otherwise a full
+// interval. It reports false once a write has failed, at which point the
+// client is gone and further heartbeats are pointless.
+func (h *heartbeatWriter) beat(now time.Time) (time.Duration, bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.failed {
-		return false
+		return 0, false
 	}
-	if now.Sub(h.lastWrite) < sseHeartbeatInterval {
-		return true
+	if idle := now.Sub(h.lastWrite); idle < sseHeartbeatInterval {
+		return sseHeartbeatInterval - idle, true
 	}
 	if _, err := h.ResponseWriter.Write([]byte(sseHeartbeatFrame)); err != nil {
 		h.fail(err)
-		return false
+		return 0, false
 	}
 	h.flusher.Flush()
 	h.lastWrite = now
-	return true
+	return sseHeartbeatInterval, true
 }
 
 // fail records the first write error; callers hold mu.

--- a/toolruntime/sse_heartbeat.go
+++ b/toolruntime/sse_heartbeat.go
@@ -1,7 +1,6 @@
 package toolruntime
 
 import (
-	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -38,6 +37,7 @@ type heartbeatWriter struct {
 	lastWrite time.Time
 	armed     bool
 	failed    bool
+	failedErr error
 
 	stopOnce sync.Once
 	stop     chan struct{}
@@ -71,13 +71,20 @@ func (h *heartbeatWriter) WriteHeader(status int) {
 	go h.run()
 }
 
+// Write forwards to the client. Once any write has failed, including a
+// heartbeat, every later write fails immediately so the streamer's own
+// write-error latch trips on its next emit and the tool loop stops
+// spending upstream tokens on a caller that has gone away.
 func (h *heartbeatWriter) Write(p []byte) (int, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.failed {
+		return 0, h.failedErr
+	}
 	n, err := h.ResponseWriter.Write(p)
 	h.lastWrite = time.Now()
 	if err != nil {
-		h.failed = true
+		h.fail(err)
 	}
 	return n, err
 }
@@ -129,11 +136,20 @@ func (h *heartbeatWriter) beat(now time.Time) bool {
 	if now.Sub(h.lastWrite) < sseHeartbeatInterval {
 		return true
 	}
-	if _, err := io.WriteString(h.ResponseWriter, sseHeartbeatFrame); err != nil {
-		h.failed = true
+	if _, err := h.ResponseWriter.Write([]byte(sseHeartbeatFrame)); err != nil {
+		h.fail(err)
 		return false
 	}
 	h.flusher.Flush()
 	h.lastWrite = now
 	return true
+}
+
+// fail records the first write error; callers hold mu.
+func (h *heartbeatWriter) fail(err error) {
+	if h.failed {
+		return
+	}
+	h.failed = true
+	h.failedErr = err
 }

--- a/toolruntime/sse_heartbeat.go
+++ b/toolruntime/sse_heartbeat.go
@@ -1,0 +1,139 @@
+package toolruntime
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// sseHeartbeatInterval is the longest the tool runtime lets a client stream
+// sit idle before emitting a comment frame. Tool execution and the
+// re-prompt that follows can exceed the idle timeouts of clients and edge
+// proxies (Cloudflare gives up after 100s), so the value stays well under
+// those while remaining infrequent enough to be negligible on the wire.
+const sseHeartbeatInterval = 15 * time.Second
+
+// sseHeartbeatFrame is an SSE comment line. Parsers ignore it by
+// specification, so it keeps the connection alive without surfacing an
+// event to the consumer.
+const sseHeartbeatFrame = ": ping\n\n"
+
+// heartbeatWriter wraps the client ResponseWriter for a tool-runtime
+// stream. Between upstream iterations the streamer has nothing to forward
+// while MCP tools run and the next model turn warms up, and that silence
+// is indistinguishable from a dead connection to anything downstream.
+// Once SSE headers have been written, a background goroutine emits a
+// comment frame whenever no bytes have gone out for sseHeartbeatInterval.
+//
+// All writes and flushes are serialised through mu because the streamer
+// and the heartbeat goroutine share the underlying ResponseWriter, which
+// is not safe for concurrent use.
+type heartbeatWriter struct {
+	http.ResponseWriter
+	flusher http.Flusher
+
+	mu        sync.Mutex
+	lastWrite time.Time
+	armed     bool
+	failed    bool
+
+	stopOnce sync.Once
+	stop     chan struct{}
+	done     chan struct{}
+}
+
+// newHeartbeatWriter returns a writer that starts heartbeating after the
+// first successful SSE WriteHeader. Callers must invoke Stop before the
+// handler returns so no heartbeat is written to a finished response.
+func newHeartbeatWriter(w http.ResponseWriter, flusher http.Flusher) *heartbeatWriter {
+	return &heartbeatWriter{
+		ResponseWriter: w,
+		flusher:        flusher,
+		stop:           make(chan struct{}),
+		done:           make(chan struct{}),
+	}
+}
+
+func (h *heartbeatWriter) WriteHeader(status int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.ResponseWriter.WriteHeader(status)
+	if h.armed || status < 200 || status >= 300 {
+		return
+	}
+	if !strings.HasPrefix(h.Header().Get("Content-Type"), "text/event-stream") {
+		return
+	}
+	h.armed = true
+	h.lastWrite = time.Now()
+	go h.run()
+}
+
+func (h *heartbeatWriter) Write(p []byte) (int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n, err := h.ResponseWriter.Write(p)
+	h.lastWrite = time.Now()
+	if err != nil {
+		h.failed = true
+	}
+	return n, err
+}
+
+func (h *heartbeatWriter) Flush() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.flusher.Flush()
+}
+
+// Stop ends the heartbeat goroutine and blocks until it has exited, so a
+// caller that defers Stop can be sure nothing touches the ResponseWriter
+// after the handler returns.
+func (h *heartbeatWriter) Stop() {
+	h.stopOnce.Do(func() { close(h.stop) })
+	h.mu.Lock()
+	armed := h.armed
+	h.mu.Unlock()
+	if armed {
+		<-h.done
+	}
+}
+
+func (h *heartbeatWriter) run() {
+	defer close(h.done)
+	ticker := time.NewTicker(sseHeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-h.stop:
+			return
+		case now := <-ticker.C:
+			if !h.beat(now) {
+				return
+			}
+		}
+	}
+}
+
+// beat writes a heartbeat if the stream has been idle for a full interval.
+// It reports false once a write has failed, at which point the client is
+// gone and further heartbeats are pointless.
+func (h *heartbeatWriter) beat(now time.Time) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.failed {
+		return false
+	}
+	if now.Sub(h.lastWrite) < sseHeartbeatInterval {
+		return true
+	}
+	if _, err := io.WriteString(h.ResponseWriter, sseHeartbeatFrame); err != nil {
+		h.failed = true
+		return false
+	}
+	h.flusher.Flush()
+	h.lastWrite = now
+	return true
+}

--- a/toolruntime/sse_heartbeat_test.go
+++ b/toolruntime/sse_heartbeat_test.go
@@ -1,0 +1,91 @@
+package toolruntime
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newArmedHeartbeat(t *testing.T) (*heartbeatWriter, *httptest.ResponseRecorder) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h := newHeartbeatWriter(rec, rec)
+	h.Header().Set("Content-Type", "text/event-stream")
+	h.WriteHeader(http.StatusOK)
+	t.Cleanup(h.Stop)
+	return h, rec
+}
+
+func TestHeartbeatWritesCommentAfterIdleInterval(t *testing.T) {
+	h, rec := newArmedHeartbeat(t)
+
+	now := time.Now()
+	if !h.beat(now.Add(sseHeartbeatInterval / 2)) {
+		t.Fatal("beat() reported failure on a healthy writer")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("heartbeat fired before the idle interval elapsed: %q", rec.Body.String())
+	}
+
+	if !h.beat(now.Add(sseHeartbeatInterval)) {
+		t.Fatal("beat() reported failure on a healthy writer")
+	}
+	if got := rec.Body.String(); got != sseHeartbeatFrame {
+		t.Fatalf("heartbeat frame = %q, want %q", got, sseHeartbeatFrame)
+	}
+}
+
+func TestHeartbeatIsSuppressedByRecentWrites(t *testing.T) {
+	h, rec := newArmedHeartbeat(t)
+
+	frame := "data: {\"choices\":[]}\n\n"
+	if _, err := h.Write([]byte(frame)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if !h.beat(time.Now().Add(sseHeartbeatInterval / 2)) {
+		t.Fatal("beat() reported failure on a healthy writer")
+	}
+	if got := rec.Body.String(); got != frame {
+		t.Fatalf("heartbeat interleaved with a fresh write: %q", got)
+	}
+}
+
+func TestHeartbeatOnlyArmsForSSEResponses(t *testing.T) {
+	rec := httptest.NewRecorder()
+	h := newHeartbeatWriter(rec, rec)
+	h.Header().Set("Content-Type", "application/json")
+	h.WriteHeader(http.StatusOK)
+	defer h.Stop()
+
+	if h.armed {
+		t.Fatal("heartbeat armed for a non-SSE response")
+	}
+}
+
+func TestHeartbeatStopsAfterWriteFailure(t *testing.T) {
+	w := &failingFlushWriter{}
+	h := newHeartbeatWriter(w, w)
+	h.Header().Set("Content-Type", "text/event-stream")
+	h.WriteHeader(http.StatusOK)
+	defer h.Stop()
+
+	if h.beat(time.Now().Add(sseHeartbeatInterval)) {
+		t.Fatal("beat() kept running after the client write failed")
+	}
+}
+
+// Comment frames must be invisible to the router's own SSE reader so a
+// heartbeat relayed by an intermediary never surfaces as an event.
+func TestHeartbeatFrameIsIgnoredBySSEReader(t *testing.T) {
+	input := sseHeartbeatFrame + "data: {\"ok\":true}\n\n"
+	reader := newSSEReader(strings.NewReader(input))
+	frame, err := reader.next()
+	if err != nil {
+		t.Fatalf("next() error = %v", err)
+	}
+	if frame.data != "{\"ok\":true}" {
+		t.Fatalf("frame.data = %q, want the data frame following the heartbeat", frame.data)
+	}
+}

--- a/toolruntime/sse_heartbeat_test.go
+++ b/toolruntime/sse_heartbeat_test.go
@@ -95,7 +95,6 @@ func TestHeartbeatFailurePropagatesToLaterWrites(t *testing.T) {
 	}
 }
 
-// failOnceWriter fails the first Write and accepts every write after it.
 type failOnceWriter struct {
 	*httptest.ResponseRecorder
 	failed bool

--- a/toolruntime/sse_heartbeat_test.go
+++ b/toolruntime/sse_heartbeat_test.go
@@ -1,6 +1,7 @@
 package toolruntime
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -74,6 +75,38 @@ func TestHeartbeatStopsAfterWriteFailure(t *testing.T) {
 	if h.beat(time.Now().Add(sseHeartbeatInterval)) {
 		t.Fatal("beat() kept running after the client write failed")
 	}
+}
+
+// A heartbeat that discovers the client is gone must surface on the
+// streamer's next Write so its writeErr latch trips and the tool loop
+// stops, even if the underlying writer would otherwise accept bytes again.
+func TestHeartbeatFailurePropagatesToLaterWrites(t *testing.T) {
+	w := &failOnceWriter{ResponseRecorder: httptest.NewRecorder()}
+	h := newHeartbeatWriter(w, w)
+	h.Header().Set("Content-Type", "text/event-stream")
+	h.WriteHeader(http.StatusOK)
+	defer h.Stop()
+
+	if h.beat(time.Now().Add(sseHeartbeatInterval)) {
+		t.Fatal("beat() did not report the failed heartbeat write")
+	}
+	if _, err := h.Write([]byte("data: {}\n\n")); err == nil {
+		t.Fatal("Write() succeeded after the heartbeat detected a dead client")
+	}
+}
+
+// failOnceWriter fails the first Write and accepts every write after it.
+type failOnceWriter struct {
+	*httptest.ResponseRecorder
+	failed bool
+}
+
+func (w *failOnceWriter) Write(p []byte) (int, error) {
+	if !w.failed {
+		w.failed = true
+		return 0, io.ErrClosedPipe
+	}
+	return w.ResponseRecorder.Write(p)
 }
 
 // Comment frames must be invisible to the router's own SSE reader so a

--- a/toolruntime/sse_heartbeat_test.go
+++ b/toolruntime/sse_heartbeat_test.go
@@ -23,18 +23,47 @@ func TestHeartbeatWritesCommentAfterIdleInterval(t *testing.T) {
 	h, rec := newArmedHeartbeat(t)
 
 	now := time.Now()
-	if !h.beat(now.Add(sseHeartbeatInterval / 2)) {
+	if _, ok := h.beat(now.Add(sseHeartbeatInterval / 2)); !ok {
 		t.Fatal("beat() reported failure on a healthy writer")
 	}
 	if rec.Body.Len() != 0 {
 		t.Fatalf("heartbeat fired before the idle interval elapsed: %q", rec.Body.String())
 	}
 
-	if !h.beat(now.Add(sseHeartbeatInterval)) {
+	if _, ok := h.beat(now.Add(sseHeartbeatInterval)); !ok {
 		t.Fatal("beat() reported failure on a healthy writer")
 	}
 	if got := rec.Body.String(); got != sseHeartbeatFrame {
 		t.Fatalf("heartbeat frame = %q, want %q", got, sseHeartbeatFrame)
+	}
+}
+
+// When a write lands partway through the idle period, the next check must
+// be scheduled for the remainder of that period rather than a full interval
+// later, otherwise a silence that starts right after a check goes unnoticed
+// for almost two intervals.
+func TestHeartbeatReschedulesFromLastWrite(t *testing.T) {
+	h, _ := newArmedHeartbeat(t)
+
+	h.mu.Lock()
+	h.lastWrite = time.Now()
+	h.mu.Unlock()
+
+	elapsed := sseHeartbeatInterval / 3
+	wait, ok := h.beat(h.lastWrite.Add(elapsed))
+	if !ok {
+		t.Fatal("beat() reported failure on a healthy writer")
+	}
+	if want := sseHeartbeatInterval - elapsed; wait != want {
+		t.Fatalf("beat() wait = %v, want remainder of idle period %v", wait, want)
+	}
+
+	wait, ok = h.beat(h.lastWrite.Add(sseHeartbeatInterval))
+	if !ok {
+		t.Fatal("beat() reported failure on a healthy writer")
+	}
+	if wait != sseHeartbeatInterval {
+		t.Fatalf("beat() wait after emitting = %v, want full interval %v", wait, sseHeartbeatInterval)
 	}
 }
 
@@ -45,7 +74,7 @@ func TestHeartbeatIsSuppressedByRecentWrites(t *testing.T) {
 	if _, err := h.Write([]byte(frame)); err != nil {
 		t.Fatalf("Write() error = %v", err)
 	}
-	if !h.beat(time.Now().Add(sseHeartbeatInterval / 2)) {
+	if _, ok := h.beat(time.Now().Add(sseHeartbeatInterval / 2)); !ok {
 		t.Fatal("beat() reported failure on a healthy writer")
 	}
 	if got := rec.Body.String(); got != frame {
@@ -72,7 +101,7 @@ func TestHeartbeatStopsAfterWriteFailure(t *testing.T) {
 	h.WriteHeader(http.StatusOK)
 	defer h.Stop()
 
-	if h.beat(time.Now().Add(sseHeartbeatInterval)) {
+	if _, ok := h.beat(time.Now().Add(sseHeartbeatInterval)); ok {
 		t.Fatal("beat() kept running after the client write failed")
 	}
 }
@@ -87,7 +116,7 @@ func TestHeartbeatFailurePropagatesToLaterWrites(t *testing.T) {
 	h.WriteHeader(http.StatusOK)
 	defer h.Stop()
 
-	if h.beat(time.Now().Add(sseHeartbeatInterval)) {
+	if _, ok := h.beat(time.Now().Add(sseHeartbeatInterval)); ok {
 		t.Fatal("beat() did not report the failed heartbeat write")
 	}
 	if _, err := h.Write([]byte("data: {}\n\n")); err == nil {

--- a/toolruntime/sse_heartbeat_test.go
+++ b/toolruntime/sse_heartbeat_test.go
@@ -45,12 +45,13 @@ func TestHeartbeatWritesCommentAfterIdleInterval(t *testing.T) {
 func TestHeartbeatReschedulesFromLastWrite(t *testing.T) {
 	h, _ := newArmedHeartbeat(t)
 
+	last := time.Now()
 	h.mu.Lock()
-	h.lastWrite = time.Now()
+	h.lastWrite = last
 	h.mu.Unlock()
 
 	elapsed := sseHeartbeatInterval / 3
-	wait, ok := h.beat(h.lastWrite.Add(elapsed))
+	wait, ok := h.beat(last.Add(elapsed))
 	if !ok {
 		t.Fatal("beat() reported failure on a healthy writer")
 	}
@@ -58,7 +59,7 @@ func TestHeartbeatReschedulesFromLastWrite(t *testing.T) {
 		t.Fatalf("beat() wait = %v, want remainder of idle period %v", wait, want)
 	}
 
-	wait, ok = h.beat(h.lastWrite.Add(sseHeartbeatInterval))
+	wait, ok = h.beat(last.Add(sseHeartbeatInterval))
 	if !ok {
 		t.Fatal("beat() reported failure on a healthy writer")
 	}


### PR DESCRIPTION
Mobile and web clients have been reporting responses that stop mid-stream with no error, or that die with a connection error on good networks, since the mid-August releases. Two router behaviours produce those symptoms.

**Upstream failures were laundered into a clean EOF.** `StreamingTokenExtractor.processStream` closed its pipe with a plain `Close()` and never checked `scanner.Err()`, so an enclave connection reset, TLS close, or oversized line ended the client's 200 body as if the answer had simply finished. Nothing was logged. The scanner error is now propagated with `CloseWithError`, so `ReverseProxy` aborts the connection and the client sees a real failure it can retry, and the router logs the cause.

**Tool-assisted streams went silent between iterations.** While MCP tools ran and the next model turn warmed up, nothing was written to the client; there were no heartbeat frames anywhere in the tool runtime. Those gaps routinely exceed client idle timeouts and Cloudflare's 100s origin read timeout, and #457 widened them for GenUI turns by buffering widget-argument deltas until the iteration ends. Both streamers now wrap the response in a writer that emits an SSE comment (`: ping`) whenever the stream has been idle for 15s. Comment frames are ignored by every consumer in play (the router's own `sseReader`, the latency detector, the iOS/web SDK parsers, the controlplane recovery persister).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops streams from stalling or truncating silently. Upstream failures now surface as real errors instead of a clean EOF, and idle tool-assisted streams stay alive with SSE heartbeats.

**Bug Fixes**
- `tokencount`'s streaming extractor propagates scanner errors through `CloseWithError`, so the reverse proxy aborts the connection and logs the cause instead of returning a truncated 200 response.
- `toolruntime` chat and responses streamers emit an SSE comment (`: ping`) after 15 seconds of idle time, including while MCP tools run or the next model turn warms up.
- Heartbeats arm only for `text/event-stream` responses, reset their timer after each write, and stop the tool loop when a heartbeat detects a disconnected client; comment frames remain invisible to stream consumers.

<sup>Written for commit 037f0fac7e035235086c9effbe5b30b32d238f51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

