### PR TITLE
feat: report web search usage in usage metrics header

### DIFF
--- a/manager/pricing.go
+++ b/manager/pricing.go
@@ -14,6 +14,31 @@ const (
 	nanodollarDecimalPlaces = 9
 )
 
+// WebSearchUsage describes the router-owned web search activity behind a
+// request. The websearch service bills one session fee per request the first
+// time the model invokes search or fetch, so the fee applies once when Calls
+// is positive regardless of how many calls followed. SessionPricing is the
+// websearch tool's published pricing; nil means the fee is unknown.
+type WebSearchUsage struct {
+	Calls          int
+	SessionPricing *ModelPricing
+}
+
+func (w *WebSearchUsage) billed() bool {
+	return w != nil && w.Calls > 0
+}
+
+func (w *WebSearchUsage) costKnown() bool {
+	return !w.billed() || w.SessionPricing != nil
+}
+
+func (w *WebSearchUsage) costNanos() int64 {
+	if !w.billed() {
+		return 0
+	}
+	return requestPriceNanos(w.SessionPricing.RequestPrice)
+}
+
 // CostKnownWithoutUsage reports whether request price alone determines cost.
 func (p ModelPricing) CostKnownWithoutUsage() bool {
 	if tokenPriceNanos(p.InputTokenPricePer1M) != 0 || tokenPriceNanos(p.OutputTokenPricePer1M) != 0 {
@@ -47,7 +72,10 @@ func requestCostNanos(usage *tokencount.Usage, pricing ModelPricing) int64 {
 }
 
 func formatRequestCostUSD(usage *tokencount.Usage, pricing ModelPricing) string {
-	costNanos := requestCostNanos(usage, pricing)
+	return formatNanosUSD(requestCostNanos(usage, pricing))
+}
+
+func formatNanosUSD(costNanos int64) string {
 	wholeDollars := costNanos / nanosPerDollar
 	fractionalNanos := costNanos % nanosPerDollar
 	if fractionalNanos == 0 {

--- a/manager/pricing_test.go
+++ b/manager/pricing_test.go
@@ -88,6 +88,56 @@ func TestRequestCostUSD(t *testing.T) {
 	}
 }
 
+func TestFormatUsageWebSearch(t *testing.T) {
+	usage := &tokencount.Usage{PromptTokens: 1_000, CompletionTokens: 500, TotalTokens: 1_500}
+	modelPricing := &ModelPricing{InputTokenPricePer1M: 1, OutputTokenPricePer1M: 2}
+	sessionPricing := &ModelPricing{RequestPrice: 0.05}
+
+	tests := []struct {
+		name      string
+		pricing   *ModelPricing
+		webSearch *WebSearchUsage
+		expected  string
+	}{
+		{
+			name:     "nil web search leaves header unchanged",
+			pricing:  modelPricing,
+			expected: "prompt=1000,completion=500,total=1500,model=m,cost_usd=0.002",
+		},
+		{
+			name:      "zero calls omits web search fields and fee",
+			pricing:   modelPricing,
+			webSearch: &WebSearchUsage{SessionPricing: sessionPricing},
+			expected:  "prompt=1000,completion=500,total=1500,model=m,cost_usd=0.002",
+		},
+		{
+			name:      "session fee is charged once regardless of call count",
+			pricing:   modelPricing,
+			webSearch: &WebSearchUsage{Calls: 3, SessionPricing: sessionPricing},
+			expected:  "prompt=1000,completion=500,total=1500,model=m,web_search_calls=3,cost_usd=0.052",
+		},
+		{
+			name:      "unknown session fee omits cost_usd but keeps call count",
+			pricing:   modelPricing,
+			webSearch: &WebSearchUsage{Calls: 1},
+			expected:  "prompt=1000,completion=500,total=1500,model=m,web_search_calls=1",
+		},
+		{
+			name:      "unknown model pricing omits cost_usd",
+			webSearch: &WebSearchUsage{Calls: 1, SessionPricing: sessionPricing},
+			expected:  "prompt=1000,completion=500,total=1500,model=m,web_search_calls=1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatUsage(usage, "m", tt.pricing, tt.webSearch); got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
 func TestModelPricingJSONAndLookup(t *testing.T) {
 	var models openAIModelsList
 	err := json.Unmarshal([]byte(`{

--- a/manager/proxy.go
+++ b/manager/proxy.go
@@ -337,7 +337,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 		var handlerCalled atomic.Bool
 		if !streaming && usageMetricsRequested && resp.StatusCode == http.StatusOK &&
 			responsePricing != nil && responsePricing.CostKnownWithoutUsage() {
-			resp.Header.Set(UsageMetricsResponseHeader, FormatUsage(&tokencount.Usage{}, modelName, responsePricing))
+			resp.Header.Set(UsageMetricsResponseHeader, FormatUsage(&tokencount.Usage{}, modelName, responsePricing, nil))
 		}
 
 		// Create a usage handler that will be called when usage is extracted
@@ -425,7 +425,7 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 				usageHandler(jsonResp.Usage)
 
 				// Set usage header directly on response
-				resp.Header.Set(UsageMetricsResponseHeader, FormatUsage(jsonResp.Usage, modelName, responsePricing))
+				resp.Header.Set(UsageMetricsResponseHeader, FormatUsage(jsonResp.Usage, modelName, responsePricing, nil))
 			} else if billingCollector != nil && apiKey != "" {
 				emitZeroTokenEvent()
 			}
@@ -474,7 +474,12 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 // FormatUsage formats token usage for the response header. It is the single
 // source of truth for the header format so every path that emits usage
 // metrics produces an identical value.
-func FormatUsage(usage *tokencount.Usage, model string, pricing *ModelPricing) string {
+//
+// webSearch is nil for requests that never entered the tool runtime. When the
+// model invoked web search, web_search_calls is emitted and the session fee
+// is folded into cost_usd. cost_usd is omitted whenever any component of the
+// total is unknown so a partial figure is never mistaken for the full cost.
+func FormatUsage(usage *tokencount.Usage, model string, pricing *ModelPricing, webSearch *WebSearchUsage) string {
 	formatted := "prompt=" + strconv.Itoa(usage.PromptTokens) +
 		",completion=" + strconv.Itoa(usage.CompletionTokens) +
 		",total=" + strconv.Itoa(usage.TotalTokens)
@@ -488,8 +493,11 @@ func FormatUsage(usage *tokencount.Usage, model string, pricing *ModelPricing) s
 	if model != "" {
 		formatted += ",model=" + model
 	}
-	if pricing != nil {
-		formatted += ",cost_usd=" + formatRequestCostUSD(usage, *pricing)
+	if webSearch.billed() {
+		formatted += ",web_search_calls=" + strconv.Itoa(webSearch.Calls)
+	}
+	if pricing != nil && webSearch.costKnown() {
+		formatted += ",cost_usd=" + formatNanosUSD(requestCostNanos(usage, *pricing)+webSearch.costNanos())
 	}
 
 	return formatted

--- a/manager/usage_writer.go
+++ b/manager/usage_writer.go
@@ -51,7 +51,7 @@ func (w *usageMetricsWriter) FormatUsage() string {
 	if w.usage == nil {
 		return ""
 	}
-	return FormatUsage(w.usage, w.model, w.pricing)
+	return FormatUsage(w.usage, w.model, w.pricing, nil)
 }
 
 // WriteTrailer writes the usage metrics as an HTTP trailer

--- a/toolruntime/chat_stream.go
+++ b/toolruntime/chat_stream.go
@@ -623,7 +623,7 @@ func (s *chatStreamer) finalize(
 	}
 
 	if s.usageMetricsRequested {
-		if formatted := formatUsageMetrics(em, usageFromRaw(finalUsage), modelName); formatted != "" {
+		if formatted := formatUsageMetrics(em, usageFromRaw(finalUsage), modelName, webSearchUsage(em, s.toolCalls)); formatted != "" {
 			s.w.Header().Set(manager.UsageMetricsResponseHeader, formatted)
 		}
 	}

--- a/toolruntime/events.go
+++ b/toolruntime/events.go
@@ -64,6 +64,19 @@ func (l *toolCallLog) list() []toolCallRecord {
 	return l.records
 }
 
+// webSearchCalls counts the recorded search/fetch calls. Failed calls are
+// included because the websearch service reports the session before running
+// the tool, so a failed search is still a billed one.
+func (l *toolCallLog) webSearchCalls() int {
+	count := 0
+	for _, record := range l.list() {
+		if isWebSearchTool(record.name) {
+			count++
+		}
+	}
+	return count
+}
+
 // toolCallRecord captures a tool call the router made on the user's behalf,
 // used to surface web_search_call progress items to clients. errorReason
 // carries the tool-side error message when the call failed so terminal

--- a/toolruntime/responses_stream.go
+++ b/toolruntime/responses_stream.go
@@ -817,7 +817,7 @@ func (s *responsesStreamer) finalize(r *http.Request, em *manager.EnclaveManager
 	})
 
 	if s.usageMetricsRequested {
-		if formatted := formatUsageMetrics(em, usageFromRaw(usage), modelName); formatted != "" {
+		if formatted := formatUsageMetrics(em, usageFromRaw(usage), modelName, webSearchUsage(em, s.toolCalls)); formatted != "" {
 			s.w.Header().Set(manager.UsageMetricsResponseHeader, formatted)
 		}
 	}

--- a/toolruntime/runtime.go
+++ b/toolruntime/runtime.go
@@ -192,11 +192,11 @@ func Handle(w http.ResponseWriter, r *http.Request, em *manager.EnclaveManager, 
 			}
 			return nil
 		}
-		response, err := runChatLoop(ctx, em, registry, body, modelName, requestHeaders, promptResult, routerOpts, eventFlags, harmony, dl)
+		response, webSearch, err := runChatLoop(ctx, em, registry, body, modelName, requestHeaders, promptResult, routerOpts, eventFlags, harmony, dl)
 		if err != nil {
 			return writeUpstreamError(w, err)
 		}
-		applyUsageMetrics(response, usageMetricsRequested, modelName, em)
+		applyUsageMetrics(response, usageMetricsRequested, modelName, em, webSearch)
 		emitBillingEvent(em, r, response, modelName, false)
 		return writeJSONResponse(w, response)
 	case "/v1/responses":
@@ -206,11 +206,11 @@ func Handle(w http.ResponseWriter, r *http.Request, em *manager.EnclaveManager, 
 			}
 			return nil
 		}
-		response, err := runResponsesLoop(ctx, em, registry, body, modelName, requestHeaders, promptResult, routerOpts, eventFlags, harmony, dl)
+		response, webSearch, err := runResponsesLoop(ctx, em, registry, body, modelName, requestHeaders, promptResult, routerOpts, eventFlags, harmony, dl)
 		if err != nil {
 			return writeUpstreamError(w, err)
 		}
-		applyUsageMetrics(response, usageMetricsRequested, modelName, em)
+		applyUsageMetrics(response, usageMetricsRequested, modelName, em, webSearch)
 		emitBillingEvent(em, r, response, modelName, false)
 		return writeJSONResponse(w, response)
 	default:
@@ -303,14 +303,27 @@ func toolSessionHeaders(r *http.Request, requestID, rootRequestID, modelName str
 // Loop wrappers
 // ---------------------------------------------------------------------------
 
-func runChatLoop(ctx context.Context, em *manager.EnclaveManager, registry *sessionRegistry, body map[string]any, modelName string, requestHeaders http.Header, prompt *mcp.GetPromptResult, routerOpts *RouterOptions, eventFlags tinfoilEventFlags, harmony bool, dl *devLog) (*upstreamJSONResponse, error) {
+func runChatLoop(ctx context.Context, em *manager.EnclaveManager, registry *sessionRegistry, body map[string]any, modelName string, requestHeaders http.Header, prompt *mcp.GetPromptResult, routerOpts *RouterOptions, eventFlags tinfoilEventFlags, harmony bool, dl *devLog) (*upstreamJSONResponse, *manager.WebSearchUsage, error) {
 	adapter := newChatLoopAdapter(body, prompt, registry.allTools(), registry.ownedTools(), modelName, requestHeaders, routerOpts)
 	return runToolLoop(ctx, em, registry, modelName, requestHeaders, adapter, eventFlags, harmony, dl)
 }
 
-func runResponsesLoop(ctx context.Context, em *manager.EnclaveManager, registry *sessionRegistry, body map[string]any, modelName string, requestHeaders http.Header, prompt *mcp.GetPromptResult, routerOpts *RouterOptions, eventFlags tinfoilEventFlags, harmony bool, dl *devLog) (*upstreamJSONResponse, error) {
+func runResponsesLoop(ctx context.Context, em *manager.EnclaveManager, registry *sessionRegistry, body map[string]any, modelName string, requestHeaders http.Header, prompt *mcp.GetPromptResult, routerOpts *RouterOptions, eventFlags tinfoilEventFlags, harmony bool, dl *devLog) (*upstreamJSONResponse, *manager.WebSearchUsage, error) {
 	adapter := newResponsesLoopAdapter(body, prompt, registry.allTools(), registry.ownedTools(), routerOpts)
 	return runToolLoop(ctx, em, registry, modelName, requestHeaders, adapter, eventFlags, harmony, dl)
+}
+
+// webSearchUsage summarizes the router-owned search/fetch calls recorded
+// during a request together with the websearch tool's published session
+// pricing so the usage metrics header can report the fee.
+func webSearchUsage(em *manager.EnclaveManager, toolCalls *toolCallLog) *manager.WebSearchUsage {
+	usage := &manager.WebSearchUsage{Calls: toolCalls.webSearchCalls()}
+	if em != nil {
+		if pricing, ok := em.ModelPricing(WebSearch.ToolServerModel); ok {
+			usage.SessionPricing = &pricing
+		}
+	}
+	return usage
 }
 
 // ---------------------------------------------------------------------------
@@ -454,7 +467,7 @@ func usageMap(usage *tokencount.Usage, inputTokensKey, outputTokensKey, detailsK
 	return usageMap
 }
 
-func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested bool, modelName string, em *manager.EnclaveManager) {
+func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested bool, modelName string, em *manager.EnclaveManager, webSearch *manager.WebSearchUsage) {
 	if response == nil {
 		return
 	}
@@ -465,14 +478,14 @@ func applyUsageMetrics(response *upstreamJSONResponse, usageMetricsRequested boo
 	}
 
 	usage := usageFromRaw(response.body["usage"])
-	formatted := formatUsageMetrics(em, usage, modelName)
+	formatted := formatUsageMetrics(em, usage, modelName, webSearch)
 	if formatted == "" {
 		return
 	}
 	response.header.Set(manager.UsageMetricsResponseHeader, formatted)
 }
 
-func formatUsageMetrics(em *manager.EnclaveManager, usage *tokencount.Usage, modelName string) string {
+func formatUsageMetrics(em *manager.EnclaveManager, usage *tokencount.Usage, modelName string, webSearch *manager.WebSearchUsage) string {
 	var pricing *manager.ModelPricing
 	if value, ok := em.ModelPricing(modelName); ok {
 		pricing = &value
@@ -483,7 +496,7 @@ func formatUsageMetrics(em *manager.EnclaveManager, usage *tokencount.Usage, mod
 		}
 		usage = &tokencount.Usage{}
 	}
-	return manager.FormatUsage(usage, modelName, pricing)
+	return manager.FormatUsage(usage, modelName, pricing, webSearch)
 }
 
 func emitBillingEvent(em *manager.EnclaveManager, r *http.Request, response *upstreamJSONResponse, modelName string, streaming bool) {

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -206,6 +206,52 @@ func TestModelRequestHeaders(t *testing.T) {
 	}
 }
 
+func TestToolCallLogWebSearchCallsCountsSearchAndFetchOnly(t *testing.T) {
+	var nilLog *toolCallLog
+	if got := nilLog.webSearchCalls(); got != 0 {
+		t.Fatalf("nil log web search calls = %d, want 0", got)
+	}
+
+	log := &toolCallLog{}
+	log.record(toolCallRecord{name: mcpSearchToolName})
+	log.record(toolCallRecord{name: routerSearchToolName, errorReason: publicToolErrorReasonString})
+	log.record(toolCallRecord{name: routerFetchToolName})
+	log.record(toolCallRecord{name: "bash"})
+	log.record(toolCallRecord{name: mcpPresentToolName})
+
+	if got := log.webSearchCalls(); got != 3 {
+		t.Fatalf("web search calls = %d, want 3 (search, failed search, fetch)", got)
+	}
+}
+
+func TestApplyUsageMetricsReportsWebSearchCalls(t *testing.T) {
+	newResponse := func() *upstreamJSONResponse {
+		return &upstreamJSONResponse{
+			body: map[string]any{
+				"usage": map[string]any{
+					"prompt_tokens":     10,
+					"completion_tokens": 5,
+					"total_tokens":      15,
+				},
+			},
+			header: make(http.Header),
+		}
+	}
+	em := newTestEnclaveManager()
+
+	response := newResponse()
+	applyUsageMetrics(response, true, "m", em, &manager.WebSearchUsage{Calls: 2})
+	if got, want := response.header.Get(manager.UsageMetricsResponseHeader), "prompt=10,completion=5,total=15,model=m,web_search_calls=2"; got != want {
+		t.Fatalf("usage header = %q, want %q", got, want)
+	}
+
+	response = newResponse()
+	applyUsageMetrics(response, true, "m", em, &manager.WebSearchUsage{})
+	if got, want := response.header.Get(manager.UsageMetricsResponseHeader), "prompt=10,completion=5,total=15,model=m"; got != want {
+		t.Fatalf("usage header without web search = %q, want %q", got, want)
+	}
+}
+
 func TestResponsesAdapterApplyUsageReplacesResponsesTotals(t *testing.T) {
 	response := &upstreamJSONResponse{
 		body: map[string]any{

--- a/toolruntime/runtime_test.go
+++ b/toolruntime/runtime_test.go
@@ -239,16 +239,31 @@ func TestApplyUsageMetricsReportsWebSearchCalls(t *testing.T) {
 	}
 	em := newTestEnclaveManager()
 
-	response := newResponse()
-	applyUsageMetrics(response, true, "m", em, &manager.WebSearchUsage{Calls: 2})
-	if got, want := response.header.Get(manager.UsageMetricsResponseHeader), "prompt=10,completion=5,total=15,model=m,web_search_calls=2"; got != want {
-		t.Fatalf("usage header = %q, want %q", got, want)
+	tests := []struct {
+		name      string
+		webSearch *manager.WebSearchUsage
+		want      string
+	}{
+		{
+			name:      "reports call count when web search ran",
+			webSearch: &manager.WebSearchUsage{Calls: 2},
+			want:      "prompt=10,completion=5,total=15,model=m,web_search_calls=2",
+		},
+		{
+			name:      "omits web search fields when no calls ran",
+			webSearch: &manager.WebSearchUsage{},
+			want:      "prompt=10,completion=5,total=15,model=m",
+		},
 	}
 
-	response = newResponse()
-	applyUsageMetrics(response, true, "m", em, &manager.WebSearchUsage{})
-	if got, want := response.header.Get(manager.UsageMetricsResponseHeader), "prompt=10,completion=5,total=15,model=m"; got != want {
-		t.Fatalf("usage header without web search = %q, want %q", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := newResponse()
+			applyUsageMetrics(response, true, "m", em, tt.webSearch)
+			if got := response.header.Get(manager.UsageMetricsResponseHeader); got != tt.want {
+				t.Fatalf("usage header = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/toolruntime/tool_loop.go
+++ b/toolruntime/tool_loop.go
@@ -125,7 +125,7 @@ func runToolLoop(
 	eventFlags tinfoilEventFlags,
 	harmony bool,
 	dl *devLog,
-) (*upstreamJSONResponse, error) {
+) (*upstreamJSONResponse, *manager.WebSearchUsage, error) {
 	reqBody := adapter.buildInitialRequest()
 	usageTotals := usageAccumulator{}
 	citeState := citations.State{NextIndex: 1, Harmony: harmony}
@@ -151,7 +151,7 @@ func runToolLoop(
 			if traceID := adapter.traceID(); traceID != "" {
 				debugLogf("toolruntime:%s %s upstream.error elapsed=%s err=%v", traceID, adapter.tracePhase(i), time.Since(start), err)
 			}
-			return nil, err
+			return nil, nil, err
 		}
 		usageTotals.Add(response)
 
@@ -170,7 +170,7 @@ func runToolLoop(
 			adapter.attachAutoContinueResponseItems(response, autoContinueResponseItems)
 			adapter.applyUsage(response, usageTotals.Usage())
 			adapter.attachCitations(response.body, &citeState, &toolCalls, eventFlags)
-			return response, nil
+			return response, webSearchUsage(em, &toolCalls), nil
 		}
 
 		dl.WriteToolCalls(routerToolCalls)
@@ -210,7 +210,7 @@ func runToolLoop(
 			adapter.attachAutoContinueResponseItems(response, append(autoContinueResponseItems, currentAutoContinueItems...))
 			adapter.applyUsage(response, usageTotals.Usage())
 			adapter.attachCitations(response.body, &citeState, &toolCalls, eventFlags)
-			return response, nil
+			return response, webSearchUsage(em, &toolCalls), nil
 		}
 
 		autoContinueResponseItems = append(autoContinueResponseItems, adapter.autoContinueResponseItems(state, autoContinueCalls)...)
@@ -222,7 +222,7 @@ func runToolLoop(
 	}
 	finalResponse, err := postJSON(ctx, em, modelName, path, adapter.forcedFinalRequest(reqBody), requestHeaders)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// The forced-final turn consumes tokens too; feed them into the
 	// accumulator before finalize overwrites response.body["usage"] with
@@ -232,7 +232,7 @@ func runToolLoop(
 	adapter.attachAutoContinueResponseItems(finalResponse, autoContinueResponseItems)
 	adapter.applyUsage(finalResponse, usageTotals.Usage())
 	adapter.attachCitations(finalResponse.body, &citeState, &toolCalls, eventFlags)
-	return finalResponse, nil
+	return finalResponse, webSearchUsage(em, &toolCalls), nil
 }
 
 // executeRouterToolCall runs one router-owned tool call on behalf of


### PR DESCRIPTION
Customers can only see whether a request incurred the web search fee on the billing page. This surfaces it in the `X-Tinfoil-Usage-Metrics` header/trailer on `/v1/chat/completions` and `/v1/responses`:

```
prompt=1000,completion=500,total=1500,model=llama3,web_search_calls=2,cost_usd=0.052
```

- `web_search_calls=N` is emitted only when the model actually invoked search/fetch. Absence means no web search was used and no fee applies. Enabling `web_search_options` alone does not trigger it.
- `cost_usd` now folds in the web search session fee, charged once per request (matching how the websearch service dedups billing). The fee is read from the `websearch` entry's `requestPrice` in `/v1/models`, so it tracks controlplane config rather than being hardcoded.
- `cost_usd` is omitted if the session fee is unknown, so a partial figure is never presented as the total.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Customers could previously see web search fees only on the billing page. The `X-Tinfoil-Usage-Metrics` header/trailer on `/v1/chat/completions` and `/v1/responses` now reports web search usage and folds the session fee into `cost_usd`:

```
prompt=1000,completion=500,total=1500,model=llama3,web_search_calls=2,cost_usd=0.052
```

- `web_search_calls=N` appears only when the model actually invoked search or fetch; enabling `web_search_options` alone doesn't trigger it.
- `cost_usd` now includes the web search session fee, charged once per request to match how the websearch service dedups billing, and reads the fee from the `websearch` entry's `requestPrice` in `/v1/models`.
- `cost_usd` is omitted if the session fee is unknown so a partial figure is never shown as the total.

<sup>Written for commit cef43403c4a85bb4d34a0950b5aecfcc54ebbea5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

