### PR TITLE
feat: report requests for unknown models to the control plane

### DIFF
--- a/billing/unknown_model.go
+++ b/billing/unknown_model.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -20,14 +19,7 @@ import (
 // requests for model names the router does not serve.
 const UnknownModelPath = "/api/internal/unknown-model-requests"
 
-const (
-	unknownModelReportTimeout = 5 * time.Second
-	// unknownModelDedupTTL bounds how often one key/model pair is reported.
-	// The controlplane emails once per owner and model; this only keeps a
-	// misconfigured client from producing a request per call.
-	unknownModelDedupTTL = time.Hour
-	unknownModelMaxSeen  = 10000
-)
+const unknownModelReportTimeout = 5 * time.Second
 
 // UnknownModelReport is the payload sent to the controlplane.
 type UnknownModelReport struct {
@@ -37,15 +29,12 @@ type UnknownModelReport struct {
 
 // UnknownModelReporter tells the controlplane when an authenticated request
 // targets a model the router does not serve, so the owner can be told the
-// model is gone.
+// model is gone. The controlplane dedupes per owner and model.
 type UnknownModelReporter struct {
 	endpoint   string
 	reporterID string
 	secret     string
 	client     *http.Client
-
-	mu   sync.Mutex
-	seen map[string]time.Time
 }
 
 // NewUnknownModelReporter returns nil when reporting is not configured.
@@ -58,39 +47,16 @@ func NewUnknownModelReporter(controlPlaneURL, reporterID, secret string) *Unknow
 		reporterID: reporterID,
 		secret:     secret,
 		client:     &http.Client{Timeout: unknownModelReportTimeout},
-		seen:       make(map[string]time.Time),
 	}
 }
 
 // Report sends the rejection asynchronously; the caller has already
 // answered the client and must not wait on the controlplane.
 func (r *UnknownModelReporter) Report(apiKey, model string) {
-	if r == nil || apiKey == "" || model == "" || !r.markSeen(apiKey, model) {
+	if r == nil || apiKey == "" || model == "" {
 		return
 	}
 	go r.send(UnknownModelReport{APIKey: apiKey, Model: model})
-}
-
-func (r *UnknownModelReporter) markSeen(apiKey, model string) bool {
-	now := time.Now()
-	key := apiKey + "\x00" + model
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if at, ok := r.seen[key]; ok && now.Sub(at) < unknownModelDedupTTL {
-		return false
-	}
-	if len(r.seen) >= unknownModelMaxSeen {
-		for k, at := range r.seen {
-			if now.Sub(at) >= unknownModelDedupTTL {
-				delete(r.seen, k)
-			}
-		}
-		if len(r.seen) >= unknownModelMaxSeen {
-			return false
-		}
-	}
-	r.seen[key] = now
-	return true
 }
 
 func (r *UnknownModelReporter) send(report UnknownModelReport) {

--- a/billing/unknown_model.go
+++ b/billing/unknown_model.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -113,7 +112,7 @@ func (r *UnknownModelReporter) send(report UnknownModelReport) {
 		return
 	}
 	nonce := hex.EncodeToString(nonceBytes)
-	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(usagereporting.HeaderReporterID, r.reporterID)
 	req.Header.Set(usagereporting.HeaderTimestamp, timestamp)

--- a/billing/unknown_model.go
+++ b/billing/unknown_model.go
@@ -1,0 +1,133 @@
+package billing
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	usagereporting "github.com/tinfoilsh/usage-reporting-go"
+)
+
+// UnknownModelPath is the controlplane endpoint that receives rejected
+// requests for model names the router does not serve.
+const UnknownModelPath = "/api/internal/unknown-model-requests"
+
+const (
+	unknownModelReportTimeout = 5 * time.Second
+	// unknownModelDedupTTL bounds how often one key/model pair is reported.
+	// The controlplane emails once per owner and model; this only keeps a
+	// misconfigured client from producing a request per call.
+	unknownModelDedupTTL = time.Hour
+	unknownModelMaxSeen  = 10000
+)
+
+// UnknownModelReport is the payload sent to the controlplane.
+type UnknownModelReport struct {
+	APIKey string `json:"api_key"`
+	Model  string `json:"model"`
+}
+
+// UnknownModelReporter tells the controlplane when an authenticated request
+// targets a model the router does not serve, so the owner can be told the
+// model is gone.
+type UnknownModelReporter struct {
+	endpoint   string
+	reporterID string
+	secret     string
+	client     *http.Client
+
+	mu   sync.Mutex
+	seen map[string]time.Time
+}
+
+// NewUnknownModelReporter returns nil when reporting is not configured.
+func NewUnknownModelReporter(controlPlaneURL, reporterID, secret string) *UnknownModelReporter {
+	if controlPlaneURL == "" || secret == "" {
+		return nil
+	}
+	return &UnknownModelReporter{
+		endpoint:   strings.TrimRight(controlPlaneURL, "/") + UnknownModelPath,
+		reporterID: reporterID,
+		secret:     secret,
+		client:     &http.Client{Timeout: unknownModelReportTimeout},
+		seen:       make(map[string]time.Time),
+	}
+}
+
+// Report sends the rejection asynchronously; the caller has already
+// answered the client and must not wait on the controlplane.
+func (r *UnknownModelReporter) Report(apiKey, model string) {
+	if r == nil || apiKey == "" || model == "" || !r.markSeen(apiKey, model) {
+		return
+	}
+	go r.send(UnknownModelReport{APIKey: apiKey, Model: model})
+}
+
+func (r *UnknownModelReporter) markSeen(apiKey, model string) bool {
+	now := time.Now()
+	key := apiKey + "\x00" + model
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if at, ok := r.seen[key]; ok && now.Sub(at) < unknownModelDedupTTL {
+		return false
+	}
+	if len(r.seen) >= unknownModelMaxSeen {
+		for k, at := range r.seen {
+			if now.Sub(at) >= unknownModelDedupTTL {
+				delete(r.seen, k)
+			}
+		}
+		if len(r.seen) >= unknownModelMaxSeen {
+			return false
+		}
+	}
+	r.seen[key] = now
+	return true
+}
+
+func (r *UnknownModelReporter) send(report UnknownModelReport) {
+	body, err := json.Marshal(report)
+	if err != nil {
+		log.WithError(err).Error("failed to marshal unknown model report")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), unknownModelReportTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.endpoint, bytes.NewReader(body))
+	if err != nil {
+		log.WithError(err).Error("failed to build unknown model report")
+		return
+	}
+	nonceBytes := make([]byte, 16)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		log.WithError(err).Error("failed to generate unknown model report nonce")
+		return
+	}
+	nonce := hex.EncodeToString(nonceBytes)
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(usagereporting.HeaderReporterID, r.reporterID)
+	req.Header.Set(usagereporting.HeaderTimestamp, timestamp)
+	req.Header.Set(usagereporting.HeaderNonce, nonce)
+	req.Header.Set(usagereporting.HeaderSignature,
+		usagereporting.SignBatch(http.MethodPost, req.URL.Path, r.reporterID, timestamp, nonce, body, r.secret))
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		log.WithError(err).WithField("model", report.Model).Warn("unknown model report failed")
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.WithFields(log.Fields{"model": report.Model, "status": resp.StatusCode}).Warn("unknown model report rejected")
+	}
+}

