### PR TITLE
Prefer multimodal models when auto routing fits are near-equal

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@ The router accepts OpenAI-compatible bodies on `/v1/chat/completions` and `/v1/r
 - `code_execution_options` — activates the code-execution tool profile. When code execution is requested, this object carries the per-request credentials (`accessToken`, `encryptionKey`, `containerAuthToken`).
 - `web_search_options` — activates the web-search tool profile.
 - `pii_check_options` — activates the PII safety check.
+- `auto_model_options` — carries `{"intelligence": N}` for `model: "auto"` requests (see below).
+
+## Auto model routing
+
+`model: "auto"` asks the router to pick a concrete model and reasoning effort. The caller states how capable a model it wants as an intelligence level from 0 to 100, either in the body as `auto_model_options.intelligence` or in the `X-Tinfoil-Intelligence` header (the body wins; absent means 50). The implementation lives in `autoroute/`.
+
+The catalog the router ranks over is every `type: "chat"` model in the control plane's `/v1/models` response that publishes an `intelligence` map. Each key of that map is a reasoning setting (`off`, `on`, `low`, `medium`, `high`) and each value is the model's Artificial Analysis Intelligence Index under that setting. How to fill those scores in for a new model is documented in the control plane repo at `config/README.md`.
+
+Selection works as follows:
+
+1. Expand every model into `(model, effort)` candidates, one per key in its `intelligence` map.
+2. Normalize each raw score to a level: `round(score * 100 / maxScore)`, where `maxScore` is the highest score anywhere in the catalog. The strongest configuration is therefore always level 100 and everything else is relative to it, so levels shift when a stronger model is added.
+3. If the request contains an image or file content part, drop text-only models.
+4. Find the best fit: the smallest `|level - target|` over all candidates.
+5. Every candidate within `FitTolerance` (3) levels of that best distance is "in band". In-band candidates sort first; within the band multimodal models win, then the nearer level, then the higher raw score, then the model name. Out-of-band candidates follow ordered by distance with the same tiebreaks.
+6. Walk the ranked list and take the first model with a healthy enclave. If none is healthy the best fit is still returned so the normal serving path reports the outage.
+7. Rewrite `body.model` to the chosen model and apply its published `reasoning_params` fragment for the chosen effort, replacing any `reasoning_effort` / `reasoning.effort` the client sent.
+
+The tolerance band exists because two models that are one index point apart are not meaningfully different, and the more capable (multimodal) one should not lose every request to a rounding-sized gap. It also means a model does not need to land exactly on a client's slider stop to be selected. When adding or rescoring a model, check what each common target (the webapp sends 0, 20, 40, 60, 80, 100) resolves to; a score that sits more than `FitTolerance` levels away from every stop while another model sits on it will never be chosen except as a health fallback.
 
 ## Tool Calling
 

--- a/autoroute/autoroute.go
+++ b/autoroute/autoroute.go
@@ -36,6 +36,13 @@ const (
 	// DefaultIntelligence is used when the caller states no level.
 	DefaultIntelligence = 50
 
+	// FitTolerance is how many normalized levels further from the target a
+	// candidate may sit than the best-fitting one and still count as an
+	// equally good fit. Within that band, capability (multimodal) decides
+	// before distance, so a model one point behind the leader is not shut
+	// out of routing by a rounding-sized score gap.
+	FitTolerance = 3
+
 	// effortPlaceholder is replaced inside a reasoning enable fragment with
 	// the model's native effort value.
 	effortPlaceholder = "$EFFORT"
@@ -173,9 +180,12 @@ func HasVisualInput(body map[string]any) bool {
 }
 
 // Rank expands the catalog into (model, effort) candidates and orders them by
-// how closely their normalized level matches target. Ties prefer multimodal
-// models, then the higher score, then the model name for determinism. When
-// requireMultimodal is set, text-only models are excluded entirely.
+// how closely their normalized level matches target. Candidates within
+// FitTolerance of the best fit form a band that sorts ahead of everything
+// else; inside it multimodal models come first, then the nearer level, then
+// the higher score, then the model name for determinism. Outside the band the
+// same order applies with distance first. When requireMultimodal is set,
+// text-only models are excluded entirely.
 func Rank(catalog []Model, target int, requireMultimodal bool) []Candidate {
 	maxScore := 0
 	for _, model := range catalog {
@@ -204,9 +214,26 @@ func Rank(catalog []Model, target int, requireMultimodal bool) []Candidate {
 		}
 	}
 
+	bestDistance := math.MaxInt
+	for _, c := range candidates {
+		if d := abs(c.Level - target); d < bestDistance {
+			bestDistance = d
+		}
+	}
+	inBand := func(c Candidate) bool {
+		return abs(c.Level-target) <= bestDistance+FitTolerance
+	}
+
 	sort.SliceStable(candidates, func(i, j int) bool {
 		a, b := candidates[i], candidates[j]
 		da, db := abs(a.Level-target), abs(b.Level-target)
+		ia, ib := inBand(a), inBand(b)
+		if ia != ib {
+			return ia
+		}
+		if ia && a.Model.Multimodal != b.Model.Multimodal {
+			return a.Model.Multimodal
+		}
 		if da != db {
 			return da < db
 		}

--- a/autoroute/autoroute_test.go
+++ b/autoroute/autoroute_test.go
@@ -119,27 +119,63 @@ func testCatalog() []Model {
 
 func TestRankOrdersByDistanceToTarget(t *testing.T) {
 	// Catalog max is 45, so normalized levels are round(score*100/45).
-	ranked := Rank(testCatalog(), 100, false)
+	ranked := Rank(testCatalog(), 0, false)
 	if len(ranked) == 0 {
 		t.Fatal("expected candidates")
 	}
-	if top := ranked[0]; top.Model.Name != "smart-text" || top.Effort != "high" || top.Level != 100 {
-		t.Fatalf("top candidate for target 100 = %s/%s (level %d), want smart-text/high (100)", top.Model.Name, top.Effort, top.Level)
-	}
-
-	ranked = Rank(testCatalog(), 0, false)
 	if top := ranked[0]; top.Model.Name != "tiny-text" || top.Effort != "off" {
 		t.Fatalf("top candidate for target 0 = %s/%s, want tiny-text/off", top.Model.Name, top.Effort)
 	}
 
-	// Every candidate must be no further from target than the one after it.
+	// Candidates inside the fit band all come first; after them every
+	// candidate must be no further from target than the one after it.
 	for target := MinIntelligence; target <= MaxIntelligence; target += 10 {
 		ranked = Rank(testCatalog(), target, false)
-		for i := 1; i < len(ranked); i++ {
-			if abs(ranked[i-1].Level-target) > abs(ranked[i].Level-target) {
+		best := MaxIntelligence
+		for _, c := range ranked {
+			if d := abs(c.Level - target); d < best {
+				best = d
+			}
+		}
+		firstOutside := len(ranked)
+		for i, c := range ranked {
+			if abs(c.Level-target) > best+FitTolerance {
+				firstOutside = i
+				break
+			}
+		}
+		for i := firstOutside; i < len(ranked); i++ {
+			if abs(ranked[i].Level-target) <= best+FitTolerance {
+				t.Fatalf("target %d: in-band candidate %d sorted after an out-of-band one", target, i)
+			}
+			if i > firstOutside && abs(ranked[i-1].Level-target) > abs(ranked[i].Level-target) {
 				t.Fatalf("target %d: candidate %d is further than candidate %d", target, i-1, i)
 			}
 		}
+	}
+}
+
+func TestRankPrefersMultimodalWithinFitTolerance(t *testing.T) {
+	// smart-text/high (45 -> 100) is the exact fit for target 100, but
+	// smart-vision/on (44 -> 98) sits inside FitTolerance and is multimodal,
+	// so it must win; the text model follows as the nearest remaining fit.
+	ranked := Rank(testCatalog(), 100, false)
+	if top := ranked[0]; top.Model.Name != "smart-vision" || top.Effort != "on" {
+		t.Fatalf("top candidate for target 100 = %s/%s, want smart-vision/on", top.Model.Name, top.Effort)
+	}
+	if second := ranked[1]; second.Model.Name != "smart-text" || second.Effort != "high" {
+		t.Fatalf("second candidate for target 100 = %s/%s, want smart-text/high", second.Model.Name, second.Effort)
+	}
+
+	// A multimodal candidate just outside the band must not jump ahead: at
+	// target 87 the band is [84, 90], holding smart-text/low (87) and
+	// fast-vision/medium (87); fast-vision/high (93) is outside it.
+	ranked = Rank(testCatalog(), 87, false)
+	if top := ranked[0]; top.Model.Name != "fast-vision" || top.Effort != "medium" {
+		t.Fatalf("top candidate for target 87 = %s/%s, want fast-vision/medium", top.Model.Name, top.Effort)
+	}
+	if second := ranked[1]; second.Model.Name != "smart-text" || second.Effort != "low" {
+		t.Fatalf("second candidate for target 87 = %s/%s, want smart-text/low", second.Model.Name, second.Effort)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -644,7 +644,10 @@ func allHealthy(models []autoroute.Model) map[string]bool {
 func TestResolveAutoModel_HeaderPicksModelAndEffort(t *testing.T) {
 	catalog := fakeCatalog{models: autoTestCatalog(), healthy: allHealthy(autoTestCatalog())}
 	header := http.Header{}
-	header.Set(autoroute.IntelligenceHeader, "100")
+	// Level 87 is the exact fit for smart-text/low (39) and fast-vision/medium
+	// (39); nothing else is inside the fit band, so the multimodal fast-vision
+	// wins and its native "medium" effort must be applied.
+	header.Set(autoroute.IntelligenceHeader, "87")
 	body := map[string]any{
 		"model":    "auto",
 		"messages": []any{map[string]any{"role": "user", "content": "hi"}},
@@ -655,12 +658,12 @@ func TestResolveAutoModel_HeaderPicksModelAndEffort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveAutoModel: %v", err)
 	}
-	if resolved != "smart-text" || body["model"] != "smart-text" {
-		t.Fatalf("resolved = %q, body[model] = %v, want smart-text", resolved, body["model"])
+	if resolved != "fast-vision" || body["model"] != "fast-vision" {
+		t.Fatalf("resolved = %q, body[model] = %v, want fast-vision", resolved, body["model"])
 	}
 	kwargs, _ := body["chat_template_kwargs"].(map[string]any)
-	if kwargs["reasoning_effort"] != "max" {
-		t.Fatalf("expected native effort max for level 100, got %v", kwargs)
+	if kwargs["reasoning_effort"] != "high" {
+		t.Fatalf("expected native effort high (mapped from medium) for level 87, got %v", kwargs)
 	}
 	if msgs, ok := body["messages"].([]any); !ok || len(msgs) != 1 || body["stream"] != true {
 		t.Fatalf("unrelated body fields were clobbered: %v", body)
@@ -710,7 +713,7 @@ func TestResolveAutoModel_DefaultLevel(t *testing.T) {
 func TestResolveAutoModel_FallsBackWhenBestFitUnhealthy(t *testing.T) {
 	models := autoTestCatalog()
 	healthy := allHealthy(models)
-	healthy["smart-text"] = false
+	healthy["smart-vision"] = false
 	catalog := fakeCatalog{models: models, healthy: healthy}
 	header := http.Header{}
 	header.Set(autoroute.IntelligenceHeader, "100")
@@ -720,11 +723,12 @@ func TestResolveAutoModel_FallsBackWhenBestFitUnhealthy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveAutoModel: %v", err)
 	}
-	if resolved != "smart-vision" {
-		t.Fatalf("resolved = %q, want smart-vision as next best when smart-text is down", resolved)
+	if resolved != "smart-text" {
+		t.Fatalf("resolved = %q, want smart-text as next best when smart-vision is down", resolved)
 	}
-	if _, ok := body["chat_template_kwargs"]; ok {
-		t.Fatal("model without reasoning params must not receive kwargs")
+	kwargs, _ := body["chat_template_kwargs"].(map[string]any)
+	if kwargs["reasoning_effort"] != "max" {
+		t.Fatalf("expected native effort max for smart-text/high, got %v", kwargs)
 	}
 }
 
@@ -738,8 +742,11 @@ func TestResolveAutoModel_NothingHealthyStillResolvesBestFit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveAutoModel: %v", err)
 	}
-	if resolved != "smart-text" {
-		t.Fatalf("resolved = %q, want best-fit smart-text so serving surfaces the outage", resolved)
+	if resolved != "smart-vision" {
+		t.Fatalf("resolved = %q, want best-fit smart-vision so serving surfaces the outage", resolved)
+	}
+	if _, ok := body["chat_template_kwargs"]; ok {
+		t.Fatal("model without reasoning params must not receive kwargs")
 	}
 }
 
@@ -780,7 +787,8 @@ func TestResolveAutoModel_VisualInputWithoutMultimodalModels(t *testing.T) {
 func TestResolveAutoModel_RouterEffortOverridesClient(t *testing.T) {
 	catalog := fakeCatalog{models: autoTestCatalog(), healthy: allHealthy(autoTestCatalog())}
 	header := http.Header{}
-	header.Set(autoroute.IntelligenceHeader, "100")
+	// Level 87 resolves to fast-vision/medium, whose native effort is "high".
+	header.Set(autoroute.IntelligenceHeader, "87")
 	body := map[string]any{
 		"model":                "auto",
 		"chat_template_kwargs": map[string]any{"reasoning_effort": "low", "keep": "me"},
@@ -790,7 +798,7 @@ func TestResolveAutoModel_RouterEffortOverridesClient(t *testing.T) {
 		t.Fatalf("resolveAutoModel: %v", err)
 	}
 	kwargs, _ := body["chat_template_kwargs"].(map[string]any)
-	if kwargs["reasoning_effort"] != "max" || kwargs["keep"] != "me" {
+	if kwargs["reasoning_effort"] != "high" || kwargs["keep"] != "me" {
 		t.Fatalf("router effort must win and siblings survive, got %v", kwargs)
 	}
 }
@@ -827,8 +835,8 @@ func TestResolveAutoModel_LegacyArrayIgnored(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveAutoModel: %v", err)
 	}
-	if resolved != "smart-text" {
-		t.Fatalf("resolved = %q, want smart-text; legacy candidate list must not steer routing", resolved)
+	if resolved != "smart-vision" {
+		t.Fatalf("resolved = %q, want smart-vision; legacy candidate list must not steer routing", resolved)
 	}
 	if _, ok := body["reasoning_effort"]; ok {
 		t.Fatal("legacy per-candidate params must not be merged into the body")


### PR DESCRIPTION
Auto routing picked the single candidate nearest the requested intelligence level, so a model one index point behind the leader (kimi-k3 at 44 vs glm-5-3 at 45) could never be selected except as a health fallback. Candidates within 3 normalized levels of the best fit are now treated as an equally good fit, and multimodal models win inside that band. Only the Max stop changes for the current catalog: it resolves to kimi-k3 with glm-5-3 as the fallback.

Also documents the routing algorithm in the README; the companion doc on how to score models lives in the controlplane repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto routing now treats candidates within 3 normalized levels of the best fit as equally good and prefers multimodal models inside that band, so a model one index point behind the leader is no longer shut out. Only the Max stop changes for the current catalog: it resolves to `kimi-k3` with `glm-5-3` as the fallback.

- Other stops resolve to the same model as before.
- Documents the routing algorithm in the README, including normalization, the fit band, and the tiebreak order.

<sup>Written for commit ace89f25f3904a751b51b0aabc2864717fb7eb31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

