### PR TITLE
Document how auto model routing chooses a model

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,26 @@ The router accepts OpenAI-compatible bodies on `/v1/chat/completions` and `/v1/r
 - `code_execution_options` — activates the code-execution tool profile. When code execution is requested, this object carries the per-request credentials (`accessToken`, `encryptionKey`, `containerAuthToken`).
 - `web_search_options` — activates the web-search tool profile.
 - `pii_check_options` — activates the PII safety check.
+- `auto_model_options` — carries `{"intelligence": N}` for `model: "auto"` requests (see below).
+
+## Auto model routing
+
+`model: "auto"` asks the router to pick a concrete model and reasoning effort. The caller states how capable a model it wants as an intelligence level from 0 to 100, either in the body as `auto_model_options.intelligence` or in the `X-Tinfoil-Intelligence` header (the body wins; absent means 50). The implementation lives in `autoroute/`.
+
+The router is deliberately neutral: it has no model names, preferences, or tuning of its own. Every routing decision follows from the scores the control plane publishes, so changing which model serves a given level is a control plane config change, not a router change. How to score a model is documented in the control plane repo at `config/README.md`.
+
+The catalog the router ranks over is every `type: "chat"` model in the control plane's `/v1/models` response that publishes an `intelligence` map. Each key of that map is a reasoning setting (`off`, `on`, `low`, `medium`, `high`) and each value is the model's Artificial Analysis Intelligence Index under that setting.
+
+Selection works as follows:
+
+1. Expand every model into `(model, effort)` candidates, one per key in its `intelligence` map.
+2. Normalize each raw score to a level: `round(score * 100 / maxScore)`, where `maxScore` is the highest score anywhere in the catalog. The strongest configuration is therefore always level 100 and everything else is relative to it, so levels shift when a stronger model is added.
+3. If the request contains an image or file content part, drop text-only models.
+4. Sort candidates by `|level - target|`, nearest first. Exact ties are broken by multimodal first, then the higher raw score, then the model name, then the effort key, so the order is deterministic.
+5. Walk the ranked list and take the first model with a healthy enclave. If none is healthy the best fit is still returned so the normal serving path reports the outage.
+6. Rewrite `body.model` to the chosen model and apply its published `reasoning_params` fragment for the chosen effort, replacing any `reasoning_effort` / `reasoning.effort` the client sent.
+
+Because only the nearest candidate wins, a model that is one point behind another at a given level will never be chosen for text requests except as a health fallback. If two models should share a level with the multimodal one preferred, the control plane must publish equal scores for them; the router does not apply a tolerance of its own.
 
 ## Tool Calling
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The router accepts OpenAI-compatible bodies on `/v1/chat/completions` and `/v1/r
 
 `model: "auto"` asks the router to pick a concrete model and reasoning effort. The caller states how capable a model it wants as an intelligence level from 0 to 100, either in the body as `auto_model_options.intelligence` or in the `X-Tinfoil-Intelligence` header (the body wins; absent means 50). The implementation lives in `autoroute/`.
 
-The router is deliberately neutral: it has no model names, preferences, or tuning of its own. Every routing decision follows from the scores the control plane publishes, so changing which model serves a given level is a control plane config change, not a router change. How to score a model is documented in the control plane repo at `config/README.md`.
+The router has no model-specific preferences or tuning of its own: how well a candidate fits a level comes entirely from the scores the control plane publishes, and the router only adds the generic rules below (request content, enclave health, deterministic tie-breaks). Changing which model serves a given level is therefore a control plane config change, not a router change. How to score a model is documented in the control plane repo at `config/README.md`.
 
 The catalog the router ranks over is every `type: "chat"` model in the control plane's `/v1/models` response that publishes an `intelligence` map. Each key of that map is a reasoning setting (`off`, `on`, `low`, `medium`, `high`) and each value is the model's Artificial Analysis Intelligence Index under that setting.
 
@@ -26,9 +26,9 @@ Selection works as follows:
 3. If the request contains an image or file content part, drop text-only models.
 4. Sort candidates by `|level - target|`, nearest first. Exact ties are broken by multimodal first, then the higher raw score, then the model name, then the effort key, so the order is deterministic.
 5. Walk the ranked list and take the first model with a healthy enclave. If none is healthy the best fit is still returned so the normal serving path reports the outage.
-6. Rewrite `body.model` to the chosen model and apply its published `reasoning_params` fragment for the chosen effort, replacing any `reasoning_effort` / `reasoning.effort` the client sent.
+6. Rewrite `body.model` to the chosen model and apply its published `reasoning_params` fragment for the chosen effort (with `$EFFORT` replaced by the model's native value from `effort_map`), replacing any `reasoning_effort` / `reasoning.effort` the client sent.
 
-Because only the nearest candidate wins, a model that is one point behind another at a given level will never be chosen for text requests except as a health fallback. If two models should share a level with the multimodal one preferred, the control plane must publish equal scores for them; the router does not apply a tolerance of its own.
+Because only the nearest candidate wins, a model whose level is one point further from the target than another's will never be chosen for text requests except as a health fallback; the tie-breaks only apply between candidates at the same level. If two models should share a level with the multimodal one preferred, the control plane must publish equal scores for them; the router does not apply a tolerance of its own.
 
 ## Tool Calling
 


### PR DESCRIPTION
Adds a README section describing the auto routing algorithm: how the intelligence level is read, how scores are normalized, the nearest-fit ordering and tiebreaks, and health fallback. It also states that the router is neutral and that model preference is expressed through the scores the control plane publishes (see tinfoilsh/controlplane#694).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds README documentation for the auto model routing algorithm so users understand how `model: "auto"` requests pick a concrete model and reasoning effort.

- Explains the intelligence level input (body or header), score normalization, nearest-fit ranking with tiebreaks, and health fallback.
- Clarifies the router is neutral and that model preference is set by control plane scores, not router config.

<sup>Written for commit 8c92a4785f8b1010ec25dd508c1ae89c6db1e5c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