--- a/billing/unknown_model.go
+++ b/billing/unknown_model.go
@@ -19,7 +19,13 @@ import (
 // requests for model names the router does not serve.
 const UnknownModelPath = "/api/internal/unknown-model-requests"
 
-const unknownModelReportTimeout = 5 * time.Second
+const (
+	unknownModelReportTimeout = 5 * time.Second
+	// unknownModelMaxInflight caps concurrent reports so a flood of unknown
+	// model requests cannot pile up goroutines and connections; excess
+	// reports are dropped, since the controlplane only needs one per owner.
+	unknownModelMaxInflight = 16
+)
 
 // UnknownModelReport is the payload sent to the controlplane.
 type UnknownModelReport struct {
@@ -35,6 +41,7 @@ type UnknownModelReporter struct {
 	reporterID string
 	secret     string
 	client     *http.Client
+	inflight   chan struct{}
 }
 
 // NewUnknownModelReporter returns nil when reporting is not configured.
@@ -47,6 +54,7 @@ func NewUnknownModelReporter(controlPlaneURL, reporterID, secret string) *Unknow
 		reporterID: reporterID,
 		secret:     secret,
 		client:     &http.Client{Timeout: unknownModelReportTimeout},
+		inflight:   make(chan struct{}, unknownModelMaxInflight),
 	}
 }
 
