### PR TITLE
Route auto requests by requested intelligence level

### DIFF
--- a/autoroute/autoroute.go
+++ b/autoroute/autoroute.go
@@ -1,0 +1,318 @@
+// Package autoroute picks a concrete model and reasoning effort for requests
+// that name the "auto" model. The caller states how capable a model it wants
+// as an intelligence level; the router matches that against the per-effort
+// intelligence scores the control plane publishes for each chat model and
+// walks the closest matches until it finds one with a healthy backend.
+package autoroute
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	// IntelligenceHeader carries the requested intelligence level when the
+	// body does not.
+	IntelligenceHeader = "X-Tinfoil-Intelligence"
+
+	// OptionsField is the router-only body field that may carry the requested
+	// intelligence level as {"intelligence": N}. It is always stripped from
+	// the body before the request is forwarded.
+	OptionsField = "auto_model_options"
+
+	// IntelligenceKey is the key inside OptionsField that holds the level.
+	IntelligenceKey = "intelligence"
+
+	// MinIntelligence and MaxIntelligence bound the requested level, which is
+	// normalized so that MaxIntelligence corresponds to the highest-scoring
+	// model and effort currently in the catalog.
+	MinIntelligence = 0
+	MaxIntelligence = 100
+
+	// DefaultIntelligence is used when the caller states no level.
+	DefaultIntelligence = 50
+
+	// effortPlaceholder is replaced inside a reasoning enable fragment with
+	// the model's native effort value.
+	effortPlaceholder = "$EFFORT"
+
+	// effortOff selects a model with reasoning disabled; effortOn selects a
+	// model whose reasoning is always enabled and has no effort knob.
+	effortOff = "off"
+	effortOn  = "on"
+)
+
+// visualPartTypes are the content part types that carry images or files a
+// text-only model cannot read.
+var visualPartTypes = map[string]bool{
+	"image_url":   true,
+	"input_image": true,
+	"file":        true,
+	"input_file":  true,
+}
+
+// EndpointParams holds the request fragments that switch a model's reasoning
+// on or off for one API endpoint. Enable may contain the literal "$EFFORT"
+// placeholder, which ApplyEffort replaces with the model's native effort.
+type EndpointParams struct {
+	Enable  map[string]any `json:"enable"`
+	Disable map[string]any `json:"disable"`
+}
+
+// Reasoning describes how to apply a reasoning setting to a request for one
+// model, as published by the control plane. Params is keyed by endpoint path;
+// EffortMap translates the client-facing effort key (low, medium, high) to
+// the model's native value.
+type Reasoning struct {
+	Params    map[string]EndpointParams `json:"params"`
+	EffortMap map[string]string         `json:"effort_map"`
+}
+
+// Model is one entry in the routing catalog.
+type Model struct {
+	Name       string
+	Multimodal bool
+	Scores     map[string]int
+	Reasoning  *Reasoning
+}
+
+// Candidate is one (model, effort) pair the router may select.
+type Candidate struct {
+	Model  Model
+	Effort string
+	// Score is the raw published intelligence score for this pair.
+	Score int
+	// Level is Score normalized to the MinIntelligence..MaxIntelligence range
+	// against the highest score in the catalog.
+	Level int
+}
+
+// Decision records why a request landed on a given candidate.
+type Decision struct {
+	Candidate Candidate
+	// Target is the requested intelligence level after defaulting.
+	Target int
+	// Visual reports whether the request carried image or file parts, which
+	// restricts routing to multimodal models.
+	Visual bool
+	// Skipped counts higher-ranked candidates passed over because their model
+	// had no healthy backend.
+	Skipped int
+}
+
+// ParseIntelligence extracts the requested intelligence level. The body's
+// OptionsField object takes precedence over IntelligenceHeader, and an absent
+// level falls back to DefaultIntelligence. The OptionsField is removed from
+// the body regardless of shape so legacy payloads never reach the backend.
+func ParseIntelligence(header http.Header, body map[string]any) (int, error) {
+	raw, present := body[OptionsField]
+	delete(body, OptionsField)
+	if present {
+		if options, ok := raw.(map[string]any); ok {
+			if value, ok := options[IntelligenceKey]; ok {
+				return intelligenceFromJSON(value)
+			}
+		}
+	}
+	if value := strings.TrimSpace(header.Get(IntelligenceHeader)); value != "" {
+		level, err := strconv.Atoi(value)
+		if err != nil {
+			return 0, fmt.Errorf("Invalid %s header: must be an integer between %d and %d.", IntelligenceHeader, MinIntelligence, MaxIntelligence)
+		}
+		return validateIntelligence(level)
+	}
+	return DefaultIntelligence, nil
+}
+
+func intelligenceFromJSON(value any) (int, error) {
+	number, ok := value.(float64)
+	if !ok || number != math.Trunc(number) {
+		return 0, fmt.Errorf("Invalid parameter: '%s.%s' must be an integer between %d and %d.", OptionsField, IntelligenceKey, MinIntelligence, MaxIntelligence)
+	}
+	return validateIntelligence(int(number))
+}
+
+func validateIntelligence(level int) (int, error) {
+	if level < MinIntelligence || level > MaxIntelligence {
+		return 0, fmt.Errorf("Invalid intelligence level %d: must be between %d and %d.", level, MinIntelligence, MaxIntelligence)
+	}
+	return level, nil
+}
+
+// HasVisualInput reports whether any message in the request carries an image
+// or file content part, for both chat completions and Responses payloads.
+func HasVisualInput(body map[string]any) bool {
+	for _, field := range []string{"messages", "input"} {
+		items, ok := body[field].([]any)
+		if !ok {
+			continue
+		}
+		for _, item := range items {
+			msg, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			parts, ok := msg["content"].([]any)
+			if !ok {
+				continue
+			}
+			for _, rawPart := range parts {
+				part, ok := rawPart.(map[string]any)
+				if !ok {
+					continue
+				}
+				if partType, _ := part["type"].(string); visualPartTypes[partType] {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// Rank expands the catalog into (model, effort) candidates and orders them by
+// how closely their normalized level matches target. Ties prefer multimodal
+// models, then the higher score, then the model name for determinism. When
+// requireMultimodal is set, text-only models are excluded entirely.
+func Rank(catalog []Model, target int, requireMultimodal bool) []Candidate {
+	maxScore := 0
+	for _, model := range catalog {
+		for _, score := range model.Scores {
+			if score > maxScore {
+				maxScore = score
+			}
+		}
+	}
+	if maxScore == 0 {
+		return nil
+	}
+
+	var candidates []Candidate
+	for _, model := range catalog {
+		if requireMultimodal && !model.Multimodal {
+			continue
+		}
+		for effort, score := range model.Scores {
+			candidates = append(candidates, Candidate{
+				Model:  model,
+				Effort: effort,
+				Score:  score,
+				Level:  normalize(score, maxScore),
+			})
+		}
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		a, b := candidates[i], candidates[j]
+		da, db := abs(a.Level-target), abs(b.Level-target)
+		if da != db {
+			return da < db
+		}
+		if a.Model.Multimodal != b.Model.Multimodal {
+			return a.Model.Multimodal
+		}
+		if a.Score != b.Score {
+			return a.Score > b.Score
+		}
+		if a.Model.Name != b.Model.Name {
+			return a.Model.Name < b.Model.Name
+		}
+		return a.Effort < b.Effort
+	})
+	return candidates
+}
+
+// ApplyEffort rewrites body so the selected candidate's reasoning setting is
+// in effect for the given endpoint path. The router-chosen setting wins over
+// any reasoning fields the client sent, so a caller asking for "auto" cannot
+// accidentally pin an expensive effort. Models without reasoning params, or
+// endpoints they do not describe, leave the body untouched.
+func ApplyEffort(body map[string]any, path string, candidate Candidate) {
+	reasoning := candidate.Model.Reasoning
+	if reasoning == nil {
+		return
+	}
+	endpoint, ok := reasoning.Params[path]
+	if !ok {
+		return
+	}
+
+	var fragment map[string]any
+	switch candidate.Effort {
+	case effortOff:
+		fragment = endpoint.Disable
+	case effortOn:
+		fragment = endpoint.Enable
+	default:
+		native := candidate.Effort
+		if mapped, ok := reasoning.EffortMap[candidate.Effort]; ok {
+			native = mapped
+		}
+		fragment = substituteEffort(endpoint.Enable, native).(map[string]any)
+	}
+	if fragment == nil {
+		return
+	}
+	mergeInto(body, fragment)
+}
+
+// substituteEffort returns a deep copy of value with every effortPlaceholder
+// string replaced by native.
+func substituteEffort(value any, native string) any {
+	switch v := value.(type) {
+	case string:
+		if v == effortPlaceholder {
+			return native
+		}
+		return v
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, inner := range v {
+			out[key] = substituteEffort(inner, native)
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, inner := range v {
+			out[i] = substituteEffort(inner, native)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// mergeInto deep-merges src into dst, recursing into nested objects present
+// on both sides and overwriting everything else.
+func mergeInto(dst, src map[string]any) {
+	for key, value := range src {
+		srcMap, srcIsMap := value.(map[string]any)
+		dstMap, dstIsMap := dst[key].(map[string]any)
+		if srcIsMap && dstIsMap {
+			mergeInto(dstMap, srcMap)
+			continue
+		}
+		if srcIsMap {
+			copied := make(map[string]any, len(srcMap))
+			mergeInto(copied, srcMap)
+			dst[key] = copied
+			continue
+		}
+		dst[key] = value
+	}
+}
+
+func normalize(score, maxScore int) int {
+	return int(math.Round(float64(score) * MaxIntelligence / float64(maxScore)))
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/autoroute/autoroute.go
+++ b/autoroute/autoroute.go
@@ -44,6 +44,17 @@ const (
 	// model whose reasoning is always enabled and has no effort knob.
 	effortOff = "off"
 	effortOn  = "on"
+
+	// effortHigh is the strongest client-facing effort key.
+	effortHigh = "high"
+
+	// clientEffortField is the OpenAI chat completions effort parameter and
+	// clientReasoningField/clientEffortKey its Responses API equivalent
+	// (reasoning.effort). Both are stripped so the router's choice governs
+	// every downstream reading of the request, not only the model call.
+	clientEffortField    = "reasoning_effort"
+	clientReasoningField = "reasoning"
+	clientEffortKey      = "effort"
 )
 
 // visualPartTypes are the content part types that carry images or files a
@@ -89,19 +100,6 @@ type Candidate struct {
 	// Level is Score normalized to the MinIntelligence..MaxIntelligence range
 	// against the highest score in the catalog.
 	Level int
-}
-
-// Decision records why a request landed on a given candidate.
-type Decision struct {
-	Candidate Candidate
-	// Target is the requested intelligence level after defaulting.
-	Target int
-	// Visual reports whether the request carried image or file parts, which
-	// restricts routing to multimodal models.
-	Visual bool
-	// Skipped counts higher-ranked candidates passed over because their model
-	// had no healthy backend.
-	Skipped int
 }
 
 // ParseIntelligence extracts the requested intelligence level. The body's
@@ -229,9 +227,18 @@ func Rank(catalog []Model, target int, requireMultimodal bool) []Candidate {
 // ApplyEffort rewrites body so the selected candidate's reasoning setting is
 // in effect for the given endpoint path. The router-chosen setting wins over
 // any reasoning fields the client sent, so a caller asking for "auto" cannot
-// accidentally pin an expensive effort. Models without reasoning params, or
-// endpoints they do not describe, leave the body untouched.
+// accidentally pin an expensive effort: the client's generic effort fields
+// are always removed, and the model's own fragment is merged in when it
+// describes the endpoint.
 func ApplyEffort(body map[string]any, path string, candidate Candidate) {
+	delete(body, clientEffortField)
+	if clientReasoning, ok := body[clientReasoningField].(map[string]any); ok {
+		delete(clientReasoning, clientEffortKey)
+		if len(clientReasoning) == 0 {
+			delete(body, clientReasoningField)
+		}
+	}
+
 	reasoning := candidate.Model.Reasoning
 	if reasoning == nil {
 		return
@@ -246,18 +253,25 @@ func ApplyEffort(body map[string]any, path string, candidate Candidate) {
 	case effortOff:
 		fragment = endpoint.Disable
 	case effortOn:
-		fragment = endpoint.Enable
+		// Always-on models have no effort knob, but their enable fragment
+		// may still carry a placeholder; fill it with the strongest effort.
+		fragment = substituteEffort(endpoint.Enable, nativeEffort(reasoning, effortHigh)).(map[string]any)
 	default:
-		native := candidate.Effort
-		if mapped, ok := reasoning.EffortMap[candidate.Effort]; ok {
-			native = mapped
-		}
-		fragment = substituteEffort(endpoint.Enable, native).(map[string]any)
+		fragment = substituteEffort(endpoint.Enable, nativeEffort(reasoning, candidate.Effort)).(map[string]any)
 	}
 	if fragment == nil {
 		return
 	}
 	mergeInto(body, fragment)
+}
+
+// nativeEffort translates a client-facing effort key to the model's native
+// value, or returns the key unchanged when the model has no mapping for it.
+func nativeEffort(reasoning *Reasoning, effort string) string {
+	if mapped, ok := reasoning.EffortMap[effort]; ok {
+		return mapped
+	}
+	return effort
 }
 
 // substituteEffort returns a deep copy of value with every effortPlaceholder

--- a/autoroute/autoroute_test.go
+++ b/autoroute/autoroute_test.go
@@ -263,6 +263,44 @@ func TestApplyEffortTopLevelField(t *testing.T) {
 	}
 }
 
+func TestApplyEffortStripsClientEffortFields(t *testing.T) {
+	// A model that takes effort through chat_template_kwargs must not leave
+	// the client's generic reasoning_effort / reasoning.effort behind, since
+	// downstream readers (input-token counting) would otherwise apply them.
+	body := map[string]any{
+		"reasoning_effort": "high",
+		"reasoning":        map[string]any{"effort": "high", "summary": "auto"},
+	}
+	ApplyEffort(body, "/v1/responses", Candidate{Model: Model{Reasoning: effortReasoning()}, Effort: "low"})
+	if _, ok := body["reasoning_effort"]; ok {
+		t.Fatal("client reasoning_effort must be removed")
+	}
+	if !reflect.DeepEqual(body["reasoning"], map[string]any{"summary": "auto"}) {
+		t.Fatalf("reasoning.effort must be removed while keeping siblings, got %v", body["reasoning"])
+	}
+
+	body = map[string]any{"reasoning": map[string]any{"effort": "high"}}
+	ApplyEffort(body, "/v1/responses", Candidate{Model: Model{Reasoning: effortReasoning()}, Effort: "low"})
+	if _, ok := body["reasoning"]; ok {
+		t.Fatalf("reasoning object left empty must be removed, got %v", body["reasoning"])
+	}
+}
+
+func TestApplyEffortOnSubstitutesPlaceholder(t *testing.T) {
+	reasoning := &Reasoning{
+		EffortMap: map[string]string{"high": "max"},
+		Params: map[string]EndpointParams{
+			"/v1/chat/completions": {Enable: map[string]any{"chat_template_kwargs": map[string]any{"reasoning_effort": effortPlaceholder}}},
+		},
+	}
+	body := map[string]any{}
+	ApplyEffort(body, "/v1/chat/completions", Candidate{Model: Model{Reasoning: reasoning}, Effort: effortOn})
+	kwargs := body["chat_template_kwargs"].(map[string]any)
+	if kwargs["reasoning_effort"] != "max" {
+		t.Fatalf("always-on model must not leak the placeholder, got %v", kwargs["reasoning_effort"])
+	}
+}
+
 func TestApplyEffortOffUsesDisableFragment(t *testing.T) {
 	reasoning := &Reasoning{Params: map[string]EndpointParams{
 		"/v1/chat/completions": {
@@ -285,15 +323,19 @@ func TestApplyEffortOffUsesDisableFragment(t *testing.T) {
 	}
 }
 
-func TestApplyEffortNoopWithoutParams(t *testing.T) {
-	body := map[string]any{"reasoning_effort": "high"}
+func TestApplyEffortWithoutParamsOnlyStripsClientEffort(t *testing.T) {
+	body := map[string]any{"reasoning_effort": "high", "messages": []any{}}
 	ApplyEffort(body, "/v1/chat/completions", Candidate{Model: Model{Name: "no-reasoning"}, Effort: effortOff})
-	if body["reasoning_effort"] != "high" {
-		t.Fatal("model without reasoning params must not touch the body")
+	if _, ok := body["reasoning_effort"]; ok {
+		t.Fatal("client effort must be stripped even when the model has no reasoning params")
+	}
+	if _, ok := body["messages"]; !ok || len(body) != 1 {
+		t.Fatalf("nothing else may change for a model without reasoning params: %v", body)
 	}
 
+	body = map[string]any{"messages": []any{}}
 	ApplyEffort(body, "/v1/embeddings", Candidate{Model: Model{Reasoning: effortReasoning()}, Effort: "low"})
 	if len(body) != 1 {
-		t.Fatalf("unknown endpoint must not touch the body: %v", body)
+		t.Fatalf("unknown endpoint must not add fragments: %v", body)
 	}
 }

--- a/autoroute/autoroute_test.go
+++ b/autoroute/autoroute_test.go
@@ -1,0 +1,299 @@
+package autoroute
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestParseIntelligence(t *testing.T) {
+	cases := []struct {
+		name    string
+		header  string
+		body    map[string]any
+		want    int
+		wantErr bool
+	}{
+		{name: "default when nothing set", body: map[string]any{}, want: DefaultIntelligence},
+		{name: "header", header: "72", body: map[string]any{}, want: 72},
+		{name: "header with whitespace", header: " 30 ", body: map[string]any{}, want: 30},
+		{name: "header bounds", header: "100", body: map[string]any{}, want: 100},
+		{name: "header over max", header: "101", body: map[string]any{}, wantErr: true},
+		{name: "header negative", header: "-1", body: map[string]any{}, wantErr: true},
+		{name: "header not a number", header: "high", body: map[string]any{}, wantErr: true},
+		{
+			name:   "body object wins over header",
+			header: "10",
+			body:   map[string]any{OptionsField: map[string]any{IntelligenceKey: float64(90)}},
+			want:   90,
+		},
+		{
+			name:    "body fractional rejected",
+			body:    map[string]any{OptionsField: map[string]any{IntelligenceKey: 42.5}},
+			wantErr: true,
+		},
+		{
+			name:    "body string rejected",
+			body:    map[string]any{OptionsField: map[string]any{IntelligenceKey: "42"}},
+			wantErr: true,
+		},
+		{
+			name:    "body out of range rejected",
+			body:    map[string]any{OptionsField: map[string]any{IntelligenceKey: float64(250)}},
+			wantErr: true,
+		},
+		{
+			name:   "legacy array ignored, header used",
+			header: "25",
+			body:   map[string]any{OptionsField: []any{map[string]any{"model": "old"}}},
+			want:   25,
+		},
+		{
+			name: "object without intelligence key falls back to default",
+			body: map[string]any{OptionsField: map[string]any{"other": true}},
+			want: DefaultIntelligence,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			header := http.Header{}
+			if tc.header != "" {
+				header.Set(IntelligenceHeader, tc.header)
+			}
+			got, err := ParseIntelligence(header, tc.body)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got level %d", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("level = %d, want %d", got, tc.want)
+			}
+			if _, present := tc.body[OptionsField]; present {
+				t.Fatalf("%s must be stripped from the body", OptionsField)
+			}
+		})
+	}
+}
+
+func TestHasVisualInput(t *testing.T) {
+	cases := []struct {
+		name string
+		body map[string]any
+		want bool
+	}{
+		{name: "string content", body: map[string]any{"messages": []any{map[string]any{"role": "user", "content": "hi"}}}},
+		{name: "text parts only", body: map[string]any{"messages": []any{map[string]any{"content": []any{map[string]any{"type": "text", "text": "hi"}}}}}},
+		{name: "chat image", body: map[string]any{"messages": []any{map[string]any{"content": []any{map[string]any{"type": "image_url"}}}}}, want: true},
+		{name: "chat file", body: map[string]any{"messages": []any{map[string]any{"content": []any{map[string]any{"type": "file"}}}}}, want: true},
+		{name: "responses image", body: map[string]any{"input": []any{map[string]any{"content": []any{map[string]any{"type": "input_image"}}}}}, want: true},
+		{name: "responses file", body: map[string]any{"input": []any{map[string]any{"content": []any{map[string]any{"type": "input_file"}}}}}, want: true},
+		{name: "responses string input", body: map[string]any{"input": "hello"}},
+		{name: "image in earlier turn", body: map[string]any{"messages": []any{
+			map[string]any{"content": []any{map[string]any{"type": "image_url"}}},
+			map[string]any{"content": "and now text"},
+		}}, want: true},
+		{name: "empty body", body: map[string]any{}},
+	}
+	for _, tc := range cases {
+		if got := HasVisualInput(tc.body); got != tc.want {
+			t.Errorf("%s: HasVisualInput = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func testCatalog() []Model {
+	return []Model{
+		{Name: "smart-text", Scores: map[string]int{"low": 39, "medium": 42, "high": 45}},
+		{Name: "smart-vision", Multimodal: true, Scores: map[string]int{"on": 44}},
+		{Name: "fast-vision", Multimodal: true, Scores: map[string]int{"low": 36, "medium": 39, "high": 42}},
+		{Name: "tiny-text", Scores: map[string]int{"off": 8}},
+		{Name: "toggle-vision", Multimodal: true, Scores: map[string]int{"off": 14, "on": 15}},
+	}
+}
+
+func TestRankOrdersByDistanceToTarget(t *testing.T) {
+	// Catalog max is 45, so normalized levels are round(score*100/45).
+	ranked := Rank(testCatalog(), 100, false)
+	if len(ranked) == 0 {
+		t.Fatal("expected candidates")
+	}
+	if top := ranked[0]; top.Model.Name != "smart-text" || top.Effort != "high" || top.Level != 100 {
+		t.Fatalf("top candidate for target 100 = %s/%s (level %d), want smart-text/high (100)", top.Model.Name, top.Effort, top.Level)
+	}
+
+	ranked = Rank(testCatalog(), 0, false)
+	if top := ranked[0]; top.Model.Name != "tiny-text" || top.Effort != "off" {
+		t.Fatalf("top candidate for target 0 = %s/%s, want tiny-text/off", top.Model.Name, top.Effort)
+	}
+
+	// Every candidate must be no further from target than the one after it.
+	for target := MinIntelligence; target <= MaxIntelligence; target += 10 {
+		ranked = Rank(testCatalog(), target, false)
+		for i := 1; i < len(ranked); i++ {
+			if abs(ranked[i-1].Level-target) > abs(ranked[i].Level-target) {
+				t.Fatalf("target %d: candidate %d is further than candidate %d", target, i-1, i)
+			}
+		}
+	}
+}
+
+func TestRankPrefersMultimodalOnTies(t *testing.T) {
+	// smart-text/medium (42) and fast-vision/high (42) share a score; the
+	// multimodal model must sort first.
+	ranked := Rank(testCatalog(), normalize(42, 45), false)
+	if ranked[0].Model.Name != "fast-vision" || ranked[0].Effort != "high" {
+		t.Fatalf("expected fast-vision/high first on tie, got %s/%s", ranked[0].Model.Name, ranked[0].Effort)
+	}
+	if ranked[1].Model.Name != "smart-text" || ranked[1].Effort != "medium" {
+		t.Fatalf("expected smart-text/medium second on tie, got %s/%s", ranked[1].Model.Name, ranked[1].Effort)
+	}
+}
+
+func TestRankRequireMultimodalExcludesTextOnlyModels(t *testing.T) {
+	ranked := Rank(testCatalog(), 100, true)
+	for _, c := range ranked {
+		if !c.Model.Multimodal {
+			t.Fatalf("text-only model %s ranked despite requireMultimodal", c.Model.Name)
+		}
+	}
+	if top := ranked[0]; top.Model.Name != "smart-vision" {
+		t.Fatalf("top multimodal candidate for target 100 = %s, want smart-vision", top.Model.Name)
+	}
+	if len(ranked) != 6 {
+		t.Fatalf("expected 6 multimodal candidates, got %d", len(ranked))
+	}
+}
+
+func TestRankIsDeterministic(t *testing.T) {
+	first := Rank(testCatalog(), 50, false)
+	for i := 0; i < 20; i++ {
+		again := Rank(testCatalog(), 50, false)
+		if !reflect.DeepEqual(first, again) {
+			t.Fatal("Rank produced a different order on repeated calls")
+		}
+	}
+}
+
+func TestRankEmptyCatalog(t *testing.T) {
+	if got := Rank(nil, 50, false); got != nil {
+		t.Fatalf("expected nil for empty catalog, got %v", got)
+	}
+	if got := Rank([]Model{{Name: "unscored", Scores: map[string]int{}}}, 50, false); got != nil {
+		t.Fatalf("expected nil for catalog without scores, got %v", got)
+	}
+}
+
+func effortReasoning() *Reasoning {
+	return &Reasoning{
+		EffortMap: map[string]string{"low": "low", "medium": "high", "high": "max"},
+		Params: map[string]EndpointParams{
+			"/v1/chat/completions": {
+				Enable: map[string]any{"chat_template_kwargs": map[string]any{"reasoning_effort": effortPlaceholder, "clear_thinking": false}},
+			},
+			"/v1/responses": {
+				Enable: map[string]any{"chat_template_kwargs": map[string]any{"reasoning_effort": effortPlaceholder}},
+			},
+		},
+	}
+}
+
+func TestApplyEffortSubstitutesMappedEffort(t *testing.T) {
+	body := map[string]any{"model": "auto", "messages": []any{}}
+	ApplyEffort(body, "/v1/chat/completions", Candidate{
+		Model:  Model{Name: "m", Reasoning: effortReasoning()},
+		Effort: "medium",
+	})
+	want := map[string]any{"reasoning_effort": "high", "clear_thinking": false}
+	if got := body["chat_template_kwargs"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("chat_template_kwargs = %v, want %v", got, want)
+	}
+	if _, ok := body["messages"]; !ok {
+		t.Fatal("unrelated body fields must be preserved")
+	}
+}
+
+func TestApplyEffortDoesNotMutateSharedFragment(t *testing.T) {
+	reasoning := effortReasoning()
+	ApplyEffort(map[string]any{}, "/v1/responses", Candidate{Model: Model{Reasoning: reasoning}, Effort: "high"})
+	kwargs := reasoning.Params["/v1/responses"].Enable["chat_template_kwargs"].(map[string]any)
+	if kwargs["reasoning_effort"] != effortPlaceholder {
+		t.Fatalf("catalog fragment was mutated: %v", kwargs)
+	}
+}
+
+func TestApplyEffortOverridesClientReasoningFields(t *testing.T) {
+	body := map[string]any{
+		"chat_template_kwargs": map[string]any{"reasoning_effort": "max", "enable_thinking": true, "custom": "kept"},
+	}
+	ApplyEffort(body, "/v1/chat/completions", Candidate{
+		Model:  Model{Reasoning: effortReasoning()},
+		Effort: "low",
+	})
+	kwargs := body["chat_template_kwargs"].(map[string]any)
+	if kwargs["reasoning_effort"] != "low" {
+		t.Fatalf("router effort must win over client effort, got %v", kwargs["reasoning_effort"])
+	}
+	if kwargs["custom"] != "kept" || kwargs["enable_thinking"] != true {
+		t.Fatalf("sibling kwargs must survive the merge: %v", kwargs)
+	}
+}
+
+func TestApplyEffortTopLevelField(t *testing.T) {
+	reasoning := &Reasoning{Params: map[string]EndpointParams{
+		"/v1/chat/completions": {Enable: map[string]any{"reasoning_effort": effortPlaceholder}},
+		"/v1/responses":        {Enable: map[string]any{"reasoning": map[string]any{"effort": effortPlaceholder}}},
+	}}
+	body := map[string]any{"reasoning_effort": "high"}
+	ApplyEffort(body, "/v1/chat/completions", Candidate{Model: Model{Reasoning: reasoning}, Effort: "low"})
+	if body["reasoning_effort"] != "low" {
+		t.Fatalf("reasoning_effort = %v, want low", body["reasoning_effort"])
+	}
+
+	body = map[string]any{"reasoning": map[string]any{"effort": "high", "summary": "auto"}}
+	ApplyEffort(body, "/v1/responses", Candidate{Model: Model{Reasoning: reasoning}, Effort: "medium"})
+	want := map[string]any{"effort": "medium", "summary": "auto"}
+	if !reflect.DeepEqual(body["reasoning"], want) {
+		t.Fatalf("reasoning = %v, want %v", body["reasoning"], want)
+	}
+}
+
+func TestApplyEffortOffUsesDisableFragment(t *testing.T) {
+	reasoning := &Reasoning{Params: map[string]EndpointParams{
+		"/v1/chat/completions": {
+			Enable:  map[string]any{"chat_template_kwargs": map[string]any{"enable_thinking": true}},
+			Disable: map[string]any{"chat_template_kwargs": map[string]any{"enable_thinking": false}},
+		},
+	}}
+	body := map[string]any{"chat_template_kwargs": map[string]any{"enable_thinking": true}}
+	ApplyEffort(body, "/v1/chat/completions", Candidate{Model: Model{Reasoning: reasoning}, Effort: effortOff})
+	kwargs := body["chat_template_kwargs"].(map[string]any)
+	if kwargs["enable_thinking"] != false {
+		t.Fatalf("enable_thinking = %v, want false", kwargs["enable_thinking"])
+	}
+
+	body = map[string]any{}
+	ApplyEffort(body, "/v1/chat/completions", Candidate{Model: Model{Reasoning: reasoning}, Effort: effortOn})
+	kwargs = body["chat_template_kwargs"].(map[string]any)
+	if kwargs["enable_thinking"] != true {
+		t.Fatalf("enable_thinking = %v, want true", kwargs["enable_thinking"])
+	}
+}
+
+func TestApplyEffortNoopWithoutParams(t *testing.T) {
+	body := map[string]any{"reasoning_effort": "high"}
+	ApplyEffort(body, "/v1/chat/completions", Candidate{Model: Model{Name: "no-reasoning"}, Effort: effortOff})
+	if body["reasoning_effort"] != "high" {
+		t.Fatal("model without reasoning params must not touch the body")
+	}
+
+	ApplyEffort(body, "/v1/embeddings", Candidate{Model: Model{Reasoning: effortReasoning()}, Effort: "low"})
+	if len(body) != 1 {
+		t.Fatalf("unknown endpoint must not touch the body: %v", body)
+	}
+}

--- a/input_tokens.go
+++ b/input_tokens.go
@@ -42,6 +42,21 @@ func isInputTokensPath(path string) bool {
 	return path == chatInputTokensPath || path == responsesInputTokensPath
 }
 
+// inputTokensCompletionPath maps an input-token counting route to the
+// completion endpoint whose request shape it counts, so model-specific
+// request parameters (such as reasoning effort) are resolved the same way
+// they would be for the completion itself.
+func inputTokensCompletionPath(path string) string {
+	switch path {
+	case chatInputTokensPath:
+		return "/v1/chat/completions"
+	case responsesInputTokensPath:
+		return "/v1/responses"
+	default:
+		return path
+	}
+}
+
 func handleInputTokens(
 	w http.ResponseWriter,
 	r *http.Request,

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/tinfoilsh/confidential-model-router/autoroute"
 	"github.com/tinfoilsh/confidential-model-router/cacheroute"
 	"github.com/tinfoilsh/confidential-model-router/manager"
 	"github.com/tinfoilsh/confidential-model-router/toolruntime"
@@ -352,77 +353,61 @@ func ensureStreamingUsageOptions(body map[string]any, headers http.Header) {
 	}
 }
 
-// autoModelParamReservedKeys lists body fields that a per-candidate param block
-// must never overwrite when merged, so client-supplied auto params cannot
-// clobber the routing model, conversation, streaming, or tool/option blobs.
-var autoModelParamReservedKeys = map[string]bool{
-	"model":                  true,
-	"messages":               true,
-	"input":                  true,
-	"stream":                 true,
-	"stream_options":         true,
-	"tools":                  true,
-	"tool_choice":            true,
-	"web_search_options":     true,
-	"code_execution_options": true,
-	"pii_check_options":      true,
+// autoRouteCatalog supplies the models the auto router may choose between and
+// their current health. Implemented by *manager.EnclaveManager.
+type autoRouteCatalog interface {
+	AutoRouteCatalog() []autoroute.Model
+	HasHealthyEnclave(modelName string) bool
 }
 
-// preferredModelResolver resolves an ordered candidate list to a concrete
-// model name, preferring healthy backends. Implemented by
-// *manager.EnclaveManager.
-type preferredModelResolver interface {
-	ResolvePreferredModel(candidates []string) string
-}
-
-// resolveAutoModel consumes the router-only auto_model_options blob, picks the
-// first candidate whose model currently has a healthy enclave, shallow-merges
-// that candidate's params into body (excluding reserved keys), rewrites
-// body["model"], and strips the blob. It returns the resolved model name.
-func resolveAutoModel(resolver preferredModelResolver, body map[string]any) (string, error) {
-	raw, ok := body["auto_model_options"].([]any)
-	delete(body, "auto_model_options")
-	if !ok || len(raw) == 0 {
-		return "", fmt.Errorf("Missing auto model choices: 'auto_model_options' is required when model is 'auto'.")
+// resolveAutoModel replaces model "auto" with a concrete model and reasoning
+// effort. The caller's requested intelligence level (body auto_model_options,
+// then the X-Tinfoil-Intelligence header, then the default) is matched against
+// the per-effort scores the control plane publishes; candidates are walked in
+// order of fit until one has a healthy enclave, so an outage on the best match
+// degrades to the next-best rather than failing. Requests carrying images or
+// files only consider multimodal models. The chosen effort is written into
+// body using the model's own reasoning parameters, overriding any effort the
+// client sent, and body["model"] is rewritten. When nothing is healthy the
+// best-fit candidate is still returned so normal serving surfaces the error.
+func resolveAutoModel(catalog autoRouteCatalog, header http.Header, path string, body map[string]any) (string, error) {
+	target, err := autoroute.ParseIntelligence(header, body)
+	if err != nil {
+		return "", err
 	}
 
-	names := make([]string, 0, len(raw))
-	paramsByModel := make(map[string]map[string]any, len(raw))
-	for _, entry := range raw {
-		opt, ok := entry.(map[string]any)
-		if !ok {
-			continue
+	visual := autoroute.HasVisualInput(body)
+	ranked := autoroute.Rank(catalog.AutoRouteCatalog(), target, visual)
+	if len(ranked) == 0 {
+		if visual {
+			return "", fmt.Errorf("Model 'auto' has no multimodal model available for image or file input.")
 		}
-		name, ok := opt["model"].(string)
-		if !ok || name == "" {
-			continue
-		}
-		names = append(names, name)
-		if _, seen := paramsByModel[name]; seen {
-			continue
-		}
-		if params, ok := opt["params"].(map[string]any); ok {
-			paramsByModel[name] = params
+		return "", fmt.Errorf("Model 'auto' is not available: no models publish intelligence scores.")
+	}
+
+	chosen, healthy := ranked[0], false
+	for i, candidate := range ranked {
+		if catalog.HasHealthyEnclave(candidate.Model.Name) {
+			chosen, healthy = candidate, true
+			if i > 0 {
+				manager.AutoRouteFallbacksTotal.WithLabelValues(chosen.Model.Name).Inc()
+			}
+			break
 		}
 	}
 
-	if len(names) == 0 {
-		return "", fmt.Errorf("Missing auto model choices: 'auto_model_options' has no valid model entries.")
-	}
-
-	resolved := resolver.ResolvePreferredModel(names)
-	if resolved == "" {
-		return "", fmt.Errorf("Missing auto model choices: no valid model could be resolved.")
-	}
-
-	for key, value := range paramsByModel[resolved] {
-		if autoModelParamReservedKeys[key] {
-			continue
-		}
-		body[key] = value
-	}
-	body["model"] = resolved
-	return resolved, nil
+	autoroute.ApplyEffort(body, path, chosen)
+	body["model"] = chosen.Model.Name
+	manager.AutoRouteDecisionsTotal.WithLabelValues(chosen.Model.Name, chosen.Effort).Inc()
+	log.WithFields(log.Fields{
+		"target":  target,
+		"visual":  visual,
+		"model":   chosen.Model.Name,
+		"effort":  chosen.Effort,
+		"level":   chosen.Level,
+		"healthy": healthy,
+	}).Debug("resolved auto model")
+	return chosen.Model.Name, nil
 }
 
 func main() {
@@ -537,7 +522,7 @@ func main() {
 				return em.DoModelRequest(ctx, modelName, path, body, headers)
 			}
 			handleInputTokens(w, r, apiKey, modelName, func(body map[string]any) (string, error) {
-				return resolveAutoModel(em, body)
+				return resolveAutoModel(em, r.Header, inputTokensCompletionPath(r.URL.Path), body)
 			}, dispatch)
 			return
 		}
@@ -731,15 +716,15 @@ func main() {
 					return
 				}
 
-				// "auto" is a router-side sentinel: the candidate models and
-				// their per-model param blocks travel in the router-only
-				// auto_model_options blob. Resolve it to a concrete, healthy
-				// model and merge that model's params before any downstream
-				// logic (tool detection, rate limiting, serving) runs.
+				// "auto" is a router-side sentinel: the caller states an
+				// intelligence level and the router picks a concrete,
+				// healthy model and reasoning effort for it before any
+				// downstream logic (tool detection, rate limiting, serving)
+				// runs.
 				if modelName == "auto" {
-					resolved, mergeErr := resolveAutoModel(em, body)
-					if mergeErr != nil {
-						jsonError(w, mergeErr.Error(), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
+					resolved, resolveErr := resolveAutoModel(em, r.Header, r.URL.Path, body)
+					if resolveErr != nil {
+						jsonError(w, resolveErr.Error(), manager.ErrTypeInvalidRequest, http.StatusBadRequest)
 						return
 					}
 					modelName = resolved

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -841,6 +842,47 @@ func TestResolveAutoModel_EmptyCatalog(t *testing.T) {
 	catalog := fakeCatalog{}
 	if _, err := resolveAutoModel(catalog, http.Header{}, "/v1/chat/completions", map[string]any{"model": "auto"}); err == nil {
 		t.Fatal("expected error when no model publishes intelligence scores")
+	}
+}
+
+// The Responses input-token route derives chat_template_kwargs from the
+// client's reasoning.effort; for model "auto" the router's chosen effort must
+// be what reaches the tokenizer, not the client's.
+func TestHandleInputTokens_AutoUsesRouterEffort(t *testing.T) {
+	catalog := fakeCatalog{models: autoTestCatalog(), healthy: allHealthy(autoTestCatalog())}
+	var dispatchedModel string
+	var dispatchedBody map[string]any
+	dispatch := func(_ context.Context, model, _ string, body []byte, _ http.Header) (*http.Response, error) {
+		dispatchedModel = model
+		if err := json.Unmarshal(body, &dispatchedBody); err != nil {
+			t.Fatal(err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"count":5}`)),
+		}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, responsesInputTokensPath, strings.NewReader(`{
+		"model":"auto",
+		"reasoning":{"effort":"high"},
+		"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}]
+	}`))
+	req.Header.Set(autoroute.IntelligenceHeader, "0")
+	rec := httptest.NewRecorder()
+	handleInputTokens(rec, req, "secret-key", "", func(body map[string]any) (string, error) {
+		return resolveAutoModel(catalog, req.Header, inputTokensCompletionPath(req.URL.Path), body)
+	}, dispatch)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if dispatchedModel != "tiny-text" || dispatchedBody["model"] != "tiny-text" {
+		t.Fatalf("expected tokenization against tiny-text, got %q / %v", dispatchedModel, dispatchedBody["model"])
+	}
+	if kwargs, ok := dispatchedBody["chat_template_kwargs"]; ok {
+		t.Fatalf("client reasoning.effort must not reach the tokenizer for a model without reasoning, got %v", kwargs)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tinfoilsh/confidential-model-router/autoroute"
 	"github.com/tinfoilsh/confidential-model-router/manager"
 	"github.com/tinfoilsh/confidential-model-router/toolruntime"
 )
@@ -596,112 +597,250 @@ func TestDetectToolProfiles(t *testing.T) {
 	}
 }
 
-// fakeResolver picks the first candidate present in healthy, else "".
-type fakeResolver struct {
+// fakeCatalog is an autoRouteCatalog backed by fixed models and health.
+type fakeCatalog struct {
+	models  []autoroute.Model
 	healthy map[string]bool
 }
 
-func (f fakeResolver) ResolvePreferredModel(candidates []string) string {
-	var first string
-	for _, c := range candidates {
-		if c == "" {
-			continue
-		}
-		if first == "" {
-			first = c
-		}
-		if f.healthy[c] {
-			return c
-		}
+func (f fakeCatalog) AutoRouteCatalog() []autoroute.Model { return f.models }
+func (f fakeCatalog) HasHealthyEnclave(name string) bool  { return f.healthy[name] }
+
+func autoTestReasoning() *autoroute.Reasoning {
+	return &autoroute.Reasoning{
+		EffortMap: map[string]string{"low": "low", "medium": "high", "high": "max"},
+		Params: map[string]autoroute.EndpointParams{
+			"/v1/chat/completions": {
+				Enable: map[string]any{"chat_template_kwargs": map[string]any{"reasoning_effort": "$EFFORT"}},
+			},
+			"/v1/responses": {
+				Enable: map[string]any{"chat_template_kwargs": map[string]any{"reasoning_effort": "$EFFORT"}},
+			},
+		},
 	}
-	return first
 }
 
-func TestResolveAutoModel(t *testing.T) {
-	resolver := fakeResolver{healthy: map[string]bool{"kimi-k2-6": true}}
+// autoTestCatalog mirrors the shape of the production catalog: a strong
+// text-only model, a strong always-on multimodal model, a mid multimodal model
+// with efforts, and a tiny text-only model with no reasoning.
+func autoTestCatalog() []autoroute.Model {
+	return []autoroute.Model{
+		{Name: "smart-text", Scores: map[string]int{"low": 39, "medium": 42, "high": 45}, Reasoning: autoTestReasoning()},
+		{Name: "smart-vision", Multimodal: true, Scores: map[string]int{"on": 44}},
+		{Name: "fast-vision", Multimodal: true, Scores: map[string]int{"low": 36, "medium": 39, "high": 42}, Reasoning: autoTestReasoning()},
+		{Name: "tiny-text", Scores: map[string]int{"off": 8}},
+	}
+}
 
+func allHealthy(models []autoroute.Model) map[string]bool {
+	healthy := make(map[string]bool, len(models))
+	for _, m := range models {
+		healthy[m.Name] = true
+	}
+	return healthy
+}
+
+func TestResolveAutoModel_HeaderPicksModelAndEffort(t *testing.T) {
+	catalog := fakeCatalog{models: autoTestCatalog(), healthy: allHealthy(autoTestCatalog())}
+	header := http.Header{}
+	header.Set(autoroute.IntelligenceHeader, "100")
 	body := map[string]any{
 		"model":    "auto",
 		"messages": []any{map[string]any{"role": "user", "content": "hi"}},
 		"stream":   true,
-		"auto_model_options": []any{
-			map[string]any{
-				"model":  "glm-5-2",
-				"params": map[string]any{"chat_template_kwargs": map[string]any{"enable_thinking": true}},
-			},
-			map[string]any{
-				"model": "kimi-k2-6",
-				"params": map[string]any{
-					"reasoning_effort": "high",
-					// Reserved keys must never be overwritten by a candidate.
-					"model":    "evil",
-					"messages": "evil",
-				},
-			},
-		},
 	}
 
-	resolved, err := resolveAutoModel(resolver, body)
+	resolved, err := resolveAutoModel(catalog, header, "/v1/chat/completions", body)
 	if err != nil {
 		t.Fatalf("resolveAutoModel: %v", err)
 	}
-	if resolved != "kimi-k2-6" {
-		t.Fatalf("resolved = %q, want kimi-k2-6", resolved)
+	if resolved != "smart-text" || body["model"] != "smart-text" {
+		t.Fatalf("resolved = %q, body[model] = %v, want smart-text", resolved, body["model"])
 	}
-	if body["model"] != "kimi-k2-6" {
-		t.Fatalf("body[model] = %v, want kimi-k2-6", body["model"])
+	kwargs, _ := body["chat_template_kwargs"].(map[string]any)
+	if kwargs["reasoning_effort"] != "max" {
+		t.Fatalf("expected native effort max for level 100, got %v", kwargs)
 	}
-	if body["reasoning_effort"] != "high" {
-		t.Fatalf("expected merged reasoning_effort=high, got %v", body["reasoning_effort"])
-	}
-	if _, ok := body["auto_model_options"]; ok {
-		t.Fatal("auto_model_options should be stripped from body")
-	}
-	if msgs, ok := body["messages"].([]any); !ok || len(msgs) != 1 {
-		t.Fatalf("reserved messages field was clobbered: %v", body["messages"])
-	}
-	// glm-5-2 (skipped) params must not leak into the body.
-	if _, ok := body["chat_template_kwargs"]; ok {
-		t.Fatal("non-selected candidate params leaked into body")
+	if msgs, ok := body["messages"].([]any); !ok || len(msgs) != 1 || body["stream"] != true {
+		t.Fatalf("unrelated body fields were clobbered: %v", body)
 	}
 }
 
-func TestResolveAutoModel_DuplicateModelKeepsFirstParams(t *testing.T) {
-	resolver := fakeResolver{}
+func TestResolveAutoModel_BodyOptionsWinOverHeader(t *testing.T) {
+	catalog := fakeCatalog{models: autoTestCatalog(), healthy: allHealthy(autoTestCatalog())}
+	header := http.Header{}
+	header.Set(autoroute.IntelligenceHeader, "100")
+	body := map[string]any{
+		"model":              "auto",
+		"auto_model_options": map[string]any{"intelligence": float64(0)},
+	}
+
+	resolved, err := resolveAutoModel(catalog, header, "/v1/chat/completions", body)
+	if err != nil {
+		t.Fatalf("resolveAutoModel: %v", err)
+	}
+	if resolved != "tiny-text" {
+		t.Fatalf("resolved = %q, want tiny-text for level 0", resolved)
+	}
+	if _, ok := body["auto_model_options"]; ok {
+		t.Fatal("auto_model_options must be stripped from the body")
+	}
+}
+
+func TestResolveAutoModel_DefaultLevel(t *testing.T) {
+	catalog := fakeCatalog{models: autoTestCatalog(), healthy: allHealthy(autoTestCatalog())}
+	body := map[string]any{"model": "auto"}
+
+	resolved, err := resolveAutoModel(catalog, http.Header{}, "/v1/chat/completions", body)
+	if err != nil {
+		t.Fatalf("resolveAutoModel: %v", err)
+	}
+	// Catalog max is 45, so fast-vision/low normalizes to 80 and tiny-text/off
+	// to 18; the default target of 50 is nearer the former.
+	if resolved != "fast-vision" {
+		t.Fatalf("resolved = %q, want fast-vision for the default level", resolved)
+	}
+	kwargs, _ := body["chat_template_kwargs"].(map[string]any)
+	if kwargs["reasoning_effort"] != "low" {
+		t.Fatalf("expected effort low, got %v", kwargs)
+	}
+}
+
+func TestResolveAutoModel_FallsBackWhenBestFitUnhealthy(t *testing.T) {
+	models := autoTestCatalog()
+	healthy := allHealthy(models)
+	healthy["smart-text"] = false
+	catalog := fakeCatalog{models: models, healthy: healthy}
+	header := http.Header{}
+	header.Set(autoroute.IntelligenceHeader, "100")
+	body := map[string]any{"model": "auto"}
+
+	resolved, err := resolveAutoModel(catalog, header, "/v1/chat/completions", body)
+	if err != nil {
+		t.Fatalf("resolveAutoModel: %v", err)
+	}
+	if resolved != "smart-vision" {
+		t.Fatalf("resolved = %q, want smart-vision as next best when smart-text is down", resolved)
+	}
+	if _, ok := body["chat_template_kwargs"]; ok {
+		t.Fatal("model without reasoning params must not receive kwargs")
+	}
+}
+
+func TestResolveAutoModel_NothingHealthyStillResolvesBestFit(t *testing.T) {
+	catalog := fakeCatalog{models: autoTestCatalog(), healthy: map[string]bool{}}
+	header := http.Header{}
+	header.Set(autoroute.IntelligenceHeader, "100")
+	body := map[string]any{"model": "auto"}
+
+	resolved, err := resolveAutoModel(catalog, header, "/v1/chat/completions", body)
+	if err != nil {
+		t.Fatalf("resolveAutoModel: %v", err)
+	}
+	if resolved != "smart-text" {
+		t.Fatalf("resolved = %q, want best-fit smart-text so serving surfaces the outage", resolved)
+	}
+}
+
+func TestResolveAutoModel_VisualInputRequiresMultimodal(t *testing.T) {
+	catalog := fakeCatalog{models: autoTestCatalog(), healthy: allHealthy(autoTestCatalog())}
+	header := http.Header{}
+	header.Set(autoroute.IntelligenceHeader, "100")
+	body := map[string]any{
+		"model": "auto",
+		"messages": []any{map[string]any{"role": "user", "content": []any{
+			map[string]any{"type": "text", "text": "what is this?"},
+			map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:image/png;base64,AA=="}},
+		}}},
+	}
+
+	resolved, err := resolveAutoModel(catalog, header, "/v1/chat/completions", body)
+	if err != nil {
+		t.Fatalf("resolveAutoModel: %v", err)
+	}
+	if resolved != "smart-vision" {
+		t.Fatalf("resolved = %q, want smart-vision (text-only smart-text must be excluded)", resolved)
+	}
+}
+
+func TestResolveAutoModel_VisualInputWithoutMultimodalModels(t *testing.T) {
+	models := []autoroute.Model{{Name: "text-only", Scores: map[string]int{"off": 20}}}
+	catalog := fakeCatalog{models: models, healthy: allHealthy(models)}
+	body := map[string]any{
+		"model": "auto",
+		"input": []any{map[string]any{"role": "user", "content": []any{map[string]any{"type": "input_image", "image_url": "https://x/y.png"}}}},
+	}
+
+	if _, err := resolveAutoModel(catalog, http.Header{}, "/v1/responses", body); err == nil {
+		t.Fatal("expected error when an image request has no multimodal candidates")
+	}
+}
+
+func TestResolveAutoModel_RouterEffortOverridesClient(t *testing.T) {
+	catalog := fakeCatalog{models: autoTestCatalog(), healthy: allHealthy(autoTestCatalog())}
+	header := http.Header{}
+	header.Set(autoroute.IntelligenceHeader, "100")
+	body := map[string]any{
+		"model":                "auto",
+		"chat_template_kwargs": map[string]any{"reasoning_effort": "low", "keep": "me"},
+	}
+
+	if _, err := resolveAutoModel(catalog, header, "/v1/responses", body); err != nil {
+		t.Fatalf("resolveAutoModel: %v", err)
+	}
+	kwargs, _ := body["chat_template_kwargs"].(map[string]any)
+	if kwargs["reasoning_effort"] != "max" || kwargs["keep"] != "me" {
+		t.Fatalf("router effort must win and siblings survive, got %v", kwargs)
+	}
+}
+
+func TestResolveAutoModel_InvalidLevel(t *testing.T) {
+	catalog := fakeCatalog{models: autoTestCatalog(), healthy: allHealthy(autoTestCatalog())}
+	header := http.Header{}
+	header.Set(autoroute.IntelligenceHeader, "101")
+	if _, err := resolveAutoModel(catalog, header, "/v1/chat/completions", map[string]any{"model": "auto"}); err == nil {
+		t.Fatal("expected error for out-of-range intelligence header")
+	}
+
+	body := map[string]any{"model": "auto", "auto_model_options": map[string]any{"intelligence": "high"}}
+	if _, err := resolveAutoModel(catalog, http.Header{}, "/v1/chat/completions", body); err == nil {
+		t.Fatal("expected error for non-numeric body intelligence")
+	}
+	if _, ok := body["auto_model_options"]; ok {
+		t.Fatal("auto_model_options must be stripped even on error")
+	}
+}
+
+func TestResolveAutoModel_LegacyArrayIgnored(t *testing.T) {
+	catalog := fakeCatalog{models: autoTestCatalog(), healthy: allHealthy(autoTestCatalog())}
+	header := http.Header{}
+	header.Set(autoroute.IntelligenceHeader, "100")
 	body := map[string]any{
 		"model": "auto",
 		"auto_model_options": []any{
-			map[string]any{
-				"model":  "kimi-k2-6",
-				"params": map[string]any{"reasoning_effort": "high"},
-			},
-			map[string]any{
-				"model":  "kimi-k2-6",
-				"params": map[string]any{"reasoning_effort": "low"},
-			},
+			map[string]any{"model": "tiny-text", "params": map[string]any{"reasoning_effort": "high"}},
 		},
 	}
 
-	resolved, err := resolveAutoModel(resolver, body)
+	resolved, err := resolveAutoModel(catalog, header, "/v1/chat/completions", body)
 	if err != nil {
 		t.Fatalf("resolveAutoModel: %v", err)
 	}
-	if resolved != "kimi-k2-6" {
-		t.Fatalf("resolved = %q, want kimi-k2-6", resolved)
+	if resolved != "smart-text" {
+		t.Fatalf("resolved = %q, want smart-text; legacy candidate list must not steer routing", resolved)
 	}
-	if body["reasoning_effort"] != "high" {
-		t.Fatalf("expected first params (high), got %v", body["reasoning_effort"])
+	if _, ok := body["reasoning_effort"]; ok {
+		t.Fatal("legacy per-candidate params must not be merged into the body")
+	}
+	if _, ok := body["auto_model_options"]; ok {
+		t.Fatal("auto_model_options must be stripped from the body")
 	}
 }
 
-func TestResolveAutoModel_MissingOptions(t *testing.T) {
-	resolver := fakeResolver{}
-	body := map[string]any{"model": "auto"}
-	if _, err := resolveAutoModel(resolver, body); err == nil {
-		t.Fatal("expected error when auto_model_options is missing")
-	}
-	if _, ok := body["auto_model_options"]; ok {
-		t.Fatal("auto_model_options should be stripped even on error")
+func TestResolveAutoModel_EmptyCatalog(t *testing.T) {
+	catalog := fakeCatalog{}
+	if _, err := resolveAutoModel(catalog, http.Header{}, "/v1/chat/completions", map[string]any{"model": "auto"}); err == nil {
+		t.Fatal("expected error when no model publishes intelligence scores")
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -850,38 +850,55 @@ func TestResolveAutoModel_EmptyCatalog(t *testing.T) {
 // be what reaches the tokenizer, not the client's.
 func TestHandleInputTokens_AutoUsesRouterEffort(t *testing.T) {
 	catalog := fakeCatalog{models: autoTestCatalog(), healthy: allHealthy(autoTestCatalog())}
-	var dispatchedModel string
-	var dispatchedBody map[string]any
-	dispatch := func(_ context.Context, model, _ string, body []byte, _ http.Header) (*http.Response, error) {
-		dispatchedModel = model
-		if err := json.Unmarshal(body, &dispatchedBody); err != nil {
-			t.Fatal(err)
+	countTokens := func(t *testing.T, level string) (string, map[string]any) {
+		t.Helper()
+		var dispatchedModel string
+		var dispatchedBody map[string]any
+		dispatch := func(_ context.Context, model, _ string, body []byte, _ http.Header) (*http.Response, error) {
+			dispatchedModel = model
+			if err := json.Unmarshal(body, &dispatchedBody); err != nil {
+				t.Fatal(err)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"count":5}`)),
+			}, nil
 		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     make(http.Header),
-			Body:       io.NopCloser(strings.NewReader(`{"count":5}`)),
-		}, nil
+		req := httptest.NewRequest(http.MethodPost, responsesInputTokensPath, strings.NewReader(`{
+			"model":"auto",
+			"reasoning":{"effort":"high"},
+			"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}]
+		}`))
+		req.Header.Set(autoroute.IntelligenceHeader, level)
+		rec := httptest.NewRecorder()
+		handleInputTokens(rec, req, "secret-key", "", func(body map[string]any) (string, error) {
+			return resolveAutoModel(catalog, req.Header, inputTokensCompletionPath(req.URL.Path), body)
+		}, dispatch)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		return dispatchedModel, dispatchedBody
 	}
 
-	req := httptest.NewRequest(http.MethodPost, responsesInputTokensPath, strings.NewReader(`{
-		"model":"auto",
-		"reasoning":{"effort":"high"},
-		"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}]
-	}`))
-	req.Header.Set(autoroute.IntelligenceHeader, "0")
-	rec := httptest.NewRecorder()
-	handleInputTokens(rec, req, "secret-key", "", func(body map[string]any) (string, error) {
-		return resolveAutoModel(catalog, req.Header, inputTokensCompletionPath(req.URL.Path), body)
-	}, dispatch)
+	// Level 50 lands on fast-vision/low; its native "low" must reach the
+	// tokenizer instead of the client's "high".
+	model, body := countTokens(t, "50")
+	if model != "fast-vision" || body["model"] != "fast-vision" {
+		t.Fatalf("expected tokenization against fast-vision, got %q / %v", model, body["model"])
+	}
+	kwargs, _ := body["chat_template_kwargs"].(map[string]any)
+	if kwargs["reasoning_effort"] != "low" {
+		t.Fatalf("router effort must reach the tokenizer, got %v", body["chat_template_kwargs"])
+	}
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	// Level 0 lands on tiny-text, which has no reasoning; the client's effort
+	// must not be re-derived into kwargs for it either.
+	model, body = countTokens(t, "0")
+	if model != "tiny-text" {
+		t.Fatalf("expected tokenization against tiny-text, got %q", model)
 	}
-	if dispatchedModel != "tiny-text" || dispatchedBody["model"] != "tiny-text" {
-		t.Fatalf("expected tokenization against tiny-text, got %q / %v", dispatchedModel, dispatchedBody["model"])
-	}
-	if kwargs, ok := dispatchedBody["chat_template_kwargs"]; ok {
+	if kwargs, ok := body["chat_template_kwargs"]; ok {
 		t.Fatalf("client reasoning.effort must not reach the tokenizer for a model without reasoning, got %v", kwargs)
 	}
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -156,6 +156,7 @@ type EnclaveManager struct {
 	models                    *sync.Map // model name -> *Model
 	multimodalModels          sync.Map  // sticky set of multimodal chat model names
 	modelPricing              atomic.Pointer[map[string]ModelPricing]
+	modelIntelligence         atomic.Pointer[map[string]ModelIntelligence]
 	initConfigURL             string
 	updateConfigURL           string
 	controlPlaneURL           string

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -769,7 +769,7 @@ func (m *Model) CacheRouteSettings() cacheroute.Settings {
 }
 
 // HasHealthyEnclave reports whether the model has at least one enclave whose
-// circuit breaker is currently closed. Used by ResolvePreferredModel to skip
+// circuit breaker is currently closed. Used by the auto router to skip
 // models whose backends are all tripped (i.e. effectively down).
 func (m *Model) HasHealthyEnclave() bool {
 	m.mu.RLock()
@@ -780,26 +780,6 @@ func (m *Model) HasHealthyEnclave() bool {
 		}
 	}
 	return false
-}
-
-// ResolvePreferredModel returns the first candidate whose model exists and has
-// a healthy enclave. When none are healthy it falls back to the first non-empty
-// candidate (so normal serving surfaces the error), and returns "" when the
-// list is empty. The result is therefore preferred, not guaranteed healthy.
-func (em *EnclaveManager) ResolvePreferredModel(candidates []string) string {
-	var first string
-	for _, name := range candidates {
-		if name == "" {
-			continue
-		}
-		if first == "" {
-			first = name
-		}
-		if model, found := em.GetModel(name); found && model.HasHealthyEnclave() {
-			return name
-		}
-	}
-	return first
 }
 
 func (e *Enclave) isOverloaded() bool {

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -146,52 +146,6 @@ func newTestManager(models map[string]*Model) *EnclaveManager {
 	return em
 }
 
-func TestResolvePreferredModel(t *testing.T) {
-	down := newTestModel("a")
-	tripBreaker(down.Enclaves["a"])
-	em := newTestManager(map[string]*Model{
-		"glm-5-2":         down,
-		"kimi-k2-6":       newTestModel("b"),
-		"deepseek-v4-pro": newTestModel("c"),
-	})
-
-	// First candidate is down -> skip to the next healthy one.
-	if got := em.ResolvePreferredModel([]string{"glm-5-2", "kimi-k2-6", "deepseek-v4-pro"}); got != "kimi-k2-6" {
-		t.Fatalf("expected kimi-k2-6, got %q", got)
-	}
-
-	// First candidate healthy -> use it.
-	if got := em.ResolvePreferredModel([]string{"kimi-k2-6", "deepseek-v4-pro"}); got != "kimi-k2-6" {
-		t.Fatalf("expected kimi-k2-6, got %q", got)
-	}
-
-	// None healthy -> fall back to the first candidate.
-	tripBreaker(em.mustModel(t, "kimi-k2-6").Enclaves["b"])
-	tripBreaker(em.mustModel(t, "deepseek-v4-pro").Enclaves["c"])
-	if got := em.ResolvePreferredModel([]string{"glm-5-2", "kimi-k2-6"}); got != "glm-5-2" {
-		t.Fatalf("expected glm-5-2 fallback, got %q", got)
-	}
-
-	// Unknown model is treated as the first candidate fallback when unhealthy.
-	if got := em.ResolvePreferredModel([]string{"does-not-exist", "kimi-k2-6"}); got != "does-not-exist" {
-		t.Fatalf("expected does-not-exist fallback, got %q", got)
-	}
-
-	// Empty / blank-only lists resolve to "".
-	if got := em.ResolvePreferredModel([]string{"", ""}); got != "" {
-		t.Fatalf("expected empty resolution, got %q", got)
-	}
-}
-
-func (em *EnclaveManager) mustModel(t *testing.T, name string) *Model {
-	t.Helper()
-	m, ok := em.GetModel(name)
-	if !ok {
-		t.Fatalf("model %q not found", name)
-	}
-	return m
-}
-
 func TestCacheRoutePool(t *testing.T) {
 	m := newTestModel("a", "b", "c")
 	m.Enclaves["b"].inflight.Add(3)

--- a/manager/model_metadata.go
+++ b/manager/model_metadata.go
@@ -11,7 +11,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const modelMetadataHTTPTimeout = 10 * time.Second
+const (
+	modelMetadataHTTPTimeout = 10 * time.Second
+
+	// maxIntelligenceScore is the upper bound of the Artificial Analysis
+	// Intelligence Index, which the control plane publishes per model and
+	// reasoning setting.
+	maxIntelligenceScore = 100
+)
 
 type ModelPricing struct {
 	InputTokenPricePer1M       float64  `json:"inputTokenPricePer1M"`
@@ -20,11 +27,37 @@ type ModelPricing struct {
 	RequestPrice               float64  `json:"requestPrice"`
 }
 
+// ReasoningEndpointParams holds the request fragments that switch a model's
+// reasoning on or off for one API endpoint. Enable may contain the literal
+// "$EFFORT" placeholder that the caller substitutes with the native effort.
+type ReasoningEndpointParams struct {
+	Enable  map[string]any `json:"enable"`
+	Disable map[string]any `json:"disable"`
+}
+
+// ReasoningParams describes how to apply a reasoning setting to a request for
+// one model, keyed by endpoint path. EffortMap translates the client-facing
+// effort key (low, medium, high) to the model's native effort value.
+type ReasoningParams struct {
+	Params    map[string]ReasoningEndpointParams `json:"params"`
+	EffortMap map[string]string                  `json:"effort_map"`
+}
+
+// ModelIntelligence describes how capable a chat model is under each
+// reasoning setting a client can select (off, on, low, medium, high), and how
+// to apply that setting to a request.
+type ModelIntelligence struct {
+	Scores    map[string]int
+	Reasoning *ReasoningParams
+}
+
 type openAIModelEntry struct {
-	ID         string        `json:"id"`
-	Multimodal bool          `json:"multimodal"`
-	Type       string        `json:"type"`
-	Pricing    *ModelPricing `json:"pricing"`
+	ID              string           `json:"id"`
+	Multimodal      bool             `json:"multimodal"`
+	Type            string           `json:"type"`
+	Pricing         *ModelPricing    `json:"pricing"`
+	Intelligence    map[string]int   `json:"intelligence"`
+	ReasoningParams *ReasoningParams `json:"reasoning_params"`
 }
 
 type openAIModelsList struct {
@@ -52,6 +85,41 @@ func (p ModelPricing) valid() bool {
 		return false
 	}
 	return p.CachedInputTokenPricePer1M == nil || *p.CachedInputTokenPricePer1M >= 0
+}
+
+// ModelIntelligence returns the per-effort intelligence scores and reasoning
+// parameters for a chat model, if the control plane publishes them.
+func (em *EnclaveManager) ModelIntelligence(modelName string) (ModelIntelligence, bool) {
+	intelligence := em.modelIntelligence.Load()
+	if intelligence == nil {
+		return ModelIntelligence{}, false
+	}
+	value, ok := (*intelligence)[modelName]
+	return value, ok
+}
+
+// IntelligenceCatalog returns every model with published intelligence scores.
+// The map is a snapshot and must not be mutated.
+func (em *EnclaveManager) IntelligenceCatalog() map[string]ModelIntelligence {
+	intelligence := em.modelIntelligence.Load()
+	if intelligence == nil {
+		return nil
+	}
+	return *intelligence
+}
+
+// validIntelligence reports whether every published score is inside the
+// Artificial Analysis Intelligence Index range.
+func validIntelligence(scores map[string]int) bool {
+	if len(scores) == 0 {
+		return false
+	}
+	for _, score := range scores {
+		if score < 0 || score > maxIntelligenceScore {
+			return false
+		}
+	}
+	return true
 }
 
 // refreshModelMetadata updates the model pricing and sticky multimodal cache
@@ -88,17 +156,24 @@ func (em *EnclaveManager) refreshModelMetadata() {
 		}
 
 		pricing := make(map[string]ModelPricing, len(parsed.Data))
+		intelligence := make(map[string]ModelIntelligence, len(parsed.Data))
 		for _, e := range parsed.Data {
 			if e.ID != "" && e.Pricing != nil && e.Pricing.valid() {
 				pricing[e.ID] = *e.Pricing
 			}
 			// Restrict to chat-shaped models so non-chat services that carry
 			// multimodal:true don't route PDFs as page images.
-			if e.ID == "" || !e.Multimodal || (e.Type != "" && e.Type != "chat") {
+			if e.ID == "" || (e.Type != "" && e.Type != "chat") {
 				continue
 			}
-			em.multimodalModels.Store(e.ID, struct{}{})
+			if validIntelligence(e.Intelligence) {
+				intelligence[e.ID] = ModelIntelligence{Scores: e.Intelligence, Reasoning: e.ReasoningParams}
+			}
+			if e.Multimodal {
+				em.multimodalModels.Store(e.ID, struct{}{})
+			}
 		}
 		em.modelPricing.Store(&pricing)
+		em.modelIntelligence.Store(&intelligence)
 	}()
 }

--- a/manager/model_metadata.go
+++ b/manager/model_metadata.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/tinfoilsh/confidential-model-router/autoroute"
 )
 
 const (
@@ -27,37 +30,21 @@ type ModelPricing struct {
 	RequestPrice               float64  `json:"requestPrice"`
 }
 
-// ReasoningEndpointParams holds the request fragments that switch a model's
-// reasoning on or off for one API endpoint. Enable may contain the literal
-// "$EFFORT" placeholder that the caller substitutes with the native effort.
-type ReasoningEndpointParams struct {
-	Enable  map[string]any `json:"enable"`
-	Disable map[string]any `json:"disable"`
-}
-
-// ReasoningParams describes how to apply a reasoning setting to a request for
-// one model, keyed by endpoint path. EffortMap translates the client-facing
-// effort key (low, medium, high) to the model's native effort value.
-type ReasoningParams struct {
-	Params    map[string]ReasoningEndpointParams `json:"params"`
-	EffortMap map[string]string                  `json:"effort_map"`
-}
-
 // ModelIntelligence describes how capable a chat model is under each
 // reasoning setting a client can select (off, on, low, medium, high), and how
 // to apply that setting to a request.
 type ModelIntelligence struct {
 	Scores    map[string]int
-	Reasoning *ReasoningParams
+	Reasoning *autoroute.Reasoning
 }
 
 type openAIModelEntry struct {
-	ID              string           `json:"id"`
-	Multimodal      bool             `json:"multimodal"`
-	Type            string           `json:"type"`
-	Pricing         *ModelPricing    `json:"pricing"`
-	Intelligence    map[string]int   `json:"intelligence"`
-	ReasoningParams *ReasoningParams `json:"reasoning_params"`
+	ID              string               `json:"id"`
+	Multimodal      bool                 `json:"multimodal"`
+	Type            string               `json:"type"`
+	Pricing         *ModelPricing        `json:"pricing"`
+	Intelligence    map[string]int       `json:"intelligence"`
+	ReasoningParams *autoroute.Reasoning `json:"reasoning_params"`
 }
 
 type openAIModelsList struct {
@@ -98,14 +85,32 @@ func (em *EnclaveManager) ModelIntelligence(modelName string) (ModelIntelligence
 	return value, ok
 }
 
-// IntelligenceCatalog returns every model with published intelligence scores.
-// The map is a snapshot and must not be mutated.
-func (em *EnclaveManager) IntelligenceCatalog() map[string]ModelIntelligence {
+// AutoRouteCatalog returns every chat model with published intelligence
+// scores in the shape the auto router ranks over, sorted by name so callers
+// see a stable order.
+func (em *EnclaveManager) AutoRouteCatalog() []autoroute.Model {
 	intelligence := em.modelIntelligence.Load()
 	if intelligence == nil {
 		return nil
 	}
-	return *intelligence
+	catalog := make([]autoroute.Model, 0, len(*intelligence))
+	for name, entry := range *intelligence {
+		catalog = append(catalog, autoroute.Model{
+			Name:       name,
+			Multimodal: em.IsMultimodal(name),
+			Scores:     entry.Scores,
+			Reasoning:  entry.Reasoning,
+		})
+	}
+	sort.Slice(catalog, func(i, j int) bool { return catalog[i].Name < catalog[j].Name })
+	return catalog
+}
+
+// HasHealthyEnclave reports whether the named model is known and has at least
+// one enclave whose circuit breaker is closed.
+func (em *EnclaveManager) HasHealthyEnclave(modelName string) bool {
+	model, found := em.GetModel(modelName)
+	return found && model.HasHealthyEnclave()
 }
 
 // validIntelligence reports whether every published score is inside the

--- a/manager/model_metadata_test.go
+++ b/manager/model_metadata_test.go
@@ -1,0 +1,78 @@
+package manager
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestModelIntelligenceJSONAndLookup(t *testing.T) {
+	var models openAIModelsList
+	err := json.Unmarshal([]byte(`{
+		"data": [{
+			"id": "scored-model",
+			"type": "chat",
+			"intelligence": {"low": 30, "high": 42},
+			"reasoning_params": {
+				"params": {
+					"/v1/chat/completions": {
+						"enable": {"chat_template_kwargs": {"reasoning_effort": "$EFFORT"}}
+					}
+				},
+				"effort_map": {"low": "low", "high": "max"}
+			}
+		}]
+	}`), &models)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(models.Data) != 1 {
+		t.Fatalf("expected one model, got %d", len(models.Data))
+	}
+	entry := models.Data[0]
+	if entry.Intelligence["high"] != 42 {
+		t.Fatalf("intelligence.high = %d, want 42", entry.Intelligence["high"])
+	}
+	if entry.ReasoningParams == nil || entry.ReasoningParams.EffortMap["high"] != "max" {
+		t.Fatalf("reasoning params did not decode: %+v", entry.ReasoningParams)
+	}
+	enable := entry.ReasoningParams.Params["/v1/chat/completions"].Enable
+	kwargs, _ := enable["chat_template_kwargs"].(map[string]any)
+	if kwargs["reasoning_effort"] != "$EFFORT" {
+		t.Fatalf("enable fragment did not decode: %v", enable)
+	}
+
+	em := &EnclaveManager{}
+	catalog := map[string]ModelIntelligence{
+		"scored-model": {Scores: entry.Intelligence, Reasoning: entry.ReasoningParams},
+	}
+	em.modelIntelligence.Store(&catalog)
+	got, ok := em.ModelIntelligence("scored-model")
+	if !ok || got.Scores["low"] != 30 {
+		t.Fatalf("ModelIntelligence lookup = %+v, %v", got, ok)
+	}
+	if _, ok := em.ModelIntelligence("missing-model"); ok {
+		t.Fatal("did not expect intelligence for missing model")
+	}
+	if len(em.IntelligenceCatalog()) != 1 {
+		t.Fatalf("catalog size = %d, want 1", len(em.IntelligenceCatalog()))
+	}
+}
+
+func TestValidIntelligence(t *testing.T) {
+	cases := []struct {
+		name   string
+		scores map[string]int
+		want   bool
+	}{
+		{"nil", nil, false},
+		{"empty", map[string]int{}, false},
+		{"in range", map[string]int{"off": 0, "high": 100}, true},
+		{"negative", map[string]int{"low": -1}, false},
+		{"over max", map[string]int{"high": 101}, false},
+	}
+	for _, tc := range cases {
+		if got := validIntelligence(tc.scores); got != tc.want {
+			t.Errorf("%s: validIntelligence = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/manager/model_metadata_test.go
+++ b/manager/model_metadata_test.go
@@ -42,10 +42,13 @@ func TestModelIntelligenceJSONAndLookup(t *testing.T) {
 	}
 
 	em := &EnclaveManager{}
-	catalog := map[string]ModelIntelligence{
+	intelligence := map[string]ModelIntelligence{
 		"scored-model": {Scores: entry.Intelligence, Reasoning: entry.ReasoningParams},
+		"vision-model": {Scores: map[string]int{"on": 20}},
 	}
-	em.modelIntelligence.Store(&catalog)
+	em.modelIntelligence.Store(&intelligence)
+	em.multimodalModels.Store("vision-model", struct{}{})
+
 	got, ok := em.ModelIntelligence("scored-model")
 	if !ok || got.Scores["low"] != 30 {
 		t.Fatalf("ModelIntelligence lookup = %+v, %v", got, ok)
@@ -53,8 +56,37 @@ func TestModelIntelligenceJSONAndLookup(t *testing.T) {
 	if _, ok := em.ModelIntelligence("missing-model"); ok {
 		t.Fatal("did not expect intelligence for missing model")
 	}
-	if len(em.IntelligenceCatalog()) != 1 {
-		t.Fatalf("catalog size = %d, want 1", len(em.IntelligenceCatalog()))
+
+	catalog := em.AutoRouteCatalog()
+	if len(catalog) != 2 {
+		t.Fatalf("catalog size = %d, want 2", len(catalog))
+	}
+	if catalog[0].Name != "scored-model" || catalog[1].Name != "vision-model" {
+		t.Fatalf("catalog not sorted by name: %q, %q", catalog[0].Name, catalog[1].Name)
+	}
+	if catalog[0].Multimodal || !catalog[1].Multimodal {
+		t.Fatalf("multimodal flags not joined onto catalog: %v, %v", catalog[0].Multimodal, catalog[1].Multimodal)
+	}
+	if catalog[0].Reasoning == nil || catalog[0].Reasoning.EffortMap["high"] != "max" {
+		t.Fatalf("reasoning params not carried into catalog: %+v", catalog[0].Reasoning)
+	}
+}
+
+func TestManagerHasHealthyEnclave(t *testing.T) {
+	down := newTestModel("a")
+	tripBreaker(down.Enclaves["a"])
+	em := newTestManager(map[string]*Model{
+		"down-model": down,
+		"up-model":   newTestModel("b"),
+	})
+	if em.HasHealthyEnclave("down-model") {
+		t.Fatal("tripped model reported healthy")
+	}
+	if !em.HasHealthyEnclave("up-model") {
+		t.Fatal("healthy model reported unhealthy")
+	}
+	if em.HasHealthyEnclave("unknown-model") {
+		t.Fatal("unknown model reported healthy")
 	}
 }
 

--- a/manager/prometheus.go
+++ b/manager/prometheus.go
@@ -148,6 +148,24 @@ var (
 		[]string{"model"},
 	)
 
+	// AutoRouteDecisionsTotal tracks which model and effort model "auto" resolved to
+	AutoRouteDecisionsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_auto_route_decisions_total",
+			Help: "Total number of auto-routed requests by resolved model and reasoning effort",
+		},
+		[]string{"model", "effort"},
+	)
+
+	// AutoRouteFallbacksTotal tracks auto-routed requests that skipped a better-fitting model because it had no healthy enclave
+	AutoRouteFallbacksTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_auto_route_fallbacks_total",
+			Help: "Total number of auto-routed requests served by a lower-ranked model because the best fit was unhealthy",
+		},
+		[]string{"model"},
+	)
+
 	// PriorityAssignmentsTotal tracks requests assigned configured vLLM priority
 	PriorityAssignmentsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
Replaces the client-supplied candidate list for `model: "auto"` with an intelligence level. The router matches it against the per-effort scores the control plane publishes (tinfoilsh/controlplane#678), picks the closest `(model, effort)` pair, and walks down the ranking until it finds a model with a healthy enclave so an outage degrades to the next-best fit instead of failing.

Level is read from `auto_model_options.intelligence` in the body, then the `X-Tinfoil-Intelligence` header, else `50`. It is 0–100 normalized so that 100 is the highest-scoring configuration currently in the catalog. Requests carrying image or file parts only consider multimodal models; otherwise multimodal only breaks ties. The chosen effort is applied with the model's own reasoning parameters and overrides any effort the client sent. `auto_model_options` is always stripped; a legacy array value is ignored.

Depends on tinfoilsh/controlplane#678 for scores to be present. Until that ships, `auto` returns a 400 stating no models publish intelligence scores.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the client-supplied candidate list for `model: "auto"` with a requested intelligence level. The router matches the level against the per-effort scores the control plane publishes, picks the closest `(model, effort)` pair, and walks down the ranking until it finds a model with a healthy enclave so an outage degrades to the next-best fit instead of failing.

**Behavior**
- Requests with image or file parts only consider multimodal models; otherwise multimodal breaks ties.
- The chosen effort is applied with the model's own reasoning parameters and overrides any effort the client sent; the client's generic effort fields are stripped so the input-token counting route sees the same effort.
- Adds `router_auto_route_decisions_total` and `router_auto_route_fallbacks_total` counters.

**Migration**
- `auto_model_options` is now `{"intelligence": 0–100}` instead of a candidate array; the legacy array is ignored and the field is always stripped.
- The level can also come from the `X-Tinfoil-Intelligence` header and defaults to 50.
- Depends on tinfoilsh/controlplane#678 for published scores; until then `auto` returns a 400.

<sup>Written for commit 81022080f4a5a45352bcdef637f5e743da213f16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

