### PR TITLE
feat: reject requests whose model header disagrees with the body

### DIFF
--- a/main.go
+++ b/main.go
@@ -273,6 +273,13 @@ func parseModelFromSubdomain(r *http.Request, domain string) (string, error) {
 	return "", nil
 }
 
+// modelHeaderMatches reports whether the optional X-Tinfoil-Model header,
+// when present, names the same model as the request body.
+func modelHeaderMatches(header http.Header, bodyModel string) bool {
+	expected := strings.TrimSpace(header.Get(manager.ModelRequestHeader))
+	return expected == "" || expected == bodyModel
+}
+
 // extractModelFromMultipart extracts the model name from a multipart form request.
 // Returns the model name (empty if not found) and the buffered body bytes for forwarding.
 func extractModelFromMultipart(r *http.Request) (string, []byte, error) {
@@ -717,6 +724,10 @@ func main() {
 				modelName, ok = modelInterface.(string)
 				if !ok {
 					jsonError(w, "Invalid parameter: 'model' must be a string.", manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+					return
+				}
+				if !modelHeaderMatches(r.Header, modelName) {
+					jsonError(w, manager.ErrMsgModelMismatch, manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 					return
 				}
 

--- a/main_test.go
+++ b/main_test.go
@@ -67,6 +67,33 @@ func TestWriteRequestBodyErrorClassifiesChunkedOversize(t *testing.T) {
 	}
 }
 
+func TestModelHeaderMatches(t *testing.T) {
+	tests := []struct {
+		name      string
+		header    string
+		bodyModel string
+		want      bool
+	}{
+		{"absent header skips check", "", "gpt-oss-120b", true},
+		{"matching header", "gpt-oss-120b", "gpt-oss-120b", true},
+		{"surrounding whitespace tolerated", "  gpt-oss-120b ", "gpt-oss-120b", true},
+		{"mismatched header", "gpt-oss-120b", "qwen3-tts", false},
+		{"header compared against literal auto", "auto", "auto", true},
+		{"case sensitive", "GPT-OSS-120B", "gpt-oss-120b", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.Header{}
+			if tt.header != "" {
+				h.Set(manager.ModelRequestHeader, tt.header)
+			}
+			if got := modelHeaderMatches(h, tt.bodyModel); got != tt.want {
+				t.Errorf("modelHeaderMatches(%q, %q) = %v, want %v", tt.header, tt.bodyModel, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExtractModelFromMultipart(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -36,6 +36,9 @@ const (
 	UsageMetricsRequestHeader = "X-Tinfoil-Request-Usage-Metrics"
 	// UsageMetricsResponseHeader is the response header (or trailer) containing usage metrics
 	UsageMetricsResponseHeader = "X-Tinfoil-Usage-Metrics"
+	// ModelRequestHeader optionally names the model the client intends to
+	// call; when set it must match the model field in the request body.
+	ModelRequestHeader = "X-Tinfoil-Model"
 	// maxUsageMetricsBodyBytes caps buffering for non-streaming usage extraction.
 	maxUsageMetricsBodyBytes = int64(10 << 20)
 	// websearchModel is charged per-request in addition to per-token.
@@ -124,6 +127,7 @@ const (
 	ErrMsgOverloaded    = "The engine is currently overloaded, please try again later."
 	ErrMsgModelNotFound = "The model does not exist."
 	ErrMsgBodyTooLarge  = "Request body is too large."
+	ErrMsgModelMismatch = "The model in the request body does not match the " + ModelRequestHeader + " header."
 )
 
 // billingCloser wraps a response body and emits a zero-token billing event


### PR DESCRIPTION
Adds an optional `X-Tinfoil-Model` request header. On the OpenAI-compatible JSON endpoints (chat completions, responses, embeddings, etc.), when the header is present it must equal the `model` field in the body; otherwise the router returns a 400 `invalid_request_error` before any routing or `auto` resolution happens.

Lets clients that set the model out-of-band (e.g. per-model SDK configuration) catch a body/header disagreement at the edge instead of silently sending traffic to the wrong model. Absent header keeps current behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `X-Tinfoil-Model` header check on the OpenAI-compatible JSON endpoints so clients that set the model out-of-band catch a body/header disagreement at the edge instead of silently routing to the wrong model.

- When the header is present and doesn't match the body's `model`, the router returns a 400 `invalid_request_error` before any routing or `auto` resolution.
- The header is compared case-sensitively after trimming surrounding whitespace; absent header keeps current behavior.
- Defines `manager.ModelRequestHeader` and `manager.ErrMsgModelMismatch` for reuse.

<sup>Written for commit 751a4626a37e2022a290c89aef556bf3a76c4d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