@@ -56,7 +64,15 @@ func (r *UnknownModelReporter) Report(apiKey, model string) {
 	if r == nil || apiKey == "" || model == "" {
 		return
 	}
-	go r.send(UnknownModelReport{APIKey: apiKey, Model: model})
+	select {
+	case r.inflight <- struct{}{}:
+	default:
+		return
+	}
+	go func() {
+		defer func() { <-r.inflight }()
+		r.send(UnknownModelReport{APIKey: apiKey, Model: model})
+	}()
 }
 
 func (r *UnknownModelReporter) send(report UnknownModelReport) {

--- a/billing/unknown_model_test.go
+++ b/billing/unknown_model_test.go
@@ -1,0 +1,77 @@
+package billing
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	usagereporting "github.com/tinfoilsh/usage-reporting-go"
+)
+
+func TestUnknownModelReporterSignsAndDedupes(t *testing.T) {
+	const secret = "test-secret"
+	reports := make(chan UnknownModelReport, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		if r.URL.Path != UnknownModelPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, UnknownModelPath)
+		}
+		reporterID, ts, nonce, sig, err := usagereporting.HeaderValues(r.Header)
+		if err != nil {
+			t.Errorf("headers: %v", err)
+		}
+		if !usagereporting.VerifyBatch(r.Method, r.URL.Path, reporterID, ts, nonce, body, secret, sig) {
+			t.Error("signature did not verify")
+		}
+		var report UnknownModelReport
+		if err := json.Unmarshal(body, &report); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+		reports <- report
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	r := NewUnknownModelReporter(server.URL, "router-test", secret)
+	for range 3 {
+		r.Report("tk_abc", "kimi-k2-5")
+	}
+	r.Report("tk_abc", "kimi-k2-6")
+	r.Report("", "kimi-k2-5")
+	r.Report("tk_abc", "")
+
+	got := map[string]bool{}
+	for range 2 {
+		select {
+		case rep := <-reports:
+			if rep.APIKey != "tk_abc" {
+				t.Errorf("api_key = %q", rep.APIKey)
+			}
+			got[rep.Model] = true
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for report")
+		}
+	}
+	if !got["kimi-k2-5"] || !got["kimi-k2-6"] {
+		t.Errorf("models reported = %v", got)
+	}
+	select {
+	case rep := <-reports:
+		t.Errorf("unexpected extra report %+v", rep)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestUnknownModelReporterNilWhenUnconfigured(t *testing.T) {
+	var r *UnknownModelReporter = NewUnknownModelReporter("https://cp", "id", "")
+	if r != nil {
+		t.Fatal("expected nil reporter without a secret")
+	}
+	r.Report("tk_abc", "kimi-k2-5")
+}

--- a/billing/unknown_model_test.go
+++ b/billing/unknown_model_test.go
@@ -11,7 +11,7 @@ import (
 	usagereporting "github.com/tinfoilsh/usage-reporting-go"
 )
 
-func TestUnknownModelReporterSignsAndDedupes(t *testing.T) {
+func TestUnknownModelReporterSignsReports(t *testing.T) {
 	const secret = "test-secret"
 	reports := make(chan UnknownModelReport, 4)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -39,9 +39,7 @@ func TestUnknownModelReporterSignsAndDedupes(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	r := NewUnknownModelReporter(server.URL, "router-test", secret)
-	for range 3 {
-		r.Report("tk_abc", "kimi-k2-5")
-	}
+	r.Report("tk_abc", "kimi-k2-5")
 	r.Report("tk_abc", "kimi-k2-6")
 	r.Report("", "kimi-k2-5")
 	r.Report("tk_abc", "")

--- a/main.go
+++ b/main.go
@@ -910,6 +910,7 @@ func main() {
 			// and the authoritative lookup below, forwarding an unsanitized
 			// body to the engine.
 			if _, found := em.GetModel(modelName); !found {
+				em.ReportUnknownModel(apiKey, modelName)
 				jsonError(w, manager.ErrMsgModelNotFound, manager.ErrTypeInvalidRequest, http.StatusNotFound)
 				return
 			}
@@ -931,6 +932,7 @@ func main() {
 
 		model, found := em.GetModel(modelName)
 		if !found {
+			em.ReportUnknownModel(apiKey, modelName)
 			jsonError(w, manager.ErrMsgModelNotFound, manager.ErrTypeInvalidRequest, http.StatusNotFound)
 			return
 		}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -162,6 +162,7 @@ type EnclaveManager struct {
 	controlPlaneURL           string
 	sigstoreClient            *sigstore.Client
 	billingCollector          *billing.Collector
+	unknownModelReporter      *billing.UnknownModelReporter
 	usageContextSecret        string
 	inferenceDelegationSecret string
 	delegationHTTPClient      *http.Client
@@ -217,6 +218,12 @@ func (em *EnclaveManager) AddBillingEvent(event billing.Event) {
 	if em.billingCollector != nil {
 		em.billingCollector.AddEvent(event)
 	}
+}
+
+// ReportUnknownModel tells the controlplane that an authenticated request
+// was rejected because modelName is not served.
+func (em *EnclaveManager) ReportUnknownModel(apiKey, modelName string) {
+	em.unknownModelReporter.Report(apiKey, modelName)
 }
 
 // UsageContextSecret returns the HMAC secret used to sign usage-context
@@ -891,6 +898,7 @@ func NewEnclaveManager(configFile []byte, controlPlaneURL string, usageReporterI
 		controlPlaneURL:           controlPlaneURL,
 		sigstoreClient:            sigstoreClient,
 		billingCollector:          billing.NewCollector(controlPlaneURL, usageReporterID, usageReporterSecret),
+		unknownModelReporter:      billing.NewUnknownModelReporter(controlPlaneURL, usageReporterID, usageReporterSecret),
 		usageContextSecret:        usageContextSecret,
 		inferenceDelegationSecret: inferenceDelegationSecret,
 		delegationHTTPClient:      &http.Client{},


### PR DESCRIPTION
When an authenticated request names a model the router does not serve, POST the API key and model name to `/api/internal/unknown-model-requests` on the control plane, signed with the existing usage-reporter HMAC. The control plane checks the name against its deprecated list and emails the owner once per model.

Reports are fire-and-forget after the 404 is written. Anonymous probes (no bearer token) are not reported.

Depends on the matching control plane endpoint in tinfoilsh/controlplane#706.