### PR TITLE
Add deepseek-v4-1-flash

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -44,6 +44,9 @@ models:
   deepseek-v4-flash:
     repo: tinfoilsh/confidential-deepseek-v4-flash
 
+  deepseek-v4-1-flash:
+    repo: tinfoilsh/confidential-deepseek-v4-1-flash
+
   kimi-k3:
     repo: tinfoilsh/confidential-kimi-k3
 


### PR DESCRIPTION
Pin `deepseek-v4-1-flash` to `tinfoilsh/confidential-deepseek-v4-1-flash`. Needs a router release + rollout per runbook.md before the model can be routed. Tracked in model-ops `launches/deepseek-v4-1-flash/state.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `deepseek-v4-1-flash` to the model config, pinned to `tinfoilsh/confidential-deepseek-v4-1-flash`.

- Routing requires a router release and rollout per `runbook.md`; tracked in model-ops `launches/deepseek-v4-1-flash/state.md`.

<sup>Written for commit 1c5bd456f50ddfa7ab2e2df812444fece3019357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-model-router/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

